### PR TITLE
Refactor MatchAnalysis state tracking for clarity

### DIFF
--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -3,9 +3,9 @@ package com.sageserpent.kineticmerge.core
 import alleycats.std.set.given
 import cats.collections.{Diet, DisjointSets, Range as CatsInclusiveRange}
 import cats.data.State
-import cats.implicits.{catsKernelOrderingForOrder, catsSyntaxFlatMapOps}
+import cats.implicits.catsKernelOrderingForOrder
 import cats.instances.seq.*
-import cats.syntax.all.{toFoldableOps, toTraverseOps}
+import cats.syntax.all.*
 import cats.{Eq, FlatMap, Order}
 import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 import com.google.common.hash.{Funnel, HashFunction, PrimitiveSink}
@@ -686,19 +686,37 @@ object MatchAnalysis extends StrictLogging:
         )
       end maximumSizeOfCoalescedSections
 
+      private def recordReplacement(
+          original: GenericMatch[Element],
+          replacement: GenericMatch[Element]
+      ): ParallelMatchesGroupIdTracking[Unit] =
+        State.modify { groupIds =>
+          groupIds
+            .get(original)
+            .fold(ifEmpty = groupIds)(groupId =>
+              groupIds + (replacement -> groupId)
+            )
+        }
+
+      private def recordReplacements(
+          original: GenericMatch[Element],
+          replacements: Iterable[GenericMatch[Element]]
+      ): ParallelMatchesGroupIdTracking[Unit] =
+        replacements.toVector.traverse_(recordReplacement(original, _))
+
       private def fragmentsOf(
           pairwiseMatchesToBeEaten: MultiDict[
             PairwiseMatch,
             (Match.AllSides[Section[Element]], BiteEdge, BiteEdge)
           ]
       ): ParallelMatchesGroupIdTracking[Set[PairwiseMatch]] =
-        pairwiseMatchesToBeEaten.sets.toSeq
-          .flatTraverse { case (pairwiseMatch, bites) =>
+        pairwiseMatchesToBeEaten.sets.toVector
+          .traverse { case (pairwiseMatch, bites) =>
             val sortedBiteEdges = sortedBiteEdgesFrom(bites.flatMap {
               case (_, biteStart, biteEnd) => Seq(biteStart, biteEnd)
             })
 
-            val fragmentsFromPairwiseMatch: Seq[PairwiseMatch] =
+            val fragmentsFromPairwiseMatch: Vector[PairwiseMatch] =
               pairwiseMatch match
                 case Match.BaseAndLeft(baseSection, leftSection) =>
                   (eatIntoSection(
@@ -713,6 +731,8 @@ object MatchAnalysis extends StrictLogging:
                     leftSection
                   ))
                     .map(Match.BaseAndLeft.apply)
+                    .toVector
+                    .asInstanceOf[Vector[PairwiseMatch]]
 
                 case Match.BaseAndRight(baseSection, rightSection) =>
                   (eatIntoSection(
@@ -725,7 +745,10 @@ object MatchAnalysis extends StrictLogging:
                     sortedBiteEdges
                   )(
                     rightSection
-                  )).map(Match.BaseAndRight.apply)
+                  ))
+                    .map(Match.BaseAndRight.apply)
+                    .toVector
+                    .asInstanceOf[Vector[PairwiseMatch]]
 
                 case Match.LeftAndRight(leftSection, rightSection) =>
                   (eatIntoSection(
@@ -738,24 +761,21 @@ object MatchAnalysis extends StrictLogging:
                     sortedBiteEdges
                   )(
                     rightSection
-                  )).map(Match.LeftAndRight.apply)
+                  ))
+                    .map(Match.LeftAndRight.apply)
+                    .toVector
+                    .asInstanceOf[Vector[PairwiseMatch]]
 
             logger.debug(
               s"Eating into pairwise match:\n${pprintCustomised(pairwiseMatch)} on behalf of all-sides matches:\n${pprintCustomised(bites)}, resulting in fragments:\n${pprintCustomised(fragmentsFromPairwiseMatch)}"
             )
 
-            fragmentsFromPairwiseMatch.foldM(())((_, fragment) =>
-              State.modify[Map[GenericMatch[Element], ParallelMatchesGroupId]](
-                groupIds =>
-                  groupIds
-                    .get(pairwiseMatch)
-                    .fold(ifEmpty = groupIds)(groupId =>
-                      groupIds + (fragment -> groupId)
-                    )
-              )
-            ) >> State.pure(fragmentsFromPairwiseMatch)
+            recordReplacements(
+              pairwiseMatch,
+              fragmentsFromPairwiseMatch
+            ) as fragmentsFromPairwiseMatch
           }
-          .map(_.toSet)
+          .map(_.flatten.toSet)
 
       def sortedBiteEdgesFrom(bites: collection.Set[BiteEdge]): Seq[BiteEdge] =
         bites.toSeq.sortWith {
@@ -1735,14 +1755,7 @@ object MatchAnalysis extends StrictLogging:
           case _ => None
 
         result.traverse(paredDownMatch =>
-          State.modify[Map[GenericMatch[Element], ParallelMatchesGroupId]](
-            groupIds =>
-              groupIds
-                .get(aMatch)
-                .fold(ifEmpty = groupIds)(groupId =>
-                  groupIds + (paredDownMatch -> groupId)
-                )
-          ) >> State.pure(paredDownMatch)
+          recordReplacement(aMatch, paredDownMatch) as paredDownMatch
         )
       end pareDownOrSuppressCompletely
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -700,9 +700,9 @@ object MatchAnalysis extends StrictLogging:
 
       private def recordReplacements(
           original: GenericMatch[Element],
-          replacements: Iterable[GenericMatch[Element]]
+          replacements: Seq[GenericMatch[Element]]
       ): ParallelMatchesGroupIdTracking[Unit] =
-        replacements.toSeq.traverse_(recordReplacement(original, _))
+        replacements.traverse_(recordReplacement(original, _))
 
       private def fragmentsOf(
           pairwiseMatchesToBeEaten: MultiDict[

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -2049,7 +2049,6 @@ object MatchAnalysis extends StrictLogging:
               .filter(
                 _.nonEmpty
               ) // Guard the zipping of group members down below...
-              .toSeq
               .traverse_ { group =>
                 // Unify the group members...
                 group

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -730,7 +730,7 @@ object MatchAnalysis extends StrictLogging:
                   )(
                     leftSection
                   ))
-                    .map { case (base, left) => Match.BaseAndLeft(base, left) }
+                    .map(Match.BaseAndLeft.apply)
 
                 case Match.BaseAndRight(baseSection, rightSection) =>
                   (eatIntoSection(
@@ -743,9 +743,7 @@ object MatchAnalysis extends StrictLogging:
                     sortedBiteEdges
                   )(
                     rightSection
-                  )).map { case (base, right) =>
-                    Match.BaseAndRight(base, right)
-                  }
+                  )).map(Match.BaseAndRight.apply)
 
                 case Match.LeftAndRight(leftSection, rightSection) =>
                   (eatIntoSection(
@@ -758,9 +756,7 @@ object MatchAnalysis extends StrictLogging:
                     sortedBiteEdges
                   )(
                     rightSection
-                  )).map { case (left, right) =>
-                    Match.LeftAndRight(left, right)
-                  }
+                  )).map(Match.LeftAndRight.apply)
 
             logger.debug(
               s"Eating into pairwise match:\n${pprintCustomised(pairwiseMatch)} on behalf of all-sides matches:\n${pprintCustomised(bites)}, resulting in fragments:\n${pprintCustomised(fragmentsFromPairwiseMatch)}"

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -2042,8 +2042,6 @@ object MatchAnalysis extends StrictLogging:
           )
         end disjointSetsOfMatches
 
-        val unusedValue = true
-
         val coalescenceWorkflow =
           for
             _ <- groupsOfBackTranslatedParallelMatches
@@ -2051,25 +2049,28 @@ object MatchAnalysis extends StrictLogging:
               .filter(
                 _.nonEmpty
               ) // Guard the zipping of group members down below...
-              .foldM(unusedValue)((_, group) =>
+              .toSeq
+              .traverse_ { group =>
                 // Unify the group members...
                 group
                   .zip(group.tail)
                   .toSeq
-                  .foldM(unusedValue) {
-                    case (_, (precedingGroupMember, succeedingGroupMember)) =>
+                  .traverse_ {
+                    case (precedingGroupMember, succeedingGroupMember) =>
                       DisjointSets
                         .union(precedingGroupMember, succeedingGroupMember)
                   }
-              )
+              }
             _ <- backTranslatedMatches
               .filter(_.isAnAllSidesMatch)
-              .foldM(unusedValue) {
-                case (_, allSidesMatch: Match.AllSides[Section[Element]]) =>
+              .toSeq
+              .traverse_ {
+                case allSidesMatch: Match.AllSides[Section[Element]] =>
                   backTranslatedMatchesAndTheirSections
                     .pairwiseMatchesSubsumingOnBothSides(allSidesMatch)
-                    .foldM(unusedValue)((_, pairwiseMatch) =>
-                      DisjointSets.union(allSidesMatch, pairwiseMatch)
+                    .toSeq
+                    .traverse_(
+                      DisjointSets.union(allSidesMatch, _)
                     )
               }
             sets <- DisjointSets.toSets

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -702,7 +702,7 @@ object MatchAnalysis extends StrictLogging:
           original: GenericMatch[Element],
           replacements: Iterable[GenericMatch[Element]]
       ): ParallelMatchesGroupIdTracking[Unit] =
-        replacements.toVector.traverse_(recordReplacement(original, _))
+        replacements.toSeq.traverse_(recordReplacement(original, _))
 
       private def fragmentsOf(
           pairwiseMatchesToBeEaten: MultiDict[
@@ -710,13 +710,13 @@ object MatchAnalysis extends StrictLogging:
             (Match.AllSides[Section[Element]], BiteEdge, BiteEdge)
           ]
       ): ParallelMatchesGroupIdTracking[Set[PairwiseMatch]] =
-        pairwiseMatchesToBeEaten.sets.toVector
-          .traverse { case (pairwiseMatch, bites) =>
+        pairwiseMatchesToBeEaten.sets.toSeq
+          .flatTraverse { case (pairwiseMatch, bites) =>
             val sortedBiteEdges = sortedBiteEdgesFrom(bites.flatMap {
               case (_, biteStart, biteEnd) => Seq(biteStart, biteEnd)
             })
 
-            val fragmentsFromPairwiseMatch: Vector[PairwiseMatch] =
+            val fragmentsFromPairwiseMatch: Seq[PairwiseMatch] =
               pairwiseMatch match
                 case Match.BaseAndLeft(baseSection, leftSection) =>
                   (eatIntoSection(
@@ -730,9 +730,7 @@ object MatchAnalysis extends StrictLogging:
                   )(
                     leftSection
                   ))
-                    .map(Match.BaseAndLeft.apply)
-                    .toVector
-                    .asInstanceOf[Vector[PairwiseMatch]]
+                    .map { case (base, left) => Match.BaseAndLeft(base, left) }
 
                 case Match.BaseAndRight(baseSection, rightSection) =>
                   (eatIntoSection(
@@ -745,10 +743,9 @@ object MatchAnalysis extends StrictLogging:
                     sortedBiteEdges
                   )(
                     rightSection
-                  ))
-                    .map(Match.BaseAndRight.apply)
-                    .toVector
-                    .asInstanceOf[Vector[PairwiseMatch]]
+                  )).map { case (base, right) =>
+                    Match.BaseAndRight(base, right)
+                  }
 
                 case Match.LeftAndRight(leftSection, rightSection) =>
                   (eatIntoSection(
@@ -761,10 +758,9 @@ object MatchAnalysis extends StrictLogging:
                     sortedBiteEdges
                   )(
                     rightSection
-                  ))
-                    .map(Match.LeftAndRight.apply)
-                    .toVector
-                    .asInstanceOf[Vector[PairwiseMatch]]
+                  )).map { case (left, right) =>
+                    Match.LeftAndRight(left, right)
+                  }
 
             logger.debug(
               s"Eating into pairwise match:\n${pprintCustomised(pairwiseMatch)} on behalf of all-sides matches:\n${pprintCustomised(bites)}, resulting in fragments:\n${pprintCustomised(fragmentsFromPairwiseMatch)}"
@@ -775,7 +771,7 @@ object MatchAnalysis extends StrictLogging:
               fragmentsFromPairwiseMatch
             ) as fragmentsFromPairwiseMatch
           }
-          .map(_.flatten.toSet)
+          .map(_.toSet)
 
       def sortedBiteEdgesFrom(bites: collection.Set[BiteEdge]): Seq[BiteEdge] =
         bites.toSeq.sortWith {


### PR DESCRIPTION
Refactored `MatchesAndTheirSections.pareDownOrSuppressCompletely` and `MatchesAndTheirSections.fragmentsOf` in `MatchAnalysis.scala` to simplify the `State` monad logic. 

Key changes:
1.  **New Helpers**: Added `recordReplacement` and `recordReplacements` to `object MatchesAndTheirSections` to encapsulate `State.modify` logic for group ID propagation.
2.  **`fragmentsOf`**: Rewritten to use `recordReplacements` and the `traverse`/`as` syntax, removing manual `foldM` and `State.modify` boilerplate.
3.  **`pareDownOrSuppressCompletely`**: Rewritten to use `recordReplacement`, making the intent of state updates much clearer.
4.  **Imports**: Broadened `cats.syntax.all` import to facilitate idiomatic functional patterns.

These changes make the reconciliation logic easier to follow for developers new to the codebase by separating the core transformation logic from state management boilerplate.

---
*PR created automatically by Jules for task [14552704461948994184](https://jules.google.com/task/14552704461948994184) started by @sageserpent-open*