### PR TITLE
Bolster parallel matches invariant with path consistency check

### DIFF
--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1186,6 +1186,99 @@ object MatchAnalysis extends StrictLogging:
         end if
       end purgedOfMatchesWithOverlappingSections
 
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(allSides)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
+            )
+        }
+      end withoutTheseMatches
+
       def reconcileMatches: MatchesAndTheirSections =
         val matches = sectionsAndTheirMatches.values.toSet
 
@@ -1296,6 +1389,631 @@ object MatchAnalysis extends StrictLogging:
         result
 
       end reconcileMatches
+
+      private def checkInvariant(): Unit =
+        // We expect to tally either two lots of a given pairwise match or three
+        // lots of a given all-sides match; we therefore scale the
+        // raw multiplicities of the section to take this into account.
+        val multiplicityScaleSubdivisibleByTwoOrThree = 6
+
+        val multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch =
+          multiplicityScaleSubdivisibleByTwoOrThree / 3
+
+        val multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch =
+          multiplicityScaleSubdivisibleByTwoOrThree / 2
+
+        val baseSectionMultiplicities = baseSectionsByPath.values
+          .flatMap(_.iterator)
+          .groupBy(identity)
+          .map((section, group) =>
+            section -> multiplicityScaleSubdivisibleByTwoOrThree * group.size
+          )
+
+        val leftSectionMultiplicities = leftSectionsByPath.values
+          .flatMap(_.iterator)
+          .groupBy(identity)
+          .map((section, group) =>
+            section -> multiplicityScaleSubdivisibleByTwoOrThree * group.size
+          )
+
+        val rightSectionMultiplicities = rightSectionsByPath.values
+          .flatMap(_.iterator)
+          .groupBy(identity)
+          .map((section, group) =>
+            section -> multiplicityScaleSubdivisibleByTwoOrThree * group.size
+          )
+
+        val tallyAllSides: Option[Int] => Option[Int] = {
+          case Some(multiplicity) =>
+            // Once we've accounted for the multiplicity, remove the entry.
+            Option.unless(
+              multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch == multiplicity
+            )(
+              multiplicity - multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch
+            )
+          // If we have an occurrence and there is no entry, start a negative
+          // count.
+          case None =>
+            Some(
+              -multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch
+            )
+        }
+
+        val tallyPairwise: Option[Int] => Option[Int] = {
+          case Some(multiplicity) =>
+            // Once we've accounted for the multiplicity, remove the entry.
+            Option.unless(
+              multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch == multiplicity
+            )(
+              multiplicity - multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch
+            )
+          // If we have an occurrence and there is no entry, start a negative
+          // count.
+          case None =>
+            Some(-multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch)
+        }
+
+        val (
+          unbalancedBaseSectionMultiplicities,
+          unbalancedLeftSectionMultiplicities,
+          unbalancedRightSectionMultiplicities
+        ) = sectionsAndTheirMatches.values.foldLeft(
+          (
+            baseSectionMultiplicities,
+            leftSectionMultiplicities,
+            rightSectionMultiplicities
+          )
+        ) {
+          case (
+                (
+                  baseSectionMultiplicities,
+                  leftSectionMultiplicities,
+                  rightSectionMultiplicities
+                ),
+                aMatch
+              ) =>
+            aMatch match
+              case Match.AllSides(
+                    baseSection,
+                    leftSection,
+                    rightSection
+                  ) =>
+                (
+                  baseSectionMultiplicities.updatedWith(baseSection)(
+                    tallyAllSides
+                  ),
+                  leftSectionMultiplicities.updatedWith(leftSection)(
+                    tallyAllSides
+                  ),
+                  rightSectionMultiplicities.updatedWith(rightSection)(
+                    tallyAllSides
+                  )
+                )
+              case Match.BaseAndLeft(
+                    baseSection,
+                    leftSection
+                  ) =>
+                (
+                  baseSectionMultiplicities.updatedWith(baseSection)(
+                    tallyPairwise
+                  ),
+                  leftSectionMultiplicities.updatedWith(leftSection)(
+                    tallyPairwise
+                  ),
+                  rightSectionMultiplicities
+                )
+              case Match.BaseAndRight(
+                    baseSection,
+                    rightSection
+                  ) =>
+                (
+                  baseSectionMultiplicities.updatedWith(baseSection)(
+                    tallyPairwise
+                  ),
+                  leftSectionMultiplicities,
+                  rightSectionMultiplicities.updatedWith(rightSection)(
+                    tallyPairwise
+                  )
+                )
+              case Match.LeftAndRight(
+                    leftSection,
+                    rightSection
+                  ) =>
+                (
+                  baseSectionMultiplicities,
+                  leftSectionMultiplicities.updatedWith(leftSection)(
+                    tallyPairwise
+                  ),
+                  rightSectionMultiplicities.updatedWith(rightSection)(
+                    tallyPairwise
+                  )
+                )
+        }
+
+        assert(
+          unbalancedBaseSectionMultiplicities.isEmpty,
+          s"Found unbalanced base section multiplicities, these are:\n${pprintCustomised(unbalancedBaseSectionMultiplicities)}"
+        )
+        assert(
+          unbalancedLeftSectionMultiplicities.isEmpty,
+          s"Found unbalanced left section multiplicities, these are:\n${pprintCustomised(unbalancedLeftSectionMultiplicities)}"
+        )
+        assert(
+          unbalancedRightSectionMultiplicities.isEmpty,
+          s"Found unbalanced right section multiplicities, these are:\n${pprintCustomised(unbalancedRightSectionMultiplicities)}"
+        )
+      end checkInvariant
+
+      private def reconciliationPostcondition(): Unit =
+        baseSectionsByPath.values.flatMap(_.iterator).foreach { baseSection =>
+          assert(!baseSubsumes(baseSection))
+        }
+        leftSectionsByPath.values.flatMap(_.iterator).foreach { leftSection =>
+          assert(!leftSubsumes(leftSection))
+        }
+        rightSectionsByPath.values.flatMap(_.iterator).foreach { rightSection =>
+          assert(!rightSubsumes(rightSection))
+        }
+
+        // No match should be redundant - i.e. no match should involve sections
+        // that all belong to another match. This goes without saying for
+        // all-sides matches, as any redundancy would imply equivalent
+        // all-sides matches being associated with the same sections - this
+        // isn't allowed by a `MultiDict` instance. The same applies for
+        // pairwise matches of the same kind; pairwise matches of different
+        // kinds can't make each other redundant.
+        // What we have to watch out for are pairwise matches having *both*
+        // sections also belonging to an all-sides match. Note that it *is*
+        // legitimate to have a pairwise match sharing just one section with an
+        // all-sides match; they are just ambiguous matches.
+
+        val matchesBySectionPairs =
+          sectionsAndTheirMatches.values.toSet.foldLeft(
+            MultiDict.empty[(Section[Element], Section[Element]), Match[
+              Section[Element]
+            ]]
+          )((matchesBySectionPairs, aMatch) =>
+            aMatch match
+              case Match.AllSides(baseSection, leftSection, rightSection) =>
+                matchesBySectionPairs + ((
+                  baseSection,
+                  leftSection
+                ) -> aMatch) + ((baseSection, rightSection) -> aMatch) + ((
+                  leftSection,
+                  rightSection
+                ) -> aMatch)
+              case Match.BaseAndLeft(baseSection, leftSection) =>
+                matchesBySectionPairs + ((
+                  baseSection,
+                  leftSection
+                ) -> aMatch)
+              case Match.BaseAndRight(baseSection, rightSection) =>
+                matchesBySectionPairs + ((
+                  baseSection,
+                  rightSection
+                ) -> aMatch)
+              case Match.LeftAndRight(leftSection, rightSection) =>
+                matchesBySectionPairs + ((
+                  leftSection,
+                  rightSection
+                ) -> aMatch)
+          )
+
+        matchesBySectionPairs.keySet.foreach { sectionPair =>
+          val matches = matchesBySectionPairs.get(sectionPair)
+
+          val (allSides, pairwiseMatches) =
+            matches.partition(_.isAnAllSidesMatch)
+
+          if allSides.nonEmpty then
+            assert(
+              pairwiseMatches.isEmpty,
+              s"Found redundancy between pairwise matches: ${pprintCustomised(pairwiseMatches)} and an all-sides match in: ${pprintCustomised(allSides)}."
+            )
+          end if
+        }
+
+        if parallelMatchesGroupIdsByMatch.nonEmpty then
+          assert(
+            parallelMatchesGroupIdsByMatch.keySet == matches,
+            s"If groups of parallel matches have been discovered, they should cover the overall population of matches exactly."
+          )
+
+          parallelMatchesGroupIdsByMatch.toSeq
+            .groupBy(_._2)
+            .values
+            .foreach { group =>
+              val matchesInGroup = group.map(_._1)
+
+              case class SidePerspective(path: Path, startOffset: Int)
+
+              case class MatchSynopsis(
+                  base: Option[SidePerspective],
+                  left: Option[SidePerspective],
+                  right: Option[SidePerspective]
+              )
+
+              object MatchSynopsis:
+                def apply(aMatch: GenericMatch[Element]): MatchSynopsis =
+                  MatchSynopsis(
+                    base = (pathOnBase(aMatch), startOffsetOnBase(aMatch))
+                      .mapN(SidePerspective.apply),
+                    left = (pathOnLeft(aMatch), startOffsetOnLeft(aMatch))
+                      .mapN(SidePerspective.apply),
+                    right = (pathOnRight(aMatch), startOffsetOnRight(aMatch))
+                      .mapN(SidePerspective.apply)
+                  )
+              end MatchSynopsis
+
+              val basePaths = matchesInGroup.flatMap(pathOnBase).toSet
+              assert(
+                basePaths.size <= 1,
+                s"""Base paths for a group of parallel matches should be the same,
+                   |but vary: $basePaths.
+                   |Matches are: ${pprintCustomised(
+                    matchesInGroup.map(MatchSynopsis.apply)
+                  )}""".stripMargin
+              )
+
+              val leftPaths = matchesInGroup.flatMap(pathOnLeft).toSet
+              assert(
+                leftPaths.size <= 1,
+                s"""Left paths for a group of parallel matches should be the same,
+                   |but vary: $leftPaths.
+                   |Matches are: ${pprintCustomised(
+                    matchesInGroup.map(MatchSynopsis.apply)
+                  )}""".stripMargin
+              )
+
+              val rightPaths = matchesInGroup.flatMap(pathOnRight).toSet
+              assert(
+                rightPaths.size <= 1,
+                s"""Right paths for a group of parallel matches should be the same,
+                   |but vary: $rightPaths.
+                   |Matches are: ${pprintCustomised(
+                    matchesInGroup.map(MatchSynopsis.apply)
+                  )}""".stripMargin
+              )
+
+              def checkOrderIsConsistentAcrossSides(
+                  firstSide: String,
+                  secondSide: String,
+                  firstSideStartOffset: GenericMatch[Element] => Option[Int],
+                  secondSideStartOffset: GenericMatch[Element] => Option[Int]
+              ): Unit =
+                val matchesOrderedFromFirstSidePerspective =
+                  matchesInGroup
+                    .flatMap(aMatch =>
+                      firstSideStartOffset(aMatch)
+                        .map(offset => aMatch -> offset)
+                    )
+                    .sortBy(_._2)
+                    .map(_._1)
+                val matchesOrderedFromSecondSidePerspective =
+                  matchesInGroup
+                    .flatMap(aMatch =>
+                      secondSideStartOffset(aMatch)
+                        .map(offset => aMatch -> offset)
+                    )
+                    .sortBy(_._2)
+                    .map(_._1)
+
+                val commonMatches =
+                  matchesOrderedFromFirstSidePerspective.toSet intersect matchesOrderedFromSecondSidePerspective.toSet
+
+                val commonMatchesOrderedFromFirstSidePerspective =
+                  matchesOrderedFromFirstSidePerspective.filter(
+                    commonMatches.contains
+                  )
+                val commonMatchesOrderedFromSecondSidePerspective =
+                  matchesOrderedFromSecondSidePerspective.filter(
+                    commonMatches.contains
+                  )
+
+                assert(
+                  commonMatchesOrderedFromFirstSidePerspective == commonMatchesOrderedFromSecondSidePerspective,
+                  s"""
+                     |Expected a consistent ordering of matches relevant to the sides $firstSide and $secondSide,
+                     |on the $firstSide they are:
+                     |${pprintCustomised(
+                      commonMatchesOrderedFromFirstSidePerspective.map(
+                        MatchSynopsis.apply
+                      )
+                    )}
+                     |and on the $secondSide they are:
+                     |${pprintCustomised(
+                      commonMatchesOrderedFromSecondSidePerspective.map(
+                        MatchSynopsis.apply
+                      )
+                    )}
+                     |""".stripMargin
+                )
+              end checkOrderIsConsistentAcrossSides
+
+              checkOrderIsConsistentAcrossSides(
+                "base",
+                "left",
+                startOffsetOnBase,
+                startOffsetOnLeft
+              )
+              checkOrderIsConsistentAcrossSides(
+                "base",
+                "right",
+                startOffsetOnBase,
+                startOffsetOnRight
+              )
+              checkOrderIsConsistentAcrossSides(
+                "left",
+                "right",
+                startOffsetOnLeft,
+                startOffsetOnRight
+              )
+            }
+        end if
+      end reconciliationPostcondition
+
+      private def pathOnBase(aMatch: GenericMatch[Element]): Option[Path] =
+        aMatch match
+          case Match.AllSides(baseSection, _, _) =>
+            Some(baseSources.pathFor(baseSection))
+          case Match.BaseAndLeft(baseSection, _) =>
+            Some(baseSources.pathFor(baseSection))
+          case Match.BaseAndRight(baseSection, _) =>
+            Some(baseSources.pathFor(baseSection))
+          case _ => None
+
+      private def pathOnLeft(aMatch: GenericMatch[Element]): Option[Path] =
+        aMatch match
+          case Match.AllSides(_, leftSection, _) =>
+            Some(leftSources.pathFor(leftSection))
+          case Match.BaseAndLeft(_, leftSection) =>
+            Some(leftSources.pathFor(leftSection))
+          case Match.LeftAndRight(leftSection, _) =>
+            Some(leftSources.pathFor(leftSection))
+          case _ => None
+
+      private def pathOnRight(aMatch: GenericMatch[Element]): Option[Path] =
+        aMatch match
+          case Match.AllSides(_, _, rightSection) =>
+            Some(rightSources.pathFor(rightSection))
+          case Match.BaseAndRight(_, rightSection) =>
+            Some(rightSources.pathFor(rightSection))
+          case Match.LeftAndRight(_, rightSection) =>
+            Some(rightSources.pathFor(rightSection))
+          case _ => None
+
+      private def startOffsetOnBase(
+          aMatch: GenericMatch[Element]
+      ): Option[Int] =
+        aMatch match
+          case Match.AllSides(baseSection, _, _) =>
+            Some(baseSection.startOffset)
+          case Match.BaseAndLeft(baseSection, _) =>
+            Some(baseSection.startOffset)
+          case Match.BaseAndRight(baseSection, _) =>
+            Some(baseSection.startOffset)
+          case _ => None
+
+      private def startOffsetOnLeft(
+          aMatch: GenericMatch[Element]
+      ): Option[Int] =
+        aMatch match
+          case Match.AllSides(_, leftSection, _) =>
+            Some(leftSection.startOffset)
+          case Match.BaseAndLeft(_, leftSection) =>
+            Some(leftSection.startOffset)
+          case Match.LeftAndRight(leftSection, _) =>
+            Some(leftSection.startOffset)
+          case _ => None
+
+      private def startOffsetOnRight(
+          aMatch: GenericMatch[Element]
+      ): Option[Int] =
+        aMatch match
+          case Match.AllSides(_, _, rightSection) =>
+            Some(rightSection.startOffset)
+          case Match.BaseAndRight(_, rightSection) =>
+            Some(rightSection.startOffset)
+          case Match.LeftAndRight(_, rightSection) =>
+            Some(rightSection.startOffset)
+          case _ => None
+
+      private def pareDownOrSuppressCompletely[MatchType <: GenericMatch[
+        Element
+      ]](
+          aMatch: MatchType
+      ): ParallelMatchesGroupIdTracking[Option[ParedDownMatch[MatchType]]] =
+        // NOTE: one thing to watch out is when fragments resulting from
+        // larger pairwise matches being eaten into collide with equivalent
+        // pairwise matches found by fingerprint matching. This can take the
+        // form of the fragments coming first due to larger all-sides matches,
+        // or the pairwise matches from fingerprint matching can be followed
+        // by fragmentation if the all-sides eating into the larger pairwise
+        // matches also come from the same fingerprinting that yielded the
+        // pairwise matching. Intercepting this here addresses both cases. {
+        val result: Option[ParedDownMatch[MatchType]] = aMatch match
+          case Match.AllSides(baseSection, leftSection, rightSection) =>
+            val trivialSubsumptionSize = baseSection.size
+
+            val subsumingOnBase =
+              subsumingMatches(
+                sectionsAndTheirMatches
+              )(
+                baseSources,
+                baseSectionsByPath
+              )(
+                baseSection,
+                includeTrivialSubsumption = false
+              )
+
+            val subsumingOnLeft =
+              subsumingMatches(
+                sectionsAndTheirMatches
+              )(
+                leftSources,
+                leftSectionsByPath
+              )(
+                leftSection,
+                includeTrivialSubsumption = false
+              )
+
+            val subsumingOnRight =
+              subsumingMatches(
+                sectionsAndTheirMatches
+              )(
+                rightSources,
+                rightSectionsByPath
+              )(
+                rightSection,
+                includeTrivialSubsumption = false
+              )
+
+            val allSidesSubsumingOnLeft =
+              subsumingOnLeft.filter(_.isAnAllSidesMatch)
+            val allSidesSubsumingOnRight =
+              subsumingOnRight.filter(_.isAnAllSidesMatch)
+            val allSidesSubsumingOnBase =
+              subsumingOnBase.filter(_.isAnAllSidesMatch)
+
+            val subsumedByAnAllSidesMatchOnMoreThanOneSide =
+              (allSidesSubsumingOnLeft intersect allSidesSubsumingOnRight).nonEmpty
+                || (allSidesSubsumingOnBase intersect allSidesSubsumingOnLeft).nonEmpty
+                || (allSidesSubsumingOnBase intersect allSidesSubsumingOnRight).nonEmpty
+
+            if !subsumedByAnAllSidesMatchOnMoreThanOneSide then
+              val subsumedBySomeMatchOnJustTheBase =
+                (subsumingOnBase diff (subsumingOnLeft union subsumingOnRight)).nonEmpty
+              val subsumedBySomeMatchOnJustTheLeft =
+                (subsumingOnLeft diff (subsumingOnBase union subsumingOnRight)).nonEmpty
+              val subsumedBySomeMatchOnJustTheRight =
+                (subsumingOnRight diff (subsumingOnBase union subsumingOnLeft)).nonEmpty
+
+              // NOTE: an all-sides match could be subsumed by *some* match on
+              // just one side for two or three sides; they would be
+              // *different* matches, each doing a one-sided subsumption.
+              (
+                subsumedBySomeMatchOnJustTheBase,
+                subsumedBySomeMatchOnJustTheLeft,
+                subsumedBySomeMatchOnJustTheRight
+              ) match
+                case (false, false, false) => Some(aMatch)
+                case (true, false, false)  =>
+                  Option.unless(
+                    leftSubsumes(leftSection) || rightSubsumes(
+                      rightSection
+                    )
+                  )(Match.LeftAndRight(leftSection, rightSection))
+                case (false, true, false) =>
+                  Option.unless(
+                    baseSubsumes(baseSection) || rightSubsumes(
+                      rightSection
+                    )
+                  )(Match.BaseAndRight(baseSection, rightSection))
+                case (false, false, true) =>
+                  Option.unless(
+                    baseSubsumes(baseSection) || leftSubsumes(
+                      leftSection
+                    )
+                  )(Match.BaseAndLeft(baseSection, leftSection))
+                case _ => None
+              end match
+            else None
+            end if
+
+          case Match.BaseAndLeft(baseSection, leftSection) =>
+            Option.unless(
+              baseSubsumes(baseSection) || leftSubsumes(
+                leftSection
+              )
+            )(aMatch)
+
+          case Match.BaseAndRight(baseSection, rightSection) =>
+            Option.unless(
+              baseSubsumes(baseSection) || rightSubsumes(
+                rightSection
+              )
+            )(aMatch)
+
+          case Match.LeftAndRight(leftSection, rightSection) =>
+            Option.unless(
+              leftSubsumes(leftSection) || rightSubsumes(
+                rightSection
+              )
+            )(aMatch)
+
+          case _ => None
+
+        result.traverse(paredDownMatch =>
+          recordReplacement(aMatch, paredDownMatch) as paredDownMatch
+        )
+      end pareDownOrSuppressCompletely
+
+      private def pairwiseMatchesSubsumingOnBothSidesWithBiteEdges(
+          allSides: Match.AllSides[Section[Element]]
+      ): Set[(PairwiseMatch, BiteEdge, BiteEdge)] =
+        val subsumingOnBase =
+          subsumingPairwiseMatchesIncludingTriviallySubsuming(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            allSides.baseElement
+          )
+        val subsumingOnLeft =
+          subsumingPairwiseMatchesIncludingTriviallySubsuming(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            allSides.leftElement
+          )
+        val subsumingOnRight =
+          subsumingPairwiseMatchesIncludingTriviallySubsuming(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            allSides.rightElement
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft).map {
+          case subsuming: Match.BaseAndLeft[Section[Element]] =>
+            (
+              subsuming,
+              BiteEdge.Start(startOffsetRelativeToMeal =
+                allSides.baseElement.startOffset - subsuming.baseElement.startOffset
+              ),
+              BiteEdge.End(onePastEndOffsetRelativeToMeal =
+                allSides.baseElement.onePastEndOffset - subsuming.baseElement.startOffset
+              )
+            )
+        } union (subsumingOnBase intersect subsumingOnRight).map {
+          case subsuming: Match.BaseAndRight[Section[Element]] =>
+            (
+              subsuming,
+              BiteEdge.Start(startOffsetRelativeToMeal =
+                allSides.baseElement.startOffset - subsuming.baseElement.startOffset
+              ),
+              BiteEdge.End(onePastEndOffsetRelativeToMeal =
+                allSides.baseElement.onePastEndOffset - subsuming.baseElement.startOffset
+              )
+            )
+        } union (subsumingOnLeft intersect subsumingOnRight).map {
+          case subsuming: Match.LeftAndRight[Section[Element]] =>
+            (
+              subsuming,
+              BiteEdge.Start(startOffsetRelativeToMeal =
+                allSides.leftElement.startOffset - subsuming.leftElement.startOffset
+              ),
+              BiteEdge.End(onePastEndOffsetRelativeToMeal =
+                allSides.leftElement.onePastEndOffset - subsuming.leftElement.startOffset
+              )
+            )
+        }
+      end pairwiseMatchesSubsumingOnBothSidesWithBiteEdges
 
       def parallelMatchesOnly: MatchesAndTheirSections =
         // PLAN:
@@ -1583,99 +2301,6 @@ object MatchAnalysis extends StrictLogging:
 
         withoutTheseMatches(redundantMatches)
       end withoutRedundantPairwiseMatches
-
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(allSides)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
-            )
-        }
-      end withoutTheseMatches
 
       private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
         aMatch match
@@ -1973,594 +2598,6 @@ object MatchAnalysis extends StrictLogging:
           .union(subsumingOnBase intersect subsumingOnRight)
           .union(subsumingOnLeft intersect subsumingOnRight)
       end pairwiseMatchesSubsumingOnBothSides
-
-      private def checkInvariant(): Unit =
-        // We expect to tally either two lots of a given pairwise match or three
-        // lots of a given all-sides match; we therefore scale the
-        // raw multiplicities of the section to take this into account.
-        val multiplicityScaleSubdivisibleByTwoOrThree = 6
-
-        val multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch =
-          multiplicityScaleSubdivisibleByTwoOrThree / 3
-
-        val multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch =
-          multiplicityScaleSubdivisibleByTwoOrThree / 2
-
-        val baseSectionMultiplicities = baseSectionsByPath.values
-          .flatMap(_.iterator)
-          .groupBy(identity)
-          .map((section, group) =>
-            section -> multiplicityScaleSubdivisibleByTwoOrThree * group.size
-          )
-
-        val leftSectionMultiplicities = leftSectionsByPath.values
-          .flatMap(_.iterator)
-          .groupBy(identity)
-          .map((section, group) =>
-            section -> multiplicityScaleSubdivisibleByTwoOrThree * group.size
-          )
-
-        val rightSectionMultiplicities = rightSectionsByPath.values
-          .flatMap(_.iterator)
-          .groupBy(identity)
-          .map((section, group) =>
-            section -> multiplicityScaleSubdivisibleByTwoOrThree * group.size
-          )
-
-        val tallyAllSides: Option[Int] => Option[Int] = {
-          case Some(multiplicity) =>
-            // Once we've accounted for the multiplicity, remove the entry.
-            Option.unless(
-              multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch == multiplicity
-            )(
-              multiplicity - multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch
-            )
-          // If we have an occurrence and there is no entry, start a negative
-          // count.
-          case None =>
-            Some(
-              -multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch
-            )
-        }
-
-        val tallyPairwise: Option[Int] => Option[Int] = {
-          case Some(multiplicity) =>
-            // Once we've accounted for the multiplicity, remove the entry.
-            Option.unless(
-              multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch == multiplicity
-            )(
-              multiplicity - multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch
-            )
-          // If we have an occurrence and there is no entry, start a negative
-          // count.
-          case None =>
-            Some(-multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch)
-        }
-
-        val (
-          unbalancedBaseSectionMultiplicities,
-          unbalancedLeftSectionMultiplicities,
-          unbalancedRightSectionMultiplicities
-        ) = sectionsAndTheirMatches.values.foldLeft(
-          (
-            baseSectionMultiplicities,
-            leftSectionMultiplicities,
-            rightSectionMultiplicities
-          )
-        ) {
-          case (
-                (
-                  baseSectionMultiplicities,
-                  leftSectionMultiplicities,
-                  rightSectionMultiplicities
-                ),
-                aMatch
-              ) =>
-            aMatch match
-              case Match.AllSides(
-                    baseSection,
-                    leftSection,
-                    rightSection
-                  ) =>
-                (
-                  baseSectionMultiplicities.updatedWith(baseSection)(
-                    tallyAllSides
-                  ),
-                  leftSectionMultiplicities.updatedWith(leftSection)(
-                    tallyAllSides
-                  ),
-                  rightSectionMultiplicities.updatedWith(rightSection)(
-                    tallyAllSides
-                  )
-                )
-              case Match.BaseAndLeft(
-                    baseSection,
-                    leftSection
-                  ) =>
-                (
-                  baseSectionMultiplicities.updatedWith(baseSection)(
-                    tallyPairwise
-                  ),
-                  leftSectionMultiplicities.updatedWith(leftSection)(
-                    tallyPairwise
-                  ),
-                  rightSectionMultiplicities
-                )
-              case Match.BaseAndRight(
-                    baseSection,
-                    rightSection
-                  ) =>
-                (
-                  baseSectionMultiplicities.updatedWith(baseSection)(
-                    tallyPairwise
-                  ),
-                  leftSectionMultiplicities,
-                  rightSectionMultiplicities.updatedWith(rightSection)(
-                    tallyPairwise
-                  )
-                )
-              case Match.LeftAndRight(
-                    leftSection,
-                    rightSection
-                  ) =>
-                (
-                  baseSectionMultiplicities,
-                  leftSectionMultiplicities.updatedWith(leftSection)(
-                    tallyPairwise
-                  ),
-                  rightSectionMultiplicities.updatedWith(rightSection)(
-                    tallyPairwise
-                  )
-                )
-        }
-
-        assert(
-          unbalancedBaseSectionMultiplicities.isEmpty,
-          s"Found unbalanced base section multiplicities, these are:\n${pprintCustomised(unbalancedBaseSectionMultiplicities)}"
-        )
-        assert(
-          unbalancedLeftSectionMultiplicities.isEmpty,
-          s"Found unbalanced left section multiplicities, these are:\n${pprintCustomised(unbalancedLeftSectionMultiplicities)}"
-        )
-        assert(
-          unbalancedRightSectionMultiplicities.isEmpty,
-          s"Found unbalanced right section multiplicities, these are:\n${pprintCustomised(unbalancedRightSectionMultiplicities)}"
-        )
-      end checkInvariant
-
-      private def reconciliationPostcondition(): Unit =
-        baseSectionsByPath.values.flatMap(_.iterator).foreach { baseSection =>
-          assert(!baseSubsumes(baseSection))
-        }
-        leftSectionsByPath.values.flatMap(_.iterator).foreach { leftSection =>
-          assert(!leftSubsumes(leftSection))
-        }
-        rightSectionsByPath.values.flatMap(_.iterator).foreach { rightSection =>
-          assert(!rightSubsumes(rightSection))
-        }
-
-        // No match should be redundant - i.e. no match should involve sections
-        // that all belong to another match. This goes without saying for
-        // all-sides matches, as any redundancy would imply equivalent
-        // all-sides matches being associated with the same sections - this
-        // isn't allowed by a `MultiDict` instance. The same applies for
-        // pairwise matches of the same kind; pairwise matches of different
-        // kinds can't make each other redundant.
-        // What we have to watch out for are pairwise matches having *both*
-        // sections also belonging to an all-sides match. Note that it *is*
-        // legitimate to have a pairwise match sharing just one section with an
-        // all-sides match; they are just ambiguous matches.
-
-        val matchesBySectionPairs =
-          sectionsAndTheirMatches.values.toSet.foldLeft(
-            MultiDict.empty[(Section[Element], Section[Element]), Match[
-              Section[Element]
-            ]]
-          )((matchesBySectionPairs, aMatch) =>
-            aMatch match
-              case Match.AllSides(baseSection, leftSection, rightSection) =>
-                matchesBySectionPairs + ((
-                  baseSection,
-                  leftSection
-                ) -> aMatch) + ((baseSection, rightSection) -> aMatch) + ((
-                  leftSection,
-                  rightSection
-                ) -> aMatch)
-              case Match.BaseAndLeft(baseSection, leftSection) =>
-                matchesBySectionPairs + ((
-                  baseSection,
-                  leftSection
-                ) -> aMatch)
-              case Match.BaseAndRight(baseSection, rightSection) =>
-                matchesBySectionPairs + ((
-                  baseSection,
-                  rightSection
-                ) -> aMatch)
-              case Match.LeftAndRight(leftSection, rightSection) =>
-                matchesBySectionPairs + ((
-                  leftSection,
-                  rightSection
-                ) -> aMatch)
-          )
-
-        matchesBySectionPairs.keySet.foreach { sectionPair =>
-          val matches = matchesBySectionPairs.get(sectionPair)
-
-          val (allSides, pairwiseMatches) =
-            matches.partition(_.isAnAllSidesMatch)
-
-          if allSides.nonEmpty then
-            assert(
-              pairwiseMatches.isEmpty,
-              s"Found redundancy between pairwise matches: ${pprintCustomised(pairwiseMatches)} and an all-sides match in: ${pprintCustomised(allSides)}."
-            )
-          end if
-        }
-
-        if parallelMatchesGroupIdsByMatch.nonEmpty then
-          assert(
-            parallelMatchesGroupIdsByMatch.keySet == matches,
-            s"If groups of parallel matches have been discovered, they should cover the overall population of matches exactly."
-          )
-
-          parallelMatchesGroupIdsByMatch.toSeq
-            .groupBy(_._2)
-            .values
-            .foreach { group =>
-              val matchesInGroup = group.map(_._1)
-
-              case class SidePerspective(path: Path, startOffset: Int)
-
-              case class MatchSynopsis(
-                  base: Option[SidePerspective],
-                  left: Option[SidePerspective],
-                  right: Option[SidePerspective]
-              )
-
-              object MatchSynopsis:
-                def apply(aMatch: GenericMatch[Element]): MatchSynopsis =
-                  MatchSynopsis(
-                    base = (pathOnBase(aMatch), startOffsetOnBase(aMatch))
-                      .mapN(SidePerspective.apply),
-                    left = (pathOnLeft(aMatch), startOffsetOnLeft(aMatch))
-                      .mapN(SidePerspective.apply),
-                    right = (pathOnRight(aMatch), startOffsetOnRight(aMatch))
-                      .mapN(SidePerspective.apply)
-                  )
-              end MatchSynopsis
-
-              val basePaths = matchesInGroup.flatMap(pathOnBase).toSet
-              assert(
-                basePaths.size <= 1,
-                s"""Base paths for a group of parallel matches should be the same,
-                   |but vary: $basePaths.
-                   |Matches are: ${pprintCustomised(
-                    matchesInGroup.map(MatchSynopsis.apply)
-                  )}""".stripMargin
-              )
-
-              val leftPaths = matchesInGroup.flatMap(pathOnLeft).toSet
-              assert(
-                leftPaths.size <= 1,
-                s"""Left paths for a group of parallel matches should be the same,
-                   |but vary: $leftPaths.
-                   |Matches are: ${pprintCustomised(
-                    matchesInGroup.map(MatchSynopsis.apply)
-                  )}""".stripMargin
-              )
-
-              val rightPaths = matchesInGroup.flatMap(pathOnRight).toSet
-              assert(
-                rightPaths.size <= 1,
-                s"""Right paths for a group of parallel matches should be the same,
-                   |but vary: $rightPaths.
-                   |Matches are: ${pprintCustomised(
-                    matchesInGroup.map(MatchSynopsis.apply)
-                  )}""".stripMargin
-              )
-
-              def checkOrder(
-                  side1Name: String,
-                  side2Name: String,
-                  offsetOnSide1: GenericMatch[Element] => Option[Int],
-                  offsetOnSide2: GenericMatch[Element] => Option[Int]
-              ): Unit =
-                val matchesOnBothSides = matchesInGroup
-                  .filter(m =>
-                    offsetOnSide1(m).isDefined && offsetOnSide2(m).isDefined
-                  )
-
-                for
-                  first  <- matchesOnBothSides
-                  second <- matchesOnBothSides
-                  if first != second
-                  offset1First  = offsetOnSide1(first).get
-                  offset1Second = offsetOnSide1(second).get
-                  if offset1First <= offset1Second
-                  offset2First  = offsetOnSide2(first).get
-                  offset2Second = offsetOnSide2(second).get
-                do
-                  assert(
-                    offset2First <= offset2Second,
-                    s"""
-                       |Relative order of matches in parallel group should be consistent between $side1Name and $side2Name,
-                       |but $first and $second are out of order.
-                       |Matches are: ${pprintCustomised(
-                        matchesInGroup.map(MatchSynopsis.apply)
-                      )}""".stripMargin
-                  )
-                end for
-              end checkOrder
-
-              checkOrder("base", "left", startOffsetOnBase, startOffsetOnLeft)
-              checkOrder("base", "right", startOffsetOnBase, startOffsetOnRight)
-              checkOrder("left", "right", startOffsetOnLeft, startOffsetOnRight)
-            }
-        end if
-      end reconciliationPostcondition
-
-      private def pathOnBase(aMatch: GenericMatch[Element]): Option[Path] =
-        aMatch match
-          case Match.AllSides(baseSection, _, _) =>
-            Some(baseSources.pathFor(baseSection))
-          case Match.BaseAndLeft(baseSection, _) =>
-            Some(baseSources.pathFor(baseSection))
-          case Match.BaseAndRight(baseSection, _) =>
-            Some(baseSources.pathFor(baseSection))
-          case _ => None
-
-      private def pathOnLeft(aMatch: GenericMatch[Element]): Option[Path] =
-        aMatch match
-          case Match.AllSides(_, leftSection, _) =>
-            Some(leftSources.pathFor(leftSection))
-          case Match.BaseAndLeft(_, leftSection) =>
-            Some(leftSources.pathFor(leftSection))
-          case Match.LeftAndRight(leftSection, _) =>
-            Some(leftSources.pathFor(leftSection))
-          case _ => None
-
-      private def pathOnRight(aMatch: GenericMatch[Element]): Option[Path] =
-        aMatch match
-          case Match.AllSides(_, _, rightSection) =>
-            Some(rightSources.pathFor(rightSection))
-          case Match.BaseAndRight(_, rightSection) =>
-            Some(rightSources.pathFor(rightSection))
-          case Match.LeftAndRight(_, rightSection) =>
-            Some(rightSources.pathFor(rightSection))
-          case _ => None
-
-      private def startOffsetOnBase(
-          aMatch: GenericMatch[Element]
-      ): Option[Int] =
-        aMatch match
-          case Match.AllSides(baseSection, _, _) =>
-            Some(baseSection.startOffset)
-          case Match.BaseAndLeft(baseSection, _) =>
-            Some(baseSection.startOffset)
-          case Match.BaseAndRight(baseSection, _) =>
-            Some(baseSection.startOffset)
-          case _ => None
-
-      private def startOffsetOnLeft(
-          aMatch: GenericMatch[Element]
-      ): Option[Int] =
-        aMatch match
-          case Match.AllSides(_, leftSection, _) =>
-            Some(leftSection.startOffset)
-          case Match.BaseAndLeft(_, leftSection) =>
-            Some(leftSection.startOffset)
-          case Match.LeftAndRight(leftSection, _) =>
-            Some(leftSection.startOffset)
-          case _ => None
-
-      private def startOffsetOnRight(
-          aMatch: GenericMatch[Element]
-      ): Option[Int] =
-        aMatch match
-          case Match.AllSides(_, _, rightSection) =>
-            Some(rightSection.startOffset)
-          case Match.BaseAndRight(_, rightSection) =>
-            Some(rightSection.startOffset)
-          case Match.LeftAndRight(_, rightSection) =>
-            Some(rightSection.startOffset)
-          case _ => None
-
-      private def pareDownOrSuppressCompletely[MatchType <: GenericMatch[
-        Element
-      ]](
-          aMatch: MatchType
-      ): ParallelMatchesGroupIdTracking[Option[ParedDownMatch[MatchType]]] =
-        // NOTE: one thing to watch out is when fragments resulting from
-        // larger pairwise matches being eaten into collide with equivalent
-        // pairwise matches found by fingerprint matching. This can take the
-        // form of the fragments coming first due to larger all-sides matches,
-        // or the pairwise matches from fingerprint matching can be followed
-        // by fragmentation if the all-sides eating into the larger pairwise
-        // matches also come from the same fingerprinting that yielded the
-        // pairwise matching. Intercepting this here addresses both cases. {
-        val result: Option[ParedDownMatch[MatchType]] = aMatch match
-          case Match.AllSides(baseSection, leftSection, rightSection) =>
-            val trivialSubsumptionSize = baseSection.size
-
-            val subsumingOnBase =
-              subsumingMatches(
-                sectionsAndTheirMatches
-              )(
-                baseSources,
-                baseSectionsByPath
-              )(
-                baseSection,
-                includeTrivialSubsumption = false
-              )
-
-            val subsumingOnLeft =
-              subsumingMatches(
-                sectionsAndTheirMatches
-              )(
-                leftSources,
-                leftSectionsByPath
-              )(
-                leftSection,
-                includeTrivialSubsumption = false
-              )
-
-            val subsumingOnRight =
-              subsumingMatches(
-                sectionsAndTheirMatches
-              )(
-                rightSources,
-                rightSectionsByPath
-              )(
-                rightSection,
-                includeTrivialSubsumption = false
-              )
-
-            val allSidesSubsumingOnLeft =
-              subsumingOnLeft.filter(_.isAnAllSidesMatch)
-            val allSidesSubsumingOnRight =
-              subsumingOnRight.filter(_.isAnAllSidesMatch)
-            val allSidesSubsumingOnBase =
-              subsumingOnBase.filter(_.isAnAllSidesMatch)
-
-            val subsumedByAnAllSidesMatchOnMoreThanOneSide =
-              (allSidesSubsumingOnLeft intersect allSidesSubsumingOnRight).nonEmpty
-                || (allSidesSubsumingOnBase intersect allSidesSubsumingOnLeft).nonEmpty
-                || (allSidesSubsumingOnBase intersect allSidesSubsumingOnRight).nonEmpty
-
-            if !subsumedByAnAllSidesMatchOnMoreThanOneSide then
-              val subsumedBySomeMatchOnJustTheBase =
-                (subsumingOnBase diff (subsumingOnLeft union subsumingOnRight)).nonEmpty
-              val subsumedBySomeMatchOnJustTheLeft =
-                (subsumingOnLeft diff (subsumingOnBase union subsumingOnRight)).nonEmpty
-              val subsumedBySomeMatchOnJustTheRight =
-                (subsumingOnRight diff (subsumingOnBase union subsumingOnLeft)).nonEmpty
-
-              // NOTE: an all-sides match could be subsumed by *some* match on
-              // just one side for two or three sides; they would be
-              // *different* matches, each doing a one-sided subsumption.
-              (
-                subsumedBySomeMatchOnJustTheBase,
-                subsumedBySomeMatchOnJustTheLeft,
-                subsumedBySomeMatchOnJustTheRight
-              ) match
-                case (false, false, false) => Some(aMatch)
-                case (true, false, false)  =>
-                  Option.unless(
-                    leftSubsumes(leftSection) || rightSubsumes(
-                      rightSection
-                    )
-                  )(Match.LeftAndRight(leftSection, rightSection))
-                case (false, true, false) =>
-                  Option.unless(
-                    baseSubsumes(baseSection) || rightSubsumes(
-                      rightSection
-                    )
-                  )(Match.BaseAndRight(baseSection, rightSection))
-                case (false, false, true) =>
-                  Option.unless(
-                    baseSubsumes(baseSection) || leftSubsumes(
-                      leftSection
-                    )
-                  )(Match.BaseAndLeft(baseSection, leftSection))
-                case _ => None
-              end match
-            else None
-            end if
-
-          case Match.BaseAndLeft(baseSection, leftSection) =>
-            Option.unless(
-              baseSubsumes(baseSection) || leftSubsumes(
-                leftSection
-              )
-            )(aMatch)
-
-          case Match.BaseAndRight(baseSection, rightSection) =>
-            Option.unless(
-              baseSubsumes(baseSection) || rightSubsumes(
-                rightSection
-              )
-            )(aMatch)
-
-          case Match.LeftAndRight(leftSection, rightSection) =>
-            Option.unless(
-              leftSubsumes(leftSection) || rightSubsumes(
-                rightSection
-              )
-            )(aMatch)
-
-          case _ => None
-
-        result.traverse(paredDownMatch =>
-          recordReplacement(aMatch, paredDownMatch) as paredDownMatch
-        )
-      end pareDownOrSuppressCompletely
-
-      private def pairwiseMatchesSubsumingOnBothSidesWithBiteEdges(
-          allSides: Match.AllSides[Section[Element]]
-      ): Set[(PairwiseMatch, BiteEdge, BiteEdge)] =
-        val subsumingOnBase =
-          subsumingPairwiseMatchesIncludingTriviallySubsuming(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            allSides.baseElement
-          )
-        val subsumingOnLeft =
-          subsumingPairwiseMatchesIncludingTriviallySubsuming(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            allSides.leftElement
-          )
-        val subsumingOnRight =
-          subsumingPairwiseMatchesIncludingTriviallySubsuming(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            allSides.rightElement
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft).map {
-          case subsuming: Match.BaseAndLeft[Section[Element]] =>
-            (
-              subsuming,
-              BiteEdge.Start(startOffsetRelativeToMeal =
-                allSides.baseElement.startOffset - subsuming.baseElement.startOffset
-              ),
-              BiteEdge.End(onePastEndOffsetRelativeToMeal =
-                allSides.baseElement.onePastEndOffset - subsuming.baseElement.startOffset
-              )
-            )
-        } union (subsumingOnBase intersect subsumingOnRight).map {
-          case subsuming: Match.BaseAndRight[Section[Element]] =>
-            (
-              subsuming,
-              BiteEdge.Start(startOffsetRelativeToMeal =
-                allSides.baseElement.startOffset - subsuming.baseElement.startOffset
-              ),
-              BiteEdge.End(onePastEndOffsetRelativeToMeal =
-                allSides.baseElement.onePastEndOffset - subsuming.baseElement.startOffset
-              )
-            )
-        } union (subsumingOnLeft intersect subsumingOnRight).map {
-          case subsuming: Match.LeftAndRight[Section[Element]] =>
-            (
-              subsuming,
-              BiteEdge.Start(startOffsetRelativeToMeal =
-                allSides.leftElement.startOffset - subsuming.leftElement.startOffset
-              ),
-              BiteEdge.End(onePastEndOffsetRelativeToMeal =
-                allSides.leftElement.onePastEndOffset - subsuming.leftElement.startOffset
-              )
-            )
-        }
-      end pairwiseMatchesSubsumingOnBothSidesWithBiteEdges
 
       @tailrec
       private final def withAllSmallFryMatches(

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -187,7 +187,7 @@ object MatchAnalysis extends StrictLogging:
 
     object MatchesAndTheirSections:
       type ParallelMatchesGroupIdTracking[X] =
-        State[Map[GenericMatch[Element], ParallelMatchesGroupId], X]
+        State[MultiDict[GenericMatch[Element], ParallelMatchesGroupId], X]
       lazy val empty: MatchesAndTheirSections = MatchesAndTheirSections(
         baseSectionsByPath = Map.empty,
         leftSectionsByPath = Map.empty,
@@ -199,7 +199,7 @@ object MatchAnalysis extends StrictLogging:
           fingerprintedInclusionsByPath(leftSources),
         rightFingerprintedInclusionsByPath =
           fingerprintedInclusionsByPath(rightSources),
-        parallelMatchesGroupIdsByMatch = Map.empty
+        parallelMatchesGroupIdsByMatch = MultiDict.empty
       )
       private val rollingHashFactoryCache: Cache[Int, RollingHash.Factory] =
         Caffeine.newBuilder().build()
@@ -877,12 +877,12 @@ object MatchAnalysis extends StrictLogging:
           original: GenericMatch[Element],
           replacement: GenericMatch[Element]
       ): ParallelMatchesGroupIdTracking[Unit] =
-        State.modify { groupIds =>
-          groupIds
-            .get(original)
-            .fold(ifEmpty = groupIds)(groupId =>
-              groupIds + (replacement -> groupId)
-            )
+        State.modify { groupIdsByMatch =>
+          val groupIds = groupIdsByMatch.get(original)
+
+          groupIds.foldLeft(groupIdsByMatch)((partialResult, groupId) =>
+            partialResult.add(replacement, groupId)
+          )
         }
 
       trait PathInclusions:
@@ -935,7 +935,7 @@ object MatchAnalysis extends StrictLogging:
         baseFingerprintedInclusionsByPath: Map[Path, FingerprintedInclusions],
         leftFingerprintedInclusionsByPath: Map[Path, FingerprintedInclusions],
         rightFingerprintedInclusionsByPath: Map[Path, FingerprintedInclusions],
-        parallelMatchesGroupIdsByMatch: Map[GenericMatch[
+        parallelMatchesGroupIdsByMatch: MultiDict[GenericMatch[
           Element
         ], ParallelMatchesGroupId]
     ) extends MatchAnalysis[Path, Element]:
@@ -1223,7 +1223,7 @@ object MatchAnalysis extends StrictLogging:
                   rightSection
                 ),
               parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(allSides)
+                parallelMatchesGroupIdsByMatch.removeKey(allSides)
             )
 
           case (
@@ -1240,7 +1240,7 @@ object MatchAnalysis extends StrictLogging:
                   .remove(baseSection, baseAndLeft)
                   .remove(leftSection, baseAndLeft),
               parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
+                parallelMatchesGroupIdsByMatch.removeKey(baseAndLeft)
             )
 
           case (
@@ -1257,7 +1257,7 @@ object MatchAnalysis extends StrictLogging:
                   .remove(baseSection, baseAndRight)
                   .remove(rightSection, baseAndRight),
               parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
+                parallelMatchesGroupIdsByMatch.removeKey(baseAndRight)
             )
 
           case (
@@ -1274,7 +1274,7 @@ object MatchAnalysis extends StrictLogging:
                   .remove(leftSection, leftAndRight)
                   .remove(rightSection, leftAndRight),
               parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
+                parallelMatchesGroupIdsByMatch.removeKey(leftAndRight)
             )
         }
       end withoutTheseMatches
@@ -1364,9 +1364,8 @@ object MatchAnalysis extends StrictLogging:
                       val matches = reconciled.matches
                       Right(
                         reconciled.copy(parallelMatchesGroupIdsByMatch =
-                          updatedParallelMatchesGroupsIdsByMatch.view
-                            .filterKeys(matches.contains)
-                            .toMap
+                          updatedParallelMatchesGroupsIdsByMatch
+                            .filterSets((key, _) => matches.contains(key))
                         )
                       )
                   else
@@ -1380,7 +1379,7 @@ object MatchAnalysis extends StrictLogging:
               .tailRecM(matches.collect {
                 case allSides: Match.AllSides[Section[Element]] => allSides
               })(reconcileUsing)
-              .runA(Map.empty)
+              .runA(MultiDict.empty)
               .value
           }: @unchecked
 
@@ -2235,11 +2234,11 @@ object MatchAnalysis extends StrictLogging:
           backTranslatedMatchesAndTheirSections.matches
 
         val parallelMatchesGroupIdsByMatch =
-          groupsOfBackTranslatedParallelMatches.zipWithIndex
-            .flatMap((parallelMatches, groupId) =>
-              parallelMatches.map(_ -> groupId)
+          MultiDict.from(
+            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
+              (parallelMatches, groupId) => parallelMatches.map(_ -> groupId)
             )
-            .toMap
+          )
 
         backTranslatedMatchesAndTheirSections
           .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1362,11 +1362,63 @@ object MatchAnalysis extends StrictLogging:
                       updatedParallelMatchesGroupsIdsByMatch <- State.get
                     yield
                       val matches = reconciled.matches
+
+                      val parallelMatchesGroupIdsByMatch =
+                        updatedParallelMatchesGroupsIdsByMatch.view
+                          .filterKeys(matches.contains)
+                          .toMap
+
+                      val pathConsistentParallelMatchesGroupIdsByMatch =
+                        if parallelMatchesGroupIdsByMatch.nonEmpty then
+                          val matchesByGroupId =
+                            parallelMatchesGroupIdsByMatch.toSeq
+                              .groupBy(_._2)
+                              .view
+                              .mapValues(_.map(_._1))
+
+                          matchesByGroupId
+                            .flatMap { case (_, matchesInGroup) =>
+                              val subGroupsByPaths = matchesInGroup.groupBy {
+                                aMatch =>
+                                  val pathOnBase = aMatch match
+                                    case Match.AllSides(baseSection, _, _) =>
+                                      Some(baseSources.pathFor(baseSection))
+                                    case Match.BaseAndLeft(baseSection, _) =>
+                                      Some(baseSources.pathFor(baseSection))
+                                    case Match.BaseAndRight(baseSection, _) =>
+                                      Some(baseSources.pathFor(baseSection))
+                                    case _ => None
+                                  val pathOnLeft = aMatch match
+                                    case Match.AllSides(_, leftSection, _) =>
+                                      Some(leftSources.pathFor(leftSection))
+                                    case Match.BaseAndLeft(_, leftSection) =>
+                                      Some(leftSources.pathFor(leftSection))
+                                    case Match.LeftAndRight(leftSection, _) =>
+                                      Some(leftSources.pathFor(leftSection))
+                                    case _ => None
+                                  val pathOnRight = aMatch match
+                                    case Match.AllSides(_, _, rightSection) =>
+                                      Some(rightSources.pathFor(rightSection))
+                                    case Match.BaseAndRight(_, rightSection) =>
+                                      Some(rightSources.pathFor(rightSection))
+                                    case Match.LeftAndRight(_, rightSection) =>
+                                      Some(rightSources.pathFor(rightSection))
+                                    case _ => None
+                                  (pathOnBase, pathOnLeft, pathOnRight)
+                              }
+
+                              subGroupsByPaths.values
+                            }
+                            .zipWithIndex
+                            .flatMap { case (subGroup, id) =>
+                              subGroup.map(_ -> id)
+                            }
+                            .toMap
+                        else parallelMatchesGroupIdsByMatch
+
                       Right(
                         reconciled.copy(parallelMatchesGroupIdsByMatch =
-                          updatedParallelMatchesGroupsIdsByMatch.view
-                            .filterKeys(matches.contains)
-                            .toMap
+                          pathConsistentParallelMatchesGroupIdsByMatch
                         )
                       )
                   else
@@ -1618,6 +1670,44 @@ object MatchAnalysis extends StrictLogging:
             parallelMatchesGroupIdsByMatch.keySet == matches,
             s"If groups of parallel matches have been discovered, they should cover the overall population of matches exactly."
           )
+
+          val matchesByGroupId =
+            parallelMatchesGroupIdsByMatch.toSeq
+              .groupBy(_._2)
+              .view
+              .mapValues(_.map(_._1))
+
+          matchesByGroupId.foreach { case (groupId, matchesInGroup) =>
+            val basePaths = matchesInGroup.collect {
+              case Match.AllSides(baseSection, _, _)  => baseSources.pathFor(baseSection)
+              case Match.BaseAndLeft(baseSection, _)  => baseSources.pathFor(baseSection)
+              case Match.BaseAndRight(baseSection, _) => baseSources.pathFor(baseSection)
+            }.toSet
+            assert(
+              basePaths.size <= 1,
+              s"Group $groupId has multiple base paths: $basePaths"
+            )
+
+            val leftPaths = matchesInGroup.collect {
+              case Match.AllSides(_, leftSection, _)  => leftSources.pathFor(leftSection)
+              case Match.BaseAndLeft(_, leftSection)  => leftSources.pathFor(leftSection)
+              case Match.LeftAndRight(leftSection, _) => leftSources.pathFor(leftSection)
+            }.toSet
+            assert(
+              leftPaths.size <= 1,
+              s"Group $groupId has multiple left paths: $leftPaths"
+            )
+
+            val rightPaths = matchesInGroup.collect {
+              case Match.AllSides(_, _, rightSection) => rightSources.pathFor(rightSection)
+              case Match.BaseAndRight(_, rightSection) => rightSources.pathFor(rightSection)
+              case Match.LeftAndRight(_, rightSection) => rightSources.pathFor(rightSection)
+            }.toSet
+            assert(
+              rightPaths.size <= 1,
+              s"Group $groupId has multiple right paths: $rightPaths"
+            )
+          }
         end if
       end reconciliationPostcondition
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1302,592 +1302,6 @@ object MatchAnalysis extends StrictLogging:
 
       end reconcileMatches
 
-      def parallelMatchesOnly: MatchesAndTheirSections =
-        // PLAN:
-
-        // 1. Build up sources composed of matched sections concatenated
-        // together by path preserving their original order.
-
-        val baseMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(baseSection, _, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndLeft(baseSection, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndRight(baseSection, _))
-                  if section == baseSection =>
-                section
-            }
-
-        val leftMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, leftSection, _))
-                  if section == leftSection =>
-                section
-              case (section, Match.BaseAndLeft(_, leftSection))
-                  if section == leftSection =>
-                section
-              case (section, Match.LeftAndRight(leftSection, _))
-                  if section == leftSection =>
-                section
-            }
-
-        val rightMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, _, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.BaseAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.LeftAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-            }
-
-        case class MetaMatchContentSources(
-            override val contentsByPath: Map[Path, IndexedSeq[
-              Section[Element]
-            ]],
-            override val label: String
-        ) extends MappedContentSources[Path, Section[Element]]
-
-        def sourcesForMetaMatching(label: String)(
-            sources: Sources[Path, Element],
-            matchedSections: Iterable[Section[Element]]
-        ) = MetaMatchContentSources(
-          contentsByPath = matchedSections
-            .groupBy(sources.pathFor)
-            .map((path, sections) =>
-              path -> sections.toIndexedSeq.sortBy(_.startOffset)
-            ),
-          label = label
-        )
-
-        val baseSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-base")(
-            baseSources,
-            baseMatchedSections
-          )
-        val leftSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-left")(
-            leftSources,
-            leftMatchedSections
-          )
-        val rightSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-right")(
-            rightSources,
-            rightMatchedSections
-          )
-
-        // 2. Apply `MatchAnalysis.of` to these sections, using the
-        // potential match key of the section to underpin equality and
-        // hashing.
-
-        object metaMatchConfiguration extends AbstractConfiguration:
-          override val minimumMatchSize: Int                    = 1
-          override val thresholdSizeFractionForMatching: Double = 0
-          override val minimumAmbiguousMatchSize: Int           = 1
-          override val ambiguousMatchesThreshold: Int           = Int.MaxValue
-          override val progressRecording: ProgressRecording     =
-            configuration.progressRecording
-        end metaMatchConfiguration
-
-        given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
-
-        given Funnel[Section[Element]] with
-          override def funnel(
-              from: Section[Element],
-              into: PrimitiveSink
-          ): Unit =
-            from.content.foreach(summon[Funnel[Element]].funnel(_, into))
-
-        end given
-
-        val metaMatchAnalysis = of(
-          baseSourcesForMetaMatching,
-          leftSourcesForMetaMatching,
-          rightSourcesForMetaMatching
-        )(metaMatchConfiguration)
-
-        // 3. The resulting meta-matches provide parallel sequences of sections
-        // that are unzipped to yield corresponding all-sides and pairwise
-        // matches.
-
-        val metaMatches = metaMatchAnalysis.matches
-
-        // NOTE: because meta-matching starts with matched *sections* and
-        // ignores gaps, we have to guard against sections that would have
-        // formed the sides of a suppressed outer match making a second attempt
-        // at building a match.
-        val groupsOfBackTranslatedParallelMatches = metaMatches
-          .map {
-            case Match.AllSides(
-                  baseMetaSection,
-                  leftMetaSection,
-                  rightMetaSection
-                ) =>
-              (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAnAllSidesMatch(
-                        baseSection,
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.AllSides(baseSection, leftSection, rightSection)
-                }
-            case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
-              (baseMetaSection.content lazyZip leftMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-                        baseSection,
-                        leftSection
-                      ) =>
-                    Match.BaseAndLeft(baseSection, leftSection)
-                }
-            case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
-              (baseMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-                        baseSection,
-                        rightSection
-                      ) =>
-                    Match.BaseAndRight(baseSection, rightSection)
-                }
-            case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
-              (leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.LeftAndRight(leftSection, rightSection)
-                }
-          }
-          .filter(_.nonEmpty)
-          .toSeq
-
-        // 4. Put the back-translated matches into their own disjoint sets, then
-        // unify those matches that come from the same group of parallel
-        // matches, then unify all-sides matches with pairwise matches that
-        // subsume them, regardless of the original group.
-
-        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
-        // the back-translated matches, because the thinning out of ambiguous
-        // matches performed by the meta-matching and back translation above
-        // means there are new opportunities for matches to be generated - while
-        // the vast majority of these are redundant pairwise matches, there are
-        // some that are vital to capture things such as moves with migrated
-        // edits / deletions - the test
-        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
-        // an example of this.
-        val backTranslatedMatchesAndTheirSections =
-          MatchesAndTheirSections.empty
-            .withMatches(
-              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
-              haveTrimmedMatches = false
-            )
-            .matchesAndTheirSections
-            .withoutRedundantPairwiseMatches
-
-        val backTranslatedMatches =
-          backTranslatedMatchesAndTheirSections.matches
-
-        val parallelMatchesGroupIdsByMatch =
-          MultiDict.from(
-            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
-              (parallelMatches, groupId) => parallelMatches.map(_ -> groupId)
-            )
-          )
-
-        backTranslatedMatchesAndTheirSections
-          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
-      end parallelMatchesOnly
-
-      // Cleans up the state when a putative all-sides match that would have
-      // been ambiguous on one side with another all-sides match was partially
-      // suppressed by a larger pairwise match. This situation results in a
-      // pairwise match that shares its sections on both sides with the other
-      // all-sides match; remove any such redundant pairwise matches.
-      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
-        val redundantMatches =
-          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
-
-        if redundantMatches.nonEmpty then
-          logger.debug(
-            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
-          )
-        end if
-
-        withoutTheseMatches(redundantMatches)
-      end withoutRedundantPairwiseMatches
-
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(allSides)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(baseAndLeft)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(baseAndRight)
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(leftAndRight)
-            )
-        }
-      end withoutTheseMatches
-
-      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
-        aMatch match
-          case Match.BaseAndLeft(baseSection, leftSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(leftSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.BaseAndRight(baseSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.LeftAndRight(leftSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(leftSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case _: Match.AllSides[Section[Element]] => false
-
-      private def isSubsumedNonTriviallyByAnAllSidesMatch(
-          baseSection: Section[Element],
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAnAllSidesMatch
-
-      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-          baseSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-          baseSection: Section[Element],
-          leftSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
-
-      private def withMatches(
-          matches: Set[GenericMatch[Element]],
-          haveTrimmedMatches: Boolean
-      ): MatchingResult =
-        val updatedMatchesAndTheirSections =
-          matches.foldLeft(this)(_ withMatch _)
-
-        val pathInclusions =
-          if !haveTrimmedMatches then
-            case class PathInclusionsImplementation(
-                basePaths: Set[Path],
-                leftPaths: Set[Path],
-                rightPaths: Set[Path]
-            ) extends PathInclusions:
-              override def isIncludedOnBase(basePath: Path): Boolean =
-                basePaths.contains(basePath)
-
-              override def isIncludedOnLeft(leftPath: Path): Boolean =
-                leftPaths.contains(leftPath)
-
-              override def isIncludedOnRight(rightPath: Path): Boolean =
-                rightPaths.contains(rightPath)
-
-              def addPathOnBaseFor(
-                  baseSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
-              def addPathOnLeftFor(
-                  leftSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
-              def addPathOnRightFor(
-                  rightSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(rightPaths =
-                  rightPaths + rightSources.pathFor(rightSection)
-                )
-            end PathInclusionsImplementation
-
-            matches.foldLeft(
-              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
-            )((partialPathInclusions, aMatch) =>
-              aMatch match
-                case Match.AllSides(baseSection, leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.BaseAndLeft(baseSection, leftSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                case Match.BaseAndRight(baseSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.LeftAndRight(leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-            )
-          else PathInclusions.all
-
-        MatchingResult(
-          matchesAndTheirSections = updatedMatchesAndTheirSections,
-          numberOfMatchesForTheGivenWindowSize = matches.size,
-          estimatedWindowSizeForOptimalMatch =
-            estimateOptimalMatchSize(matches),
-          pathInclusions = pathInclusions
-        )
-      end withMatches
-
-      private def withMatch(
-          aMatch: GenericMatch[Element]
-      ): MatchesAndTheirSections =
-        aMatch match
-          case Match.AllSides(baseSection, leftSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
-              baseFingerprintedInclusionsByPath =
-                knockOutFromBaseFingerprintedInclusions(baseSection),
-              leftFingerprintedInclusionsByPath =
-                knockOutFromLeftFingerprintedInclusions(leftSection),
-              rightFingerprintedInclusionsByPath =
-                knockOutFromRightFingerprintedInclusions(rightSection)
-            )
-          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
-            )
-          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
-            )
-          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
-            copy(
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
-            )
-        end match
-      end withMatch
-
       private def checkInvariant(): Unit =
         // We expect to tally either two lots of a given pairwise match or three
         // lots of a given all-sides match; we therefore scale the
@@ -2528,6 +1942,608 @@ object MatchAnalysis extends StrictLogging:
             )
         }
       end pairwiseMatchesSubsumingOnBothSidesWithBiteEdges
+
+      def parallelMatchesOnly: MatchesAndTheirSections =
+        // PLAN:
+
+        // 1. Build up sources composed of matched sections concatenated
+        // together by path preserving their original order.
+
+        val baseMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(baseSection, _, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndLeft(baseSection, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndRight(baseSection, _))
+                  if section == baseSection =>
+                section
+            }
+
+        val leftMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, leftSection, _))
+                  if section == leftSection =>
+                section
+              case (section, Match.BaseAndLeft(_, leftSection))
+                  if section == leftSection =>
+                section
+              case (section, Match.LeftAndRight(leftSection, _))
+                  if section == leftSection =>
+                section
+            }
+
+        val rightMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, _, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.BaseAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.LeftAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+            }
+
+        case class MetaMatchContentSources(
+            override val contentsByPath: Map[Path, IndexedSeq[
+              Section[Element]
+            ]],
+            override val label: String
+        ) extends MappedContentSources[Path, Section[Element]]
+
+        def sourcesForMetaMatching(label: String)(
+            sources: Sources[Path, Element],
+            matchedSections: Iterable[Section[Element]]
+        ) = MetaMatchContentSources(
+          contentsByPath = matchedSections
+            .groupBy(sources.pathFor)
+            .map((path, sections) =>
+              path -> sections.toIndexedSeq
+                .sortBy(section =>
+                  // NOTE: use the negative of the section size as a tiebreaker
+                  // if more than one section has the same start offset. This
+                  // makes sure that a subsuming section comes *before* any
+                  // sections that it might subsume, so it can't interpose
+                  // itself within what would have been a run of parallel
+                  // subsumed sections; that way we don't accidentally split
+                  // what should be larger meta-matches. That can occur when the
+                  // subsuming section is contributed by a larger pairwise match
+                  // that subsumes several all-sides matches, and the first
+                  // all-sides match aligns with the start of the pairwise
+                  // match. The test
+                  // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation`
+                  // has an example of this.
+                  section.startOffset -> -section.size
+                )
+            ),
+          label = label
+        )
+
+        val baseSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-base")(
+            baseSources,
+            baseMatchedSections
+          )
+        val leftSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-left")(
+            leftSources,
+            leftMatchedSections
+          )
+        val rightSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-right")(
+            rightSources,
+            rightMatchedSections
+          )
+
+        // 2. Apply `MatchAnalysis.of` to these sections, using the
+        // potential match key of the section to underpin equality and
+        // hashing.
+
+        object metaMatchConfiguration extends AbstractConfiguration:
+          override val minimumMatchSize: Int                    = 1
+          override val thresholdSizeFractionForMatching: Double = 0
+          override val minimumAmbiguousMatchSize: Int           = 1
+          override val ambiguousMatchesThreshold: Int           = Int.MaxValue
+          override val progressRecording: ProgressRecording     =
+            configuration.progressRecording
+        end metaMatchConfiguration
+
+        given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
+
+        given Funnel[Section[Element]] with
+          override def funnel(
+              from: Section[Element],
+              into: PrimitiveSink
+          ): Unit =
+            from.content.foreach(summon[Funnel[Element]].funnel(_, into))
+
+        end given
+
+        val metaMatchAnalysis = of(
+          baseSourcesForMetaMatching,
+          leftSourcesForMetaMatching,
+          rightSourcesForMetaMatching
+        )(metaMatchConfiguration)
+
+        // 3. The resulting meta-matches provide parallel sequences of sections
+        // that are unzipped to yield corresponding all-sides and pairwise
+        // matches.
+
+        val metaMatches = metaMatchAnalysis.matches
+
+        // NOTE: because meta-matching starts with matched *sections* and
+        // ignores gaps, we have to guard against sections that would have
+        // formed the sides of a suppressed outer match making a second attempt
+        // at building a match.
+        val groupsOfBackTranslatedParallelMatches = metaMatches
+          .map {
+            case Match.AllSides(
+                  baseMetaSection,
+                  leftMetaSection,
+                  rightMetaSection
+                ) =>
+              (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (baseSection, leftSection, rightSection)
+                      if !isSubsumedNonTriviallyByAnAllSidesMatch(
+                        baseSection,
+                        leftSection,
+                        rightSection
+                      ) =>
+                    Match.AllSides(baseSection, leftSection, rightSection)
+                }
+            case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
+              (baseMetaSection.content lazyZip leftMetaSection.content)
+                .collect {
+                  case (baseSection, leftSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+                        baseSection,
+                        leftSection
+                      ) =>
+                    Match.BaseAndLeft(baseSection, leftSection)
+                }
+            case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
+              (baseMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (baseSection, rightSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+                        baseSection,
+                        rightSection
+                      ) =>
+                    Match.BaseAndRight(baseSection, rightSection)
+                }
+            case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
+              (leftMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (leftSection, rightSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+                        leftSection,
+                        rightSection
+                      ) =>
+                    Match.LeftAndRight(leftSection, rightSection)
+                }
+          }
+          .filter(_.nonEmpty)
+          .toSeq
+
+        // 4. Put the back-translated matches into their own disjoint sets, then
+        // unify those matches that come from the same group of parallel
+        // matches, then unify all-sides matches with pairwise matches that
+        // subsume them, regardless of the original group.
+
+        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
+        // the back-translated matches, because the thinning out of ambiguous
+        // matches performed by the meta-matching and back translation above
+        // means there are new opportunities for matches to be generated - while
+        // the vast majority of these are redundant pairwise matches, there are
+        // some that are vital to capture things such as moves with migrated
+        // edits / deletions - the test
+        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
+        // an example of this.
+        val backTranslatedMatchesAndTheirSections =
+          MatchesAndTheirSections.empty
+            .withMatches(
+              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
+              haveTrimmedMatches = false
+            )
+            .matchesAndTheirSections
+            .withoutRedundantPairwiseMatches
+
+        val backTranslatedMatches =
+          backTranslatedMatchesAndTheirSections.matches
+
+        val parallelMatchesGroupIdsByMatch =
+          MultiDict.from(
+            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
+              (parallelMatches, groupId) => parallelMatches.map(_ -> groupId)
+            )
+          )
+
+        backTranslatedMatchesAndTheirSections
+          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
+      end parallelMatchesOnly
+
+      // Cleans up the state when a putative all-sides match that would have
+      // been ambiguous on one side with another all-sides match was partially
+      // suppressed by a larger pairwise match. This situation results in a
+      // pairwise match that shares its sections on both sides with the other
+      // all-sides match; remove any such redundant pairwise matches.
+      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
+        val redundantMatches =
+          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
+
+        if redundantMatches.nonEmpty then
+          logger.debug(
+            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
+          )
+        end if
+
+        withoutTheseMatches(redundantMatches)
+      end withoutRedundantPairwiseMatches
+
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(allSides)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(baseAndLeft)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(baseAndRight)
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(leftAndRight)
+            )
+        }
+      end withoutTheseMatches
+
+      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
+        aMatch match
+          case Match.BaseAndLeft(baseSection, leftSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(leftSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.BaseAndRight(baseSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.LeftAndRight(leftSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(leftSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case _: Match.AllSides[Section[Element]] => false
+
+      private def isSubsumedNonTriviallyByAnAllSidesMatch(
+          baseSection: Section[Element],
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAnAllSidesMatch
+
+      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+          baseSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+          baseSection: Section[Element],
+          leftSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
+
+      private def withMatches(
+          matches: Set[GenericMatch[Element]],
+          haveTrimmedMatches: Boolean
+      ): MatchingResult =
+        val updatedMatchesAndTheirSections =
+          matches.foldLeft(this)(_ withMatch _)
+
+        val pathInclusions =
+          if !haveTrimmedMatches then
+            case class PathInclusionsImplementation(
+                basePaths: Set[Path],
+                leftPaths: Set[Path],
+                rightPaths: Set[Path]
+            ) extends PathInclusions:
+              override def isIncludedOnBase(basePath: Path): Boolean =
+                basePaths.contains(basePath)
+
+              override def isIncludedOnLeft(leftPath: Path): Boolean =
+                leftPaths.contains(leftPath)
+
+              override def isIncludedOnRight(rightPath: Path): Boolean =
+                rightPaths.contains(rightPath)
+
+              def addPathOnBaseFor(
+                  baseSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
+              def addPathOnLeftFor(
+                  leftSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
+              def addPathOnRightFor(
+                  rightSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(rightPaths =
+                  rightPaths + rightSources.pathFor(rightSection)
+                )
+            end PathInclusionsImplementation
+
+            matches.foldLeft(
+              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
+            )((partialPathInclusions, aMatch) =>
+              aMatch match
+                case Match.AllSides(baseSection, leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.BaseAndLeft(baseSection, leftSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                case Match.BaseAndRight(baseSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.LeftAndRight(leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+            )
+          else PathInclusions.all
+
+        MatchingResult(
+          matchesAndTheirSections = updatedMatchesAndTheirSections,
+          numberOfMatchesForTheGivenWindowSize = matches.size,
+          estimatedWindowSizeForOptimalMatch =
+            estimateOptimalMatchSize(matches),
+          pathInclusions = pathInclusions
+        )
+      end withMatches
+
+      private def withMatch(
+          aMatch: GenericMatch[Element]
+      ): MatchesAndTheirSections =
+        aMatch match
+          case Match.AllSides(baseSection, leftSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
+              baseFingerprintedInclusionsByPath =
+                knockOutFromBaseFingerprintedInclusions(baseSection),
+              leftFingerprintedInclusionsByPath =
+                knockOutFromLeftFingerprintedInclusions(leftSection),
+              rightFingerprintedInclusionsByPath =
+                knockOutFromRightFingerprintedInclusions(rightSection)
+            )
+          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
+            )
+          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
+            )
+          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
+            copy(
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
+            )
+        end match
+      end withMatch
 
       private def pairwiseMatchesSubsumingOnBothSides(
           allSides: Match.AllSides[Section[Element]]

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -780,7 +780,7 @@ object MatchAnalysis extends StrictLogging:
                     )(
                       rightSection
                     )).map(Match.LeftAndRight.apply)
-                    
+
               _ <- recordReplacements(pairwiseMatch, fragmentsFromPairwiseMatch)
             yield
               logger.debug(
@@ -792,7 +792,9 @@ object MatchAnalysis extends StrictLogging:
           .map(_.toSet)
 
       // Breaks up a section by eating into it with smaller bites, yielding the
-      // fragment sections.
+      // fragment sections. There are preconditions buried in the implementation
+      // that require the bite edges to be sorted in terms of their offsets and
+      // not exceed the section's boundaries.
       private def eatIntoSection(
           side: Sources[Path, Element],
           biteEdges: Seq[BiteEdge]
@@ -829,23 +831,22 @@ object MatchAnalysis extends StrictLogging:
                 val startOffset =
                   section.startOffset + startOffsetRelativeToMeal
 
+                require(startOffset >= mealStartOffset)
                 require(mealOnePastEndOffset > startOffset)
-                val guardedStartOffset = startOffset max mealStartOffset
-
                 this
                   .copy(
-                    mealStartOffset = guardedStartOffset,
+                    mealStartOffset = startOffset,
                     biteDepth = 1 + biteDepth
                   )
                   .apply(
                     remainingBiteEdges,
                     fragments =
-                      if 0 == biteDepth && guardedStartOffset > mealStartOffset
+                      if 0 == biteDepth && startOffset > mealStartOffset
                       then
                         fragments.appended(
                           side.section(path)(
                             startOffset = mealStartOffset,
-                            size = guardedStartOffset - mealStartOffset
+                            size = startOffset - mealStartOffset
                           )
                         )
                       else fragments
@@ -860,12 +861,10 @@ object MatchAnalysis extends StrictLogging:
                   section.startOffset + onePastEndOffsetRelativeToMeal
 
                 require(mealStartOffset <= onePastEndOffset)
-                val guardedOnePastEndOffset =
-                  onePastEndOffset min mealOnePastEndOffset
-
+                require(onePastEndOffset <= mealOnePastEndOffset)
                 this
                   .copy(
-                    mealStartOffset = guardedOnePastEndOffset,
+                    mealStartOffset = onePastEndOffset,
                     biteDepth = biteDepth - 1
                   )
                   .apply(remainingBiteEdges, fragments)
@@ -894,6 +893,12 @@ object MatchAnalysis extends StrictLogging:
             partialResult.add(replacement, groupId)
           )
         }
+
+      private def assignParallelMatchesGroupIdsForFragments(
+          biteEdges: Seq[BiteEdge]
+      )(
+          matchesBySortedBiteEdge: Map[BiteEdge, Set[ParallelMatchesGroupId]]
+      ): Seq[Set[ParallelMatchesGroupId]] = ???
 
       trait PathInclusions:
         def isIncludedOnBase(basePath: Path): Boolean

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -185,14 +185,9 @@ object MatchAnalysis extends StrictLogging:
 
     val tiebreakContentSamplingLimit = 5
 
-    val matchToId = mutable.Map.empty[GenericMatch[Element], Int]
-    given matchOrder: Order[GenericMatch[Element]] =
-      Order.by(m => matchToId.getOrElseUpdate(m, matchToId.size))
-
     object MatchesAndTheirSections:
-      type ParallelMatchesGrouping = DisjointSets[GenericMatch[Element]]
       type ParallelMatchesGroupIdTracking[X] =
-        State[ParallelMatchesGrouping, X]
+        State[Map[GenericMatch[Element], ParallelMatchesGroupId], X]
       lazy val empty: MatchesAndTheirSections = MatchesAndTheirSections(
         baseSectionsByPath = Map.empty,
         leftSectionsByPath = Map.empty,
@@ -766,14 +761,13 @@ object MatchAnalysis extends StrictLogging:
           original: GenericMatch[Element],
           replacement: GenericMatch[Element]
       ): ParallelMatchesGroupIdTracking[Unit] =
-        for
-          _ <- State.modify[ParallelMatchesGrouping](_ + replacement)
-          _ <- State.modify[ParallelMatchesGrouping](sets =>
-            if sets.contains(original) then
-              sets.union(original, replacement)._1
-            else sets
-          )
-        yield ()
+        State.modify { groupIds =>
+          groupIds
+            .get(original)
+            .fold(ifEmpty = groupIds)(groupId =>
+              groupIds + (replacement -> groupId)
+            )
+        }
 
       def sortedBiteEdgesFrom(bites: collection.Set[BiteEdge]): Seq[BiteEdge] =
         bites.toSeq.sortWith {
@@ -903,10 +897,6 @@ object MatchAnalysis extends StrictLogging:
         val minimumMatchSizeConsidered: Int
         def thresholdSize(fileSize: Int): Int
       end MatchSearchingContext
-
-      enum MatchSide:
-        case Base, Left, Right
-      end MatchSide
 
       enum BiteEdge:
         case Start(startOffsetRelativeToMeal: Int)
@@ -1196,6 +1186,66 @@ object MatchAnalysis extends StrictLogging:
         end if
       end purgedOfMatchesWithOverlappingSections
 
+      private def pathOnBase(aMatch: GenericMatch[Element]): Option[Path] =
+        aMatch match
+          case Match.AllSides(baseSection, _, _) =>
+            Some(baseSources.pathFor(baseSection))
+          case Match.BaseAndLeft(baseSection, _) =>
+            Some(baseSources.pathFor(baseSection))
+          case Match.BaseAndRight(baseSection, _) =>
+            Some(baseSources.pathFor(baseSection))
+          case _ => None
+
+      private def pathOnLeft(aMatch: GenericMatch[Element]): Option[Path] =
+        aMatch match
+          case Match.AllSides(_, leftSection, _) =>
+            Some(leftSources.pathFor(leftSection))
+          case Match.BaseAndLeft(_, leftSection) =>
+            Some(leftSources.pathFor(leftSection))
+          case Match.LeftAndRight(leftSection, _) =>
+            Some(leftSources.pathFor(leftSection))
+          case _ => None
+
+      private def pathOnRight(aMatch: GenericMatch[Element]): Option[Path] =
+        aMatch match
+          case Match.AllSides(_, _, rightSection) =>
+            Some(rightSources.pathFor(rightSection))
+          case Match.BaseAndRight(_, rightSection) =>
+            Some(rightSources.pathFor(rightSection))
+          case Match.LeftAndRight(_, rightSection) =>
+            Some(rightSources.pathFor(rightSection))
+          case _ => None
+
+      private def offsetOnBase(aMatch: GenericMatch[Element]): Option[Int] =
+        aMatch match
+          case Match.AllSides(baseSection, _, _) =>
+            Some(baseSection.startOffset)
+          case Match.BaseAndLeft(baseSection, _) =>
+            Some(baseSection.startOffset)
+          case Match.BaseAndRight(baseSection, _) =>
+            Some(baseSection.startOffset)
+          case _ => None
+
+      private def offsetOnLeft(aMatch: GenericMatch[Element]): Option[Int] =
+        aMatch match
+          case Match.AllSides(_, leftSection, _) =>
+            Some(leftSection.startOffset)
+          case Match.BaseAndLeft(_, leftSection) =>
+            Some(leftSection.startOffset)
+          case Match.LeftAndRight(leftSection, _) =>
+            Some(leftSection.startOffset)
+          case _ => None
+
+      private def offsetOnRight(aMatch: GenericMatch[Element]): Option[Int] =
+        aMatch match
+          case Match.AllSides(_, _, rightSection) =>
+            Some(rightSection.startOffset)
+          case Match.BaseAndRight(_, rightSection) =>
+            Some(rightSection.startOffset)
+          case Match.LeftAndRight(_, rightSection) =>
+            Some(rightSection.startOffset)
+          case _ => None
+
       private def withoutTheseMatches(
           matches: Iterable[GenericMatch[Element]]
       ): MatchesAndTheirSections =
@@ -1289,142 +1339,6 @@ object MatchAnalysis extends StrictLogging:
         }
       end withoutTheseMatches
 
-      private def pathOnBase(aMatch: GenericMatch[Element]): Option[Path] =
-        aMatch match
-          case Match.AllSides(baseSection, _, _)  => Some(baseSources.pathFor(baseSection))
-          case Match.BaseAndLeft(baseSection, _)  => Some(baseSources.pathFor(baseSection))
-          case Match.BaseAndRight(baseSection, _) => Some(baseSources.pathFor(baseSection))
-          case _                                  => None
-
-      private def pathOnLeft(aMatch: GenericMatch[Element]): Option[Path] =
-        aMatch match
-          case Match.AllSides(_, leftSection, _)  => Some(leftSources.pathFor(leftSection))
-          case Match.BaseAndLeft(_, leftSection)  => Some(leftSources.pathFor(leftSection))
-          case Match.LeftAndRight(leftSection, _) => Some(leftSources.pathFor(leftSection))
-          case _                                  => None
-
-      private def pathOnRight(aMatch: GenericMatch[Element]): Option[Path] =
-        aMatch match
-          case Match.AllSides(_, _, rightSection) => Some(rightSources.pathFor(rightSection))
-          case Match.BaseAndRight(_, rightSection) => Some(rightSources.pathFor(rightSection))
-          case Match.LeftAndRight(_, rightSection) => Some(rightSources.pathFor(rightSection))
-          case _                                   => None
-
-      private def arePathCompatible(
-          first: GenericMatch[Element],
-          second: GenericMatch[Element]
-      ): Boolean =
-        val baseCompatible = (pathOnBase(first), pathOnBase(second)) match
-          case (Some(p1), Some(p2)) => p1 == p2
-          case _                    => true
-
-        val leftCompatible = (pathOnLeft(first), pathOnLeft(second)) match
-          case (Some(p1), Some(p2)) => p1 == p2
-          case _                    => true
-
-        val rightCompatible = (pathOnRight(first), pathOnRight(second)) match
-          case (Some(p1), Some(p2)) => p1 == p2
-          case _                    => true
-
-        baseCompatible && leftCompatible && rightCompatible
-      end arePathCompatible
-
-      private def sidesOf(
-          aMatch: GenericMatch[Element]
-      ): Set[MatchSide] = aMatch match
-        case _: Match.AllSides[Section[Element]] =>
-          Set(MatchSide.Base, MatchSide.Left, MatchSide.Right)
-        case _: Match.BaseAndLeft[Section[Element]] =>
-          Set(MatchSide.Base, MatchSide.Left)
-        case _: Match.BaseAndRight[Section[Element]] =>
-          Set(MatchSide.Base, MatchSide.Right)
-        case _: Match.LeftAndRight[Section[Element]] =>
-          Set(MatchSide.Left, MatchSide.Right)
-
-      private def offsetOf(aMatch: GenericMatch[Element], side: MatchSide): Int =
-        side match
-          case MatchSide.Base =>
-            aMatch match
-              case m: Match.AllSides[Section[Element]]     => m.baseElement.startOffset
-              case m: Match.BaseAndLeft[Section[Element]]  => m.baseElement.startOffset
-              case m: Match.BaseAndRight[Section[Element]] => m.baseElement.startOffset
-              case _ => throw new RuntimeException("Match doesn't have Base side")
-          case MatchSide.Left =>
-            aMatch match
-              case m: Match.AllSides[Section[Element]]     => m.leftElement.startOffset
-              case m: Match.BaseAndLeft[Section[Element]]  => m.leftElement.startOffset
-              case m: Match.LeftAndRight[Section[Element]] => m.leftElement.startOffset
-              case _ => throw new RuntimeException("Match doesn't have Left side")
-          case MatchSide.Right =>
-            aMatch match
-              case m: Match.AllSides[Section[Element]]      => m.rightElement.startOffset
-              case m: Match.BaseAndRight[Section[Element]] => m.rightElement.startOffset
-              case m: Match.LeftAndRight[Section[Element]] => m.rightElement.startOffset
-              case _ => throw new RuntimeException("Match doesn't have Right side")
-
-      private def isOrderConsistent(group: Iterable[GenericMatch[Element]]): Boolean =
-        val sides = Seq(MatchSide.Base, MatchSide.Left, MatchSide.Right)
-        val orderings = sides.flatMap { s =>
-          val matchesWithSide = group.filter(sidesOf(_).contains(s)).toSeq
-          if (matchesWithSide.size > 1) {
-            val sorted = matchesWithSide.sortBy(offsetOf(_, s))
-            Some(s -> sorted)
-          } else None
-        }.toMap
-
-        orderings.forall { case (s1, o1) =>
-          orderings.forall { case (s2, o2) =>
-            if (s1 == s2) true
-            else {
-              val common = o1.filter(m => sidesOf(m).contains(s2))
-              val commonInO2 = o2.filter(m => sidesOf(m).contains(s1))
-              common == commonInO2
-            }
-          }
-        }
-
-      private def parallelConsistentSubgroups(
-          matches: Iterable[GenericMatch[Element]]
-      ): Iterable[Set[GenericMatch[Element]]] =
-        val subgroups =
-          mutable.Buffer.empty[mutable.Set[GenericMatch[Element]]]
-
-        // Sort matches to ensure stable results and possibly better grouping
-        val sortedMatches = matches.toSeq.sortBy(m =>
-          (
-            pathOnBase(m).map(_.toString).getOrElse(""),
-            pathOnLeft(m).map(_.toString).getOrElse(""),
-            pathOnRight(m).map(_.toString).getOrElse(""),
-            -sidesOf(m).size // Prioritize all-sides matches for greedy grouping
-          )
-        )
-
-        sortedMatches.foreach { m =>
-          subgroups.find { subgroup =>
-            val mIsAllSides = m.isAnAllSidesMatch
-            val subgroupHasAllSides =
-              subgroup.exists(_.isAnAllSidesMatch)
-            val flavourCompatible =
-              mIsAllSides || subgroupHasAllSides || subgroup.forall(sm =>
-                // Same pairwise flavour
-                (sm, m) match
-                  case (_: Match.BaseAndLeft[?], _: Match.BaseAndLeft[?])   => true
-                  case (_: Match.BaseAndRight[?], _: Match.BaseAndRight[?]) => true
-                  case (_: Match.LeftAndRight[?], _: Match.LeftAndRight[?]) => true
-                  case _                                                   => false
-              )
-
-            flavourCompatible &&
-            subgroup.forall(arePathCompatible(m, _)) &&
-            isOrderConsistent(subgroup.toSeq :+ m)
-          } match
-            case Some(subgroup) => subgroup.add(m)
-            case None           => subgroups.addOne(mutable.Set(m))
-        }
-
-        subgroups.map(_.toSet)
-      end parallelConsistentSubgroups
-
       def reconcileMatches: MatchesAndTheirSections =
         val matches = sectionsAndTheirMatches.values.toSet
 
@@ -1460,18 +1374,7 @@ object MatchAnalysis extends StrictLogging:
 
               for
                 // Reset the state for each iteration of `reconcileUsing`.
-                _ <- State.set[ParallelMatchesGrouping] {
-                  val initialGrouping =
-                    DisjointSets(matches.toSeq*)
-                  val groups =
-                    parallelMatchesGroupIdsByMatch.toSeq.groupBy(_._2).values
-                  groups.foldLeft(initialGrouping) { (accDs, groupMatches) =>
-                    val ms = groupMatches.map(_._1)
-                    if ms.size > 1 then
-                      ms.tail.foldLeft(accDs)((d, m) => d.union(ms.head, m)._1)
-                    else accDs
-                  }
-                }
+                _ <- State.set(parallelMatchesGroupIdsByMatch)
 
                 fragments <- fragmentsOf(pairwiseMatchesToBeEaten).map(
                   _.diff(matches.asInstanceOf[Set[PairwiseMatch]])
@@ -1487,24 +1390,6 @@ object MatchAnalysis extends StrictLogging:
                 // NOTE: prefer `traverse` + `flatten` to `flatTraverse` as it
                 // manages flattening `Option` values into an enclosing `Set`
                 // nicely. The same holds a bit later on too.
-                _ <- matches
-                  .filter(_.isAnAllSidesMatch)
-                  .toSeq
-                  .traverse_ {
-                    case allSidesMatch: Match.AllSides[Section[Element]] =>
-                      pairwiseMatchesSubsumingOnBothSides(allSidesMatch)
-                        .filter(arePathCompatible(allSidesMatch, _))
-                        .toSeq
-                        .traverse_(pairwiseMatch =>
-                          State.modify[ParallelMatchesGrouping](sets =>
-                            if sets.contains(allSidesMatch) && sets
-                                .contains(pairwiseMatch)
-                            then sets.union(allSidesMatch, pairwiseMatch)._1
-                            else sets
-                          )
-                        )
-                  }
-
                 paredDownMatches <- matches
                   .traverse(
                     takingFragmentationIntoAccount.pareDownOrSuppressCompletely
@@ -1534,25 +1419,14 @@ object MatchAnalysis extends StrictLogging:
                       reconciled = rebuilt.withoutRedundantPairwiseMatches
                       _          = reconciled.checkInvariant()
                       _          = progressRecordingSession.upTo(0)
-                      updatedParallelMatchesGrouping <-
-                        State.get[ParallelMatchesGrouping]
+                      updatedParallelMatchesGroupsIdsByMatch <- State.get
                     yield
                       val matches = reconciled.matches
-                      val groupIdsByMatch = updatedParallelMatchesGrouping
-                        .toSets._2
-                        .toScalaMap
-                        .values
-                        .flatMap(group =>
-                          parallelConsistentSubgroups(
-                            group.toScalaSet.filter(matches.contains)
-                          )
-                        )
-                        .zipWithIndex
-                        .flatMap { (subgroup, id) => subgroup.map(_ -> id) }
-                        .toMap
                       Right(
                         reconciled.copy(parallelMatchesGroupIdsByMatch =
-                          groupIdsByMatch
+                          updatedParallelMatchesGroupsIdsByMatch.view
+                            .filterKeys(matches.contains)
+                            .toMap
                         )
                       )
                   else
@@ -1566,9 +1440,7 @@ object MatchAnalysis extends StrictLogging:
               .tailRecM(matches.collect {
                 case allSides: Match.AllSides[Section[Element]] => allSides
               })(reconcileUsing)
-              .runA(
-                DisjointSets(Seq.empty[GenericMatch[Element]]*)
-              )
+              .runA(Map.empty)
               .value
           }: @unchecked
 
@@ -1816,39 +1688,50 @@ object MatchAnalysis extends StrictLogging:
               val basePaths = matchesInGroup.flatMap(pathOnBase).toSet
               assert(
                 basePaths.size <= 1,
-                s"Base paths for parallel matches group should be consistent, but are: $basePaths."
+                s"Base paths for parallel matches group should be consistent, but are: $basePaths. Matches are: ${pprintCustomised(matchesInGroup)}"
               )
 
               val leftPaths = matchesInGroup.flatMap(pathOnLeft).toSet
               assert(
                 leftPaths.size <= 1,
-                s"Left paths for parallel matches group should be consistent, but are: $leftPaths."
+                s"Left paths for parallel matches group should be consistent, but are: $leftPaths. Matches are: ${pprintCustomised(matchesInGroup)}"
               )
 
               val rightPaths = matchesInGroup.flatMap(pathOnRight).toSet
               assert(
                 rightPaths.size <= 1,
-                s"Right paths for parallel matches group should be consistent, but are: $rightPaths."
+                s"Right paths for parallel matches group should be consistent, but are: $rightPaths. Matches are: ${pprintCustomised(matchesInGroup)}"
               )
 
-              assert(
-                isOrderConsistent(matchesInGroup),
-                s"Ordering for parallel matches group should be consistent, matches are: ${pprintCustomised(matchesInGroup)}"
-              )
+              def checkOrder(
+                  side1Name: String,
+                  side2Name: String,
+                  offsetOnSide1: GenericMatch[Element] => Option[Int],
+                  offsetOnSide2: GenericMatch[Element] => Option[Int]
+              ): Unit =
+                val matchesOnBothSides = matchesInGroup
+                  .filter(m =>
+                    offsetOnSide1(m).isDefined && offsetOnSide2(m).isDefined
+                  )
+                  .sortBy(offsetOnSide1(_).get)
 
-              val hasAllSidesMatch = matchesInGroup.exists(_.isAnAllSidesMatch)
-              if !hasAllSidesMatch then
-                val flavours = matchesInGroup.map {
-                  case _: Match.BaseAndLeft[?]  => 1
-                  case _: Match.BaseAndRight[?] => 2
-                  case _: Match.LeftAndRight[?] => 3
-                  case _: Match.AllSides[?]    => 0
-                }.toSet
-                assert(
-                  flavours.size <= 1,
-                  s"A parallel matches group without an all-sides match should be homogeneous in flavour, but has flavours: $flavours"
-                )
-              end if
+                if matchesOnBothSides.size > 1 then
+                  matchesOnBothSides
+                    .zip(matchesOnBothSides.tail)
+                    .foreach { (first, second) =>
+                      val firstOffset2  = offsetOnSide2(first).get
+                      val secondOffset2 = offsetOnSide2(second).get
+                      assert(
+                        firstOffset2 < secondOffset2,
+                        s"Relative order of matches in parallel group should be consistent between $side1Name and $side2Name, but $first and $second are out of order. Matches are: ${pprintCustomised(matchesInGroup)}"
+                      )
+                    }
+                end if
+              end checkOrder
+
+              checkOrder("base", "left", offsetOnBase, offsetOnLeft)
+              checkOrder("base", "right", offsetOnBase, offsetOnRight)
+              checkOrder("left", "right", offsetOnLeft, offsetOnRight)
             }
         end if
       end reconciliationPostcondition
@@ -2287,12 +2170,6 @@ object MatchAnalysis extends StrictLogging:
                   .zip(group.tail)
                   // Zipping views together makes an `Iterable`, so ...
                   .toSeq
-                  .filter((precedingGroupMember, succeedingGroupMember) =>
-                    backTranslatedMatchesAndTheirSections.arePathCompatible(
-                      precedingGroupMember,
-                      succeedingGroupMember
-                    )
-                  )
                   .traverse_ {
                     case (precedingGroupMember, succeedingGroupMember) =>
                       DisjointSets
@@ -2305,10 +2182,6 @@ object MatchAnalysis extends StrictLogging:
                 case allSidesMatch: Match.AllSides[Section[Element]] =>
                   backTranslatedMatchesAndTheirSections
                     .pairwiseMatchesSubsumingOnBothSides(allSidesMatch)
-                    .filter(
-                      backTranslatedMatchesAndTheirSections
-                        .arePathCompatible(allSidesMatch, _)
-                    )
                     .traverse_(
                       DisjointSets.union(allSidesMatch, _)
                     )

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1704,7 +1704,11 @@ object MatchAnalysis extends StrictLogging:
                        |Expected a consistent ordering of matches relevant to the sides $firstSide and $secondSide.
                        |Total of ${matchesWithOffsets.size} common matches, up to 10 follow...
                        |Relative order should be consistent between $firstSide and $secondSide,
-                       |but $matchA and $matchB are out of order.
+                       |but ${pprintCustomised(
+                        MatchSynopsis(matchA)
+                      )} and ${pprintCustomised(
+                        MatchSynopsis(matchB)
+                      )} are out of order.
                        |Matches are:
                        |${pprintCustomised(
                         matchesWithOffsets.take(10).map(_._1).map(MatchSynopsis.apply)

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -751,7 +751,7 @@ object MatchAnalysis extends StrictLogging:
                 )
 
               fragmentsFromPairwiseMatch = fragmentsAndGroupIds.map(_._1)
-              groupIdsForFragments      = fragmentsAndGroupIds.map(_._2)
+              groupIdsForFragments       = fragmentsAndGroupIds.map(_._2)
 
               _ <- fragmentsFromPairwiseMatch
                 .zip(groupIdsForFragments)

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1,12 +1,12 @@
 package com.sageserpent.kineticmerge.core
 
 import alleycats.std.set.given
-import cats.collections.{Diet, DisjointSets, Range as CatsInclusiveRange}
+import cats.collections.{Diet, Range as CatsInclusiveRange}
 import cats.data.State
 import cats.implicits.catsKernelOrderingForOrder
 import cats.instances.seq.*
 import cats.syntax.all.*
-import cats.{Eq, FlatMap, Order}
+import cats.{Eq, FlatMap}
 import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 import com.google.common.hash.{Funnel, HashFunction, PrimitiveSink}
 import com.sageserpent.kineticmerge
@@ -751,24 +751,6 @@ object MatchAnalysis extends StrictLogging:
           }
           .map(_.toSet)
 
-      private def recordReplacements(
-          original: GenericMatch[Element],
-          replacements: Seq[GenericMatch[Element]]
-      ): ParallelMatchesGroupIdTracking[Unit] =
-        replacements.traverse_(recordReplacement(original, _))
-
-      private def recordReplacement(
-          original: GenericMatch[Element],
-          replacement: GenericMatch[Element]
-      ): ParallelMatchesGroupIdTracking[Unit] =
-        State.modify { groupIds =>
-          groupIds
-            .get(original)
-            .fold(ifEmpty = groupIds)(groupId =>
-              groupIds + (replacement -> groupId)
-            )
-        }
-
       def sortedBiteEdgesFrom(bites: collection.Set[BiteEdge]): Seq[BiteEdge] =
         bites.toSeq.sortWith {
           case (
@@ -884,6 +866,24 @@ object MatchAnalysis extends StrictLogging:
           biteDepth = 0
         )(biteEdges, fragments = Vector.empty)
       end eatIntoSection
+
+      private def recordReplacements(
+          original: GenericMatch[Element],
+          replacements: Seq[GenericMatch[Element]]
+      ): ParallelMatchesGroupIdTracking[Unit] =
+        replacements.traverse_(recordReplacement(original, _))
+
+      private def recordReplacement(
+          original: GenericMatch[Element],
+          replacement: GenericMatch[Element]
+      ): ParallelMatchesGroupIdTracking[Unit] =
+        State.modify { groupIds =>
+          groupIds
+            .get(original)
+            .fold(ifEmpty = groupIds)(groupId =>
+              groupIds + (replacement -> groupId)
+            )
+        }
 
       trait PathInclusions:
         def isIncludedOnBase(basePath: Path): Boolean
@@ -1185,6 +1185,99 @@ object MatchAnalysis extends StrictLogging:
         else this
         end if
       end purgedOfMatchesWithOverlappingSections
+
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(allSides)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
+            )
+        }
+      end withoutTheseMatches
 
       def reconcileMatches: MatchesAndTheirSections =
         val matches = sectionsAndTheirMatches.values.toSet
@@ -1938,178 +2031,6 @@ object MatchAnalysis extends StrictLogging:
         }
       end pairwiseMatchesSubsumingOnBothSidesWithBiteEdges
 
-      // Cleans up the state when a putative all-sides match that would have
-      // been ambiguous on one side with another all-sides match was partially
-      // suppressed by a larger pairwise match. This situation results in a
-      // pairwise match that shares its sections on both sides with the other
-      // all-sides match; remove any such redundant pairwise matches.
-      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
-        val redundantMatches =
-          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
-
-        if redundantMatches.nonEmpty then
-          logger.debug(
-            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
-          )
-        end if
-
-        withoutTheseMatches(redundantMatches)
-      end withoutRedundantPairwiseMatches
-
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(allSides)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
-            )
-        }
-      end withoutTheseMatches
-
-      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
-        aMatch match
-          case Match.BaseAndLeft(baseSection, leftSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(leftSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.BaseAndRight(baseSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.LeftAndRight(leftSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(leftSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case _: Match.AllSides[Section[Element]] => false
-
-      private def withMatch(
-          aMatch: GenericMatch[Element]
-      ): MatchesAndTheirSections =
-        aMatch match
-          case Match.AllSides(baseSection, leftSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
-              baseFingerprintedInclusionsByPath =
-                knockOutFromBaseFingerprintedInclusions(baseSection),
-              leftFingerprintedInclusionsByPath =
-                knockOutFromLeftFingerprintedInclusions(leftSection),
-              rightFingerprintedInclusionsByPath =
-                knockOutFromRightFingerprintedInclusions(rightSection)
-            )
-          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
-            )
-          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
-            )
-          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
-            copy(
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
-            )
-        end match
-      end withMatch
-
       def parallelMatchesOnly: MatchesAndTheirSections =
         // PLAN:
 
@@ -2313,71 +2234,53 @@ object MatchAnalysis extends StrictLogging:
         val backTranslatedMatches =
           backTranslatedMatchesAndTheirSections.matches
 
-        val disjointSetsOfMatches =
-          // NASTY HACK: the Cats implementation of a disjoint sets data
-          // structure insists on the set elements having `Order`. The problem
-          // with this is that while it's easy to define an order on `Match`, it
-          // gets fiddly down at the `Section` level, because we need to take
-          // paths into account as well as the obvious start offset and size -
-          // that means we have to distinguish between sections belonging to the
-          // base, left or right sides and look up the path accordingly.
-          // The workaround is to rely on *equality* of matches being
-          // well-formed (it is) and then building a synthetic order based on
-          // ids.
-          val backTranslatedMatchIds = backTranslatedMatches.zipWithIndex.toMap
-
-          given matchOrdering: Order[Match[Section[Element]]] =
-            Order.by(backTranslatedMatchIds.apply)
-
-          DisjointSets(
-            backTranslatedMatches.toSeq*
-          )
-        end disjointSetsOfMatches
-
-        val coalescenceWorkflow =
-          for
-            _ <- groupsOfBackTranslatedParallelMatches
-              .map(_.filter(backTranslatedMatches.contains))
-              .filter(
-                _.nonEmpty
-              ) // Guard the zipping of group members down below...
-              .traverse_ { group =>
-                // Unify the group members...
-                group
-                  .zip(group.tail)
-                  // Zipping views together makes an `Iterable`, so ...
-                  .toSeq
-                  .traverse_ {
-                    case (precedingGroupMember, succeedingGroupMember) =>
-                      DisjointSets
-                        .union(precedingGroupMember, succeedingGroupMember)
-                  }
-              }
-            _ <- backTranslatedMatches
-              .filter(_.isAnAllSidesMatch)
-              .traverse_ {
-                case allSidesMatch: Match.AllSides[Section[Element]] =>
-                  backTranslatedMatchesAndTheirSections
-                    .pairwiseMatchesSubsumingOnBothSides(allSidesMatch)
-                    .traverse_(
-                      DisjointSets.union(allSidesMatch, _)
-                    )
-              }
-            sets <- DisjointSets.toSets
-          yield sets
-
-        val parallelMatchesGroupIdsByMatch = coalescenceWorkflow
-          .runA(disjointSetsOfMatches)
-          .value
-          .toList
-          .map(_._2.toIterator)
-          .zipWithIndex
-          .flatMap((group, id) => group.map(_ -> id))
-          .toMap
+        val parallelMatchesGroupIdsByMatch =
+          groupsOfBackTranslatedParallelMatches.zipWithIndex
+            .flatMap((parallelMatches, groupId) =>
+              parallelMatches.map(_ -> groupId)
+            )
+            .toMap
 
         backTranslatedMatchesAndTheirSections
           .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
       end parallelMatchesOnly
+
+      // Cleans up the state when a putative all-sides match that would have
+      // been ambiguous on one side with another all-sides match was partially
+      // suppressed by a larger pairwise match. This situation results in a
+      // pairwise match that shares its sections on both sides with the other
+      // all-sides match; remove any such redundant pairwise matches.
+      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
+        val redundantMatches =
+          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
+
+        if redundantMatches.nonEmpty then
+          logger.debug(
+            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
+          )
+        end if
+
+        withoutTheseMatches(redundantMatches)
+      end withoutRedundantPairwiseMatches
+
+      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
+        aMatch match
+          case Match.BaseAndLeft(baseSection, leftSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(leftSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.BaseAndRight(baseSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.LeftAndRight(leftSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(leftSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case _: Match.AllSides[Section[Element]] => false
 
       private def isSubsumedNonTriviallyByAnAllSidesMatch(
           baseSection: Section[Element],
@@ -2578,6 +2481,48 @@ object MatchAnalysis extends StrictLogging:
           pathInclusions = pathInclusions
         )
       end withMatches
+
+      private def withMatch(
+          aMatch: GenericMatch[Element]
+      ): MatchesAndTheirSections =
+        aMatch match
+          case Match.AllSides(baseSection, leftSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
+              baseFingerprintedInclusionsByPath =
+                knockOutFromBaseFingerprintedInclusions(baseSection),
+              leftFingerprintedInclusionsByPath =
+                knockOutFromLeftFingerprintedInclusions(leftSection),
+              rightFingerprintedInclusionsByPath =
+                knockOutFromRightFingerprintedInclusions(rightSection)
+            )
+          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
+            )
+          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
+            )
+          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
+            copy(
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
+            )
+        end match
+      end withMatch
 
       private def pairwiseMatchesSubsumingOnBothSides(
           allSides: Match.AllSides[Section[Element]]

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -2523,8 +2523,13 @@ object MatchAnalysis extends StrictLogging:
                 subsumedBySomeMatchOnJustTheLeft,
                 subsumedBySomeMatchOnJustTheRight
               ) match
-                case (false, false, false) => Some(aMatch)
-                case (true, false, false)  =>
+                case (false, false, false) =>
+                  Option.unless(
+                    baseSubsumes(baseSection) || leftSubsumes(
+                      leftSection
+                    ) || rightSubsumes(rightSection)
+                  )(aMatch)
+                case (true, false, false) =>
                   Option.unless(
                     leftSubsumes(leftSection) || rightSubsumes(
                       rightSection

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -2606,34 +2606,61 @@ object MatchAnalysis extends StrictLogging:
             allSides.rightElement
           )
 
-        (subsumingOnBase intersect subsumingOnLeft).map {
+        // NOTE: we have to be mindful that a pairwise match may have multiple
+        // sites where the same content can be matched by a smaller all-sides
+        // match that is ambiguous. That can lead to the biting all-sides match
+        // being a 'cross-over', where the two sides aren't correlated - each
+        // side of the all-sides match refers to a different site in the
+        // pairwise match.
+        (subsumingOnBase intersect subsumingOnLeft).flatMap {
           case subsuming: Match.BaseAndLeft[Section[Element]] =>
-            (
+            val offsetRelativeToSubsumingOnBaseSide =
+              allSides.baseElement.startOffset - subsuming.baseElement.startOffset
+            val offsetRelativeToSubsumingOnLeftSide =
+              allSides.leftElement.startOffset - subsuming.leftElement.startOffset
+
+            Option.when(
+              offsetRelativeToSubsumingOnBaseSide == offsetRelativeToSubsumingOnLeftSide
+            )(
               subsuming,
               BiteEdge.Start(startOffsetRelativeToMeal =
-                allSides.baseElement.startOffset - subsuming.baseElement.startOffset
+                offsetRelativeToSubsumingOnBaseSide
               ),
               BiteEdge.End(onePastEndOffsetRelativeToMeal =
                 allSides.baseElement.onePastEndOffset - subsuming.baseElement.startOffset
               )
             )
-        } union (subsumingOnBase intersect subsumingOnRight).map {
+        } union (subsumingOnBase intersect subsumingOnRight).flatMap {
           case subsuming: Match.BaseAndRight[Section[Element]] =>
-            (
+            val offsetRelativeToSubsumingOnBaseSide =
+              allSides.baseElement.startOffset - subsuming.baseElement.startOffset
+            val offsetRelativeToSubsumingOnRightSide =
+              allSides.rightElement.startOffset - subsuming.rightElement.startOffset
+
+            Option.when(
+              offsetRelativeToSubsumingOnBaseSide == offsetRelativeToSubsumingOnRightSide
+            )(
               subsuming,
               BiteEdge.Start(startOffsetRelativeToMeal =
-                allSides.baseElement.startOffset - subsuming.baseElement.startOffset
+                offsetRelativeToSubsumingOnBaseSide
               ),
               BiteEdge.End(onePastEndOffsetRelativeToMeal =
                 allSides.baseElement.onePastEndOffset - subsuming.baseElement.startOffset
               )
             )
-        } union (subsumingOnLeft intersect subsumingOnRight).map {
+        } union (subsumingOnLeft intersect subsumingOnRight).flatMap {
           case subsuming: Match.LeftAndRight[Section[Element]] =>
-            (
+            val offsetRelativeToSubsumingOnLeftSide =
+              allSides.leftElement.startOffset - subsuming.leftElement.startOffset
+            val offsetRelativeToSubsumingOnRightSide =
+              allSides.rightElement.startOffset - subsuming.rightElement.startOffset
+
+            Option.when(
+              offsetRelativeToSubsumingOnLeftSide == offsetRelativeToSubsumingOnRightSide
+            )(
               subsuming,
               BiteEdge.Start(startOffsetRelativeToMeal =
-                allSides.leftElement.startOffset - subsuming.leftElement.startOffset
+                offsetRelativeToSubsumingOnLeftSide
               ),
               BiteEdge.End(onePastEndOffsetRelativeToMeal =
                 allSides.leftElement.onePastEndOffset - subsuming.leftElement.startOffset

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1688,19 +1688,19 @@ object MatchAnalysis extends StrictLogging:
               val basePaths = matchesInGroup.flatMap(pathOnBase).toSet
               assert(
                 basePaths.size <= 1,
-                s"Base paths for parallel matches group should be consistent, but are: $basePaths. Matches are: ${pprintCustomised(matchesInGroup)}"
+                s"Base paths for parallel matches group should be consistent, but are: $basePaths. Matches size: ${matchesInGroup.size}. Up to 10 matches are: ${pprintCustomised(matchesInGroup.take(10)).toString.take(1000)}"
               )
 
               val leftPaths = matchesInGroup.flatMap(pathOnLeft).toSet
               assert(
                 leftPaths.size <= 1,
-                s"Left paths for parallel matches group should be consistent, but are: $leftPaths. Matches are: ${pprintCustomised(matchesInGroup)}"
+                s"Left paths for parallel matches group should be consistent, but are: $leftPaths. Matches size: ${matchesInGroup.size}. Up to 10 matches are: ${pprintCustomised(matchesInGroup.take(10)).toString.take(1000)}"
               )
 
               val rightPaths = matchesInGroup.flatMap(pathOnRight).toSet
               assert(
                 rightPaths.size <= 1,
-                s"Right paths for parallel matches group should be consistent, but are: $rightPaths. Matches are: ${pprintCustomised(matchesInGroup)}"
+                s"Right paths for parallel matches group should be consistent, but are: $rightPaths. Matches size: ${matchesInGroup.size}. Up to 10 matches are: ${pprintCustomised(matchesInGroup.take(10)).toString.take(1000)}"
               )
 
               def checkOrder(
@@ -1713,20 +1713,22 @@ object MatchAnalysis extends StrictLogging:
                   .filter(m =>
                     offsetOnSide1(m).isDefined && offsetOnSide2(m).isDefined
                   )
-                  .sortBy(offsetOnSide1(_).get)
 
-                if matchesOnBothSides.size > 1 then
-                  matchesOnBothSides
-                    .zip(matchesOnBothSides.tail)
-                    .foreach { (first, second) =>
-                      val firstOffset2  = offsetOnSide2(first).get
-                      val secondOffset2 = offsetOnSide2(second).get
-                      assert(
-                        firstOffset2 < secondOffset2,
-                        s"Relative order of matches in parallel group should be consistent between $side1Name and $side2Name, but $first and $second are out of order. Matches are: ${pprintCustomised(matchesInGroup)}"
-                      )
-                    }
-                end if
+                for
+                  first  <- matchesOnBothSides
+                  second <- matchesOnBothSides
+                  if first != second
+                  offset1First  = offsetOnSide1(first).get
+                  offset1Second = offsetOnSide1(second).get
+                  if offset1First <= offset1Second
+                  offset2First  = offsetOnSide2(first).get
+                  offset2Second = offsetOnSide2(second).get
+                do
+                  assert(
+                    offset2First <= offset2Second,
+                    s"Relative order of matches in parallel group should be consistent between $side1Name and $side2Name, but $first and $second are out of order. Matches size: ${matchesInGroup.size}. Up to 10 matches are: ${pprintCustomised(matchesInGroup.take(10)).toString.take(1000)}"
+                  )
+                end for
               end checkOrder
 
               checkOrder("base", "left", offsetOnBase, offsetOnLeft)

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -744,8 +744,11 @@ object MatchAnalysis extends StrictLogging:
 
               sortedBiteEdges = groupIdsBySortedBiteEdge.keySet
 
-              fragmentsFromPairwiseMatch: Seq[PairwiseMatch] =
-                pairwiseMatch match
+              (
+                fragmentsFromPairwiseMatch: Vector[PairwiseMatch],
+                groupIdsForFragments: Vector[Set[ParallelMatchesGroupId]]
+              ) =
+                (pairwiseMatch match
                   case Match.BaseAndLeft(baseSection, leftSection) =>
                     (sortedBiteEdges.eatIntoSection(
                       baseSources,
@@ -754,7 +757,11 @@ object MatchAnalysis extends StrictLogging:
                       leftSources,
                       leftSection
                     ))
-                      .map(Match.BaseAndLeft.apply)
+                      .map(Match.BaseAndLeft.apply) -> sortedBiteEdges
+                      .assignParallelMatchesGroupIdsForFragments(
+                        groupIdsBySortedBiteEdge,
+                        sectionSize = baseSection.size
+                      )
 
                   case Match.BaseAndRight(baseSection, rightSection) =>
                     (sortedBiteEdges.eatIntoSection(
@@ -763,7 +770,11 @@ object MatchAnalysis extends StrictLogging:
                     ) zip sortedBiteEdges.eatIntoSection(
                       rightSources,
                       rightSection
-                    )).map(Match.BaseAndRight.apply)
+                    )).map(Match.BaseAndRight.apply) -> sortedBiteEdges
+                      .assignParallelMatchesGroupIdsForFragments(
+                        groupIdsBySortedBiteEdge,
+                        sectionSize = baseSection.size
+                      )
 
                   case Match.LeftAndRight(leftSection, rightSection) =>
                     (sortedBiteEdges.eatIntoSection(
@@ -772,9 +783,16 @@ object MatchAnalysis extends StrictLogging:
                     ) zip sortedBiteEdges.eatIntoSection(
                       rightSources,
                       rightSection
-                    )).map(Match.LeftAndRight.apply)
+                    )).map(Match.LeftAndRight.apply) -> sortedBiteEdges
+                      .assignParallelMatchesGroupIdsForFragments(
+                        groupIdsBySortedBiteEdge,
+                        sectionSize = leftSection.size
+                      )
+                ): @unchecked
 
-              _ <- recordReplacements(pairwiseMatch, fragmentsFromPairwiseMatch)
+              _ <- fragmentsFromPairwiseMatch
+                .zip(groupIdsForFragments)
+                .traverse_(assignGroupIds)
             yield
               logger.debug(
                 s"Eating into pairwise match:\n${pprintCustomised(pairwiseMatch)} on behalf of all-sides matches:\n${pprintCustomised(bites)}, resulting in fragments:\n${pprintCustomised(fragmentsFromPairwiseMatch)}"
@@ -793,7 +811,11 @@ object MatchAnalysis extends StrictLogging:
         private def eatIntoSection(
             side: Sources[Path, Element],
             section: Section[Element]
-        ) =
+        ): Vector[Section[Element]] =
+          // NOTE: here we work in terms of offsets into `section`, hence we
+          // must bias the offsets from the bite edges. Compare with
+          // `assignParallelMatchesGroupIdsForFragments`.
+
           val mealOnePastEndOffset: Int = section.onePastEndOffset
 
           val path = side.pathFor(section)
@@ -870,18 +892,93 @@ object MatchAnalysis extends StrictLogging:
         end eatIntoSection
 
         private def assignParallelMatchesGroupIdsForFragments(
-            matchesBySortedBiteEdge: Map[BiteEdge, Set[ParallelMatchesGroupId]],
+            groupIdsBySortedBiteEdge: Map[BiteEdge, collection.Set[
+              ParallelMatchesGroupId
+            ]],
             sectionSize: Int
-        ): Seq[Set[ParallelMatchesGroupId]] = ???
+        ): Vector[Set[ParallelMatchesGroupId]] =
+          // NOTE: here we work with zero-relative offsets from the start of the
+          // meal, thus we can work directly with the offsets from the bite
+          // edges. Compare with `eatIntoSection`.
+
+          case class State(
+              groupIdsFromPreviousBite: Set[ParallelMatchesGroupId],
+              mealStartOffset: Int,
+              biteDepth: Int
+          ):
+            @tailrec
+            final def apply(
+                biteEdges: Seq[BiteEdge],
+                fragments: Vector[Set[ParallelMatchesGroupId]]
+            ): Vector[Set[ParallelMatchesGroupId]] =
+              biteEdges match
+                case Seq() =>
+                  if sectionSize > mealStartOffset then
+                    fragments.appended(groupIdsFromPreviousBite)
+                  else fragments
+                case Seq(
+                      biteEdge @ BiteEdge.Start(startOffsetRelativeToMeal),
+                      remainingBiteEdges*
+                    ) =>
+                  require(startOffsetRelativeToMeal >= mealStartOffset)
+                  require(sectionSize > startOffsetRelativeToMeal)
+                  this
+                    .copy(
+                      groupIdsFromPreviousBite =
+                        Set.empty, // TODO: review this - what about nested or overlapping bites?
+                      mealStartOffset = startOffsetRelativeToMeal,
+                      biteDepth = 1 + biteDepth
+                    )
+                    .apply(
+                      remainingBiteEdges,
+                      fragments =
+                        if 0 == biteDepth && startOffsetRelativeToMeal > mealStartOffset
+                        then
+                          fragments.appended(
+                            groupIdsFromPreviousBite union groupIdsBySortedBiteEdge(
+                              biteEdge
+                            )
+                          )
+                        else fragments
+                    )
+                case Seq(
+                      biteEdge @ BiteEdge.End(onePastEndOffsetRelativeToMeal),
+                      remainingBiteEdges*
+                    ) =>
+                  assume(0 < biteDepth)
+
+                  require(mealStartOffset <= onePastEndOffsetRelativeToMeal)
+                  require(onePastEndOffsetRelativeToMeal <= sectionSize)
+                  this
+                    .copy(
+                      groupIdsFromPreviousBite =
+                        groupIdsBySortedBiteEdge(biteEdge).toSet,
+                      mealStartOffset = onePastEndOffsetRelativeToMeal,
+                      biteDepth = biteDepth - 1
+                    )
+                    .apply(remainingBiteEdges, fragments)
+          end State
+
+          State(
+            groupIdsFromPreviousBite = Set.empty,
+            mealStartOffset = 0,
+            biteDepth = 0
+          )(biteEdges.toSeq, fragments = Vector.empty)
+        end assignParallelMatchesGroupIdsForFragments
+
       end extension
 
-      private def recordReplacements(
-          original: GenericMatch[Element],
-          replacements: Seq[GenericMatch[Element]]
+      private def assignGroupIds(
+          fragment: PairwiseMatch,
+          groupIds: Set[ParallelMatchesGroupId]
       ): ParallelMatchesGroupIdTracking[Unit] =
-        replacements.traverse_(recordReplacement(original, _))
+        State.modify[GroupsOfParallelMatches] { groupIdsByMatch =>
+          groupIds.foldLeft(groupIdsByMatch)((partialResult, groupId) =>
+            partialResult.add(fragment, groupId)
+          )
+        }
 
-      private def recordReplacement(
+      private def propagateGroupIds(
           original: GenericMatch[Element],
           replacement: GenericMatch[Element]
       ): ParallelMatchesGroupIdTracking[Unit] =
@@ -1367,7 +1464,8 @@ object MatchAnalysis extends StrictLogging:
           contentsByPath = matchedSections
             .groupBy(sources.pathFor)
             .map((path, sections) =>
-              path -> sections.toIndexedSeq.sortBy(_.startOffset)
+              path -> sections.toIndexedSeq
+                .sortBy(section => section.startOffset -> -section.size)
             ),
           label = label
         )
@@ -2458,7 +2556,7 @@ object MatchAnalysis extends StrictLogging:
           case _ => None
 
         result.traverse(paredDownMatch =>
-          recordReplacement(aMatch, paredDownMatch) as paredDownMatch
+          propagateGroupIds(aMatch, paredDownMatch) as paredDownMatch
         )
       end pareDownOrSuppressCompletely
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1363,65 +1363,143 @@ object MatchAnalysis extends StrictLogging:
                     yield
                       val matches = reconciled.matches
 
-                      val parallelMatchesGroupIdsByMatch =
+                      val initialParallelMatchesGroupIdsByMatch =
                         updatedParallelMatchesGroupsIdsByMatch.view
                           .filterKeys(matches.contains)
                           .toMap
 
-                      val pathConsistentParallelMatchesGroupIdsByMatch =
-                        if parallelMatchesGroupIdsByMatch.nonEmpty then
-                          val matchesByGroupId =
-                            parallelMatchesGroupIdsByMatch.toSeq
-                              .groupBy(_._2)
-                              .view
-                              .mapValues(_.map(_._1))
+                      val disjointSetsOfMatches =
+                        val initialParallelMatchIds =
+                          matches.zipWithIndex.toMap
 
-                          matchesByGroupId
-                            .flatMap { case (_, matchesInGroup) =>
-                              val subGroupsByPaths = matchesInGroup.groupBy {
-                                aMatch =>
-                                  val pathOnBase = (aMatch match
-                                    case Match.AllSides(baseSection, _, _) =>
-                                      Some(baseSection)
-                                    case Match.BaseAndLeft(baseSection, _) =>
-                                      Some(baseSection)
-                                    case Match.BaseAndRight(baseSection, _) =>
-                                      Some(baseSection)
-                                    case _ => None
-                                  ).map(baseSources.pathFor)
-                                  val pathOnLeft = (aMatch match
-                                    case Match.AllSides(_, leftSection, _) =>
-                                      Some(leftSection)
-                                    case Match.BaseAndLeft(_, leftSection) =>
-                                      Some(leftSection)
-                                    case Match.LeftAndRight(leftSection, _) =>
-                                      Some(leftSection)
-                                    case _ => None
-                                  ).map(leftSources.pathFor)
-                                  val pathOnRight = (aMatch match
-                                    case Match.AllSides(_, _, rightSection) =>
-                                      Some(rightSection)
-                                    case Match.BaseAndRight(_, rightSection) =>
-                                      Some(rightSection)
-                                    case Match.LeftAndRight(_, rightSection) =>
-                                      Some(rightSection)
-                                    case _ => None
-                                  ).map(rightSources.pathFor)
-                                  (pathOnBase, pathOnLeft, pathOnRight)
-                              }
+                        given matchOrdering: Order[Match[Section[Element]]] =
+                          Order.by(initialParallelMatchIds.apply)
 
-                              subGroupsByPaths.values
+                        DisjointSets(
+                          matches.toSeq*
+                        )
+                      end disjointSetsOfMatches
+
+                      val coalescenceWorkflow =
+                        for
+                          _ <- initialParallelMatchesGroupIdsByMatch.toSeq
+                            .groupBy(_._2)
+                            .view
+                            .mapValues(_.map(_._1))
+                            .values
+                            .toSeq
+                            .traverse_ { group =>
+                              group
+                                .zip(group.tail)
+                                .traverse_ {
+                                  case (
+                                        precedingGroupMember,
+                                        succeedingGroupMember
+                                      ) =>
+                                    DisjointSets
+                                      .union(
+                                        precedingGroupMember,
+                                        succeedingGroupMember
+                                      )
+                                }
                             }
-                            .zipWithIndex
-                            .flatMap { case (subGroup, id) =>
-                              subGroup.map(_ -> id)
+                          _ <- matches
+                            .filter(_.isAnAllSidesMatch)
+                            .traverse_ {
+                              case allSidesMatch: Match.AllSides[
+                                    Section[Element]
+                                  ] =>
+                                reconciled
+                                  .pairwiseMatchesSubsumingOnBothSides(
+                                    allSidesMatch
+                                  )
+                                  .traverse_ { pairwiseMatch =>
+                                    val allSidesPaths = (
+                                      Some(
+                                        baseSources.pathFor(
+                                          allSidesMatch.baseElement
+                                        )
+                                      ),
+                                      Some(
+                                        leftSources.pathFor(
+                                          allSidesMatch.leftElement
+                                        )
+                                      ),
+                                      Some(
+                                        rightSources.pathFor(
+                                          allSidesMatch.rightElement
+                                        )
+                                      )
+                                    )
+                                    val pairwisePaths = pairwiseMatch match
+                                      case Match.BaseAndLeft(
+                                            baseSection,
+                                            leftSection
+                                          ) =>
+                                        (
+                                          Some(baseSources.pathFor(baseSection)),
+                                          Some(leftSources.pathFor(leftSection)),
+                                          None
+                                        )
+                                      case Match.BaseAndRight(
+                                            baseSection,
+                                            rightSection
+                                          ) =>
+                                        (
+                                          Some(baseSources.pathFor(baseSection)),
+                                          None,
+                                          Some(
+                                            rightSources.pathFor(rightSection)
+                                          )
+                                        )
+                                      case Match.LeftAndRight(
+                                            leftSection,
+                                            rightSection
+                                          ) =>
+                                        (
+                                          None,
+                                          Some(leftSources.pathFor(leftSection)),
+                                          Some(
+                                            rightSources.pathFor(rightSection)
+                                          )
+                                        )
+                                    end pairwisePaths
+
+                                    val isPathConsistent =
+                                      (allSidesPaths._1, pairwisePaths._1)
+                                        .mapN(_ == _)
+                                        .getOrElse(true) &&
+                                        (allSidesPaths._2, pairwisePaths._2)
+                                          .mapN(_ == _)
+                                          .getOrElse(true) &&
+                                        (allSidesPaths._3, pairwisePaths._3)
+                                          .mapN(_ == _)
+                                          .getOrElse(true)
+
+                                    if isPathConsistent then
+                                      DisjointSets.union(
+                                        allSidesMatch,
+                                        pairwiseMatch
+                                      )
+                                    else State.pure(false)
+                                    end if
+                                  }
                             }
-                            .toMap
-                        else parallelMatchesGroupIdsByMatch
+                          sets <- DisjointSets.toSets
+                        yield sets
+
+                      val parallelMatchesGroupIdsByMatch = coalescenceWorkflow
+                        .runA(disjointSetsOfMatches)
+                        .value
+                        .toList
+                        .map(_._2.toIterator)
+                        .zipWithIndex
+                        .flatMap((group, id) => group.map(_ -> id))
+                        .toMap
 
                       Right(
                         reconciled.copy(parallelMatchesGroupIdsByMatch =
-                          pathConsistentParallelMatchesGroupIdsByMatch
+                          parallelMatchesGroupIdsByMatch
                         )
                       )
                   else
@@ -2162,16 +2240,6 @@ object MatchAnalysis extends StrictLogging:
                       DisjointSets
                         .union(precedingGroupMember, succeedingGroupMember)
                   }
-              }
-            _ <- backTranslatedMatches
-              .filter(_.isAnAllSidesMatch)
-              .traverse_ {
-                case allSidesMatch: Match.AllSides[Section[Element]] =>
-                  backTranslatedMatchesAndTheirSections
-                    .pairwiseMatchesSubsumingOnBothSides(allSidesMatch)
-                    .traverse_(
-                      DisjointSets.union(allSidesMatch, _)
-                    )
               }
             sets <- DisjointSets.toSets
           yield sets

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -744,54 +744,14 @@ object MatchAnalysis extends StrictLogging:
 
               sortedBiteEdges = groupIdsBySortedBiteEdge.keySet
 
-              (
-                fragmentsFromPairwiseMatch,
-                groupIdsForFragments
-              ) =
-                {
-                  val triples = pairwiseMatch match
-                    case Match.BaseAndLeft(baseSection, leftSection) =>
-                      sortedBiteEdges.eatIntoSection(
-                        baseSources,
-                        baseSection,
-                        leftSources,
-                        leftSection,
-                        groupIdsBySortedBiteEdge
-                      )
-                    case Match.BaseAndRight(baseSection, rightSection) =>
-                      sortedBiteEdges.eatIntoSection(
-                        baseSources,
-                        baseSection,
-                        rightSources,
-                        rightSection,
-                        groupIdsBySortedBiteEdge
-                      )
-                    case Match.LeftAndRight(leftSection, rightSection) =>
-                      sortedBiteEdges.eatIntoSection(
-                        leftSources,
-                        leftSection,
-                        rightSources,
-                        rightSection,
-                        groupIdsBySortedBiteEdge
-                      )
-                  end triples
+              fragmentsAndGroupIds =
+                sortedBiteEdges.eatIntoPairwiseMatch(
+                  pairwiseMatch,
+                  groupIdsBySortedBiteEdge
+                )
 
-                  val fragments = triples.map {
-                    case (firstSection, secondSection, _) =>
-                      (pairwiseMatch match
-                        case Match.BaseAndLeft(_, _) =>
-                          Match.BaseAndLeft(firstSection, secondSection)
-                        case Match.BaseAndRight(_, _) =>
-                          Match.BaseAndRight(firstSection, secondSection)
-                        case Match.LeftAndRight(_, _) =>
-                          Match.LeftAndRight(firstSection, secondSection)
-                      ).asInstanceOf[PairwiseMatch]
-                  }
-
-                  val groupIds = triples.map(_._3)
-
-                  fragments -> groupIds
-                }
+              fragmentsFromPairwiseMatch = fragmentsAndGroupIds.map(_._1)
+              groupIdsForFragments      = fragmentsAndGroupIds.map(_._2)
 
               _ <- fragmentsFromPairwiseMatch
                 .zip(groupIdsForFragments)
@@ -809,20 +769,49 @@ object MatchAnalysis extends StrictLogging:
       // bite edges to be sorted in terms of their offsets and not exceed the
       // section's boundaries.
       extension (biteEdges: SortedSet[BiteEdge])
-        private def eatIntoSection(
-            firstSide: Sources[Path, Element],
-            firstSection: Section[Element],
-            secondSide: Sources[Path, Element],
-            secondSection: Section[Element],
+        private def eatIntoPairwiseMatch(
+            pairwiseMatch: PairwiseMatch,
             groupIdsBySortedBiteEdge: Map[BiteEdge, collection.Set[
               ParallelMatchesGroupId
             ]]
-        ): Vector[
-          (Section[Element], Section[Element], Set[ParallelMatchesGroupId])
-        ] =
+        ): Vector[(PairwiseMatch, Set[ParallelMatchesGroupId])] =
           // NOTE: here we work with zero-relative offsets from the start of the
           // meal, thus we can work directly with the offsets from the bite
           // edges.
+
+          val (firstSide, firstSection, secondSide, secondSection, factory) =
+            (pairwiseMatch match
+              case Match.BaseAndLeft(baseSection, leftSection) =>
+                (
+                  baseSources,
+                  baseSection,
+                  leftSources,
+                  leftSection,
+                  Match.BaseAndLeft.apply[Section[Element]]
+                )
+              case Match.BaseAndRight(baseSection, rightSection) =>
+                (
+                  baseSources,
+                  baseSection,
+                  rightSources,
+                  rightSection,
+                  Match.BaseAndRight.apply[Section[Element]]
+                )
+              case Match.LeftAndRight(leftSection, rightSection) =>
+                (
+                  leftSources,
+                  leftSection,
+                  rightSources,
+                  rightSection,
+                  Match.LeftAndRight.apply[Section[Element]]
+                )
+            ): (
+                Sources[Path, Element],
+                Section[Element],
+                Sources[Path, Element],
+                Section[Element],
+                (Section[Element], Section[Element]) => PairwiseMatch
+            )
 
           val firstPath  = firstSide.pathFor(firstSection)
           val secondPath = secondSide.pathFor(secondSection)
@@ -838,22 +827,14 @@ object MatchAnalysis extends StrictLogging:
             @tailrec
             final def apply(
                 remainingBiteEdges: Seq[BiteEdge],
-                fragments: Vector[
-                  (
-                      Section[Element],
-                      Section[Element],
-                      Set[ParallelMatchesGroupId]
-                  )
-                ]
-            ): Vector[
-              (Section[Element], Section[Element], Set[ParallelMatchesGroupId])
-            ] =
+                fragments: Vector[(PairwiseMatch, Set[ParallelMatchesGroupId])]
+            ): Vector[(PairwiseMatch, Set[ParallelMatchesGroupId])] =
               remainingBiteEdges match
                 case Seq() =>
                   if sectionSize > mealStartOffsetRelativeToMeal then
                     val size = sectionSize - mealStartOffsetRelativeToMeal
                     fragments.appended(
-                      (
+                      factory(
                         firstSide.section(firstPath)(
                           firstSection.startOffset + mealStartOffsetRelativeToMeal,
                           size
@@ -861,9 +842,8 @@ object MatchAnalysis extends StrictLogging:
                         secondSide.section(secondPath)(
                           secondSection.startOffset + mealStartOffsetRelativeToMeal,
                           size
-                        ),
-                        groupIdsFromPreviousBite
-                      )
+                        )
+                      ) -> groupIdsFromPreviousBite
                     )
                   else fragments
 
@@ -882,7 +862,7 @@ object MatchAnalysis extends StrictLogging:
                       val size =
                         startOffsetRelativeToMeal - mealStartOffsetRelativeToMeal
                       fragments.appended(
-                        (
+                        factory(
                           firstSide.section(firstPath)(
                             firstSection.startOffset + mealStartOffsetRelativeToMeal,
                             size
@@ -890,11 +870,10 @@ object MatchAnalysis extends StrictLogging:
                           secondSide.section(secondPath)(
                             secondSection.startOffset + mealStartOffsetRelativeToMeal,
                             size
-                          ),
-                          groupIdsFromPreviousBite union groupIdsBySortedBiteEdge(
-                            biteEdge
-                          ).toSet
-                        )
+                          )
+                        ) -> (groupIdsFromPreviousBite union groupIdsBySortedBiteEdge(
+                          biteEdge
+                        ).toSet)
                       )
                     else fragments
 
@@ -938,7 +917,7 @@ object MatchAnalysis extends StrictLogging:
             mealStartOffsetRelativeToMeal = 0,
             biteDepth = 0
           )(biteEdges.toSeq, fragments = Vector.empty)
-        end eatIntoSection
+        end eatIntoPairwiseMatch
 
       end extension
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1186,159 +1186,6 @@ object MatchAnalysis extends StrictLogging:
         end if
       end purgedOfMatchesWithOverlappingSections
 
-      private def pathOnBase(aMatch: GenericMatch[Element]): Option[Path] =
-        aMatch match
-          case Match.AllSides(baseSection, _, _) =>
-            Some(baseSources.pathFor(baseSection))
-          case Match.BaseAndLeft(baseSection, _) =>
-            Some(baseSources.pathFor(baseSection))
-          case Match.BaseAndRight(baseSection, _) =>
-            Some(baseSources.pathFor(baseSection))
-          case _ => None
-
-      private def pathOnLeft(aMatch: GenericMatch[Element]): Option[Path] =
-        aMatch match
-          case Match.AllSides(_, leftSection, _) =>
-            Some(leftSources.pathFor(leftSection))
-          case Match.BaseAndLeft(_, leftSection) =>
-            Some(leftSources.pathFor(leftSection))
-          case Match.LeftAndRight(leftSection, _) =>
-            Some(leftSources.pathFor(leftSection))
-          case _ => None
-
-      private def pathOnRight(aMatch: GenericMatch[Element]): Option[Path] =
-        aMatch match
-          case Match.AllSides(_, _, rightSection) =>
-            Some(rightSources.pathFor(rightSection))
-          case Match.BaseAndRight(_, rightSection) =>
-            Some(rightSources.pathFor(rightSection))
-          case Match.LeftAndRight(_, rightSection) =>
-            Some(rightSources.pathFor(rightSection))
-          case _ => None
-
-      private def offsetOnBase(aMatch: GenericMatch[Element]): Option[Int] =
-        aMatch match
-          case Match.AllSides(baseSection, _, _) =>
-            Some(baseSection.startOffset)
-          case Match.BaseAndLeft(baseSection, _) =>
-            Some(baseSection.startOffset)
-          case Match.BaseAndRight(baseSection, _) =>
-            Some(baseSection.startOffset)
-          case _ => None
-
-      private def offsetOnLeft(aMatch: GenericMatch[Element]): Option[Int] =
-        aMatch match
-          case Match.AllSides(_, leftSection, _) =>
-            Some(leftSection.startOffset)
-          case Match.BaseAndLeft(_, leftSection) =>
-            Some(leftSection.startOffset)
-          case Match.LeftAndRight(leftSection, _) =>
-            Some(leftSection.startOffset)
-          case _ => None
-
-      private def offsetOnRight(aMatch: GenericMatch[Element]): Option[Int] =
-        aMatch match
-          case Match.AllSides(_, _, rightSection) =>
-            Some(rightSection.startOffset)
-          case Match.BaseAndRight(_, rightSection) =>
-            Some(rightSection.startOffset)
-          case Match.LeftAndRight(_, rightSection) =>
-            Some(rightSection.startOffset)
-          case _ => None
-
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(allSides)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
-            )
-        }
-      end withoutTheseMatches
-
       def reconcileMatches: MatchesAndTheirSections =
         val matches = sectionsAndTheirMatches.values.toSet
 
@@ -1449,491 +1296,6 @@ object MatchAnalysis extends StrictLogging:
         result
 
       end reconcileMatches
-
-      private def checkInvariant(): Unit =
-        // We expect to tally either two lots of a given pairwise match or three
-        // lots of a given all-sides match; we therefore scale the
-        // raw multiplicities of the section to take this into account.
-        val multiplicityScaleSubdivisibleByTwoOrThree = 6
-
-        val multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch =
-          multiplicityScaleSubdivisibleByTwoOrThree / 3
-
-        val multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch =
-          multiplicityScaleSubdivisibleByTwoOrThree / 2
-
-        val baseSectionMultiplicities = baseSectionsByPath.values
-          .flatMap(_.iterator)
-          .groupBy(identity)
-          .map((section, group) =>
-            section -> multiplicityScaleSubdivisibleByTwoOrThree * group.size
-          )
-
-        val leftSectionMultiplicities = leftSectionsByPath.values
-          .flatMap(_.iterator)
-          .groupBy(identity)
-          .map((section, group) =>
-            section -> multiplicityScaleSubdivisibleByTwoOrThree * group.size
-          )
-
-        val rightSectionMultiplicities = rightSectionsByPath.values
-          .flatMap(_.iterator)
-          .groupBy(identity)
-          .map((section, group) =>
-            section -> multiplicityScaleSubdivisibleByTwoOrThree * group.size
-          )
-
-        val tallyAllSides: Option[Int] => Option[Int] = {
-          case Some(multiplicity) =>
-            // Once we've accounted for the multiplicity, remove the entry.
-            Option.unless(
-              multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch == multiplicity
-            )(
-              multiplicity - multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch
-            )
-          // If we have an occurrence and there is no entry, start a negative
-          // count.
-          case None =>
-            Some(
-              -multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch
-            )
-        }
-
-        val tallyPairwise: Option[Int] => Option[Int] = {
-          case Some(multiplicity) =>
-            // Once we've accounted for the multiplicity, remove the entry.
-            Option.unless(
-              multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch == multiplicity
-            )(
-              multiplicity - multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch
-            )
-          // If we have an occurrence and there is no entry, start a negative
-          // count.
-          case None =>
-            Some(-multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch)
-        }
-
-        val (
-          unbalancedBaseSectionMultiplicities,
-          unbalancedLeftSectionMultiplicities,
-          unbalancedRightSectionMultiplicities
-        ) = sectionsAndTheirMatches.values.foldLeft(
-          (
-            baseSectionMultiplicities,
-            leftSectionMultiplicities,
-            rightSectionMultiplicities
-          )
-        ) {
-          case (
-                (
-                  baseSectionMultiplicities,
-                  leftSectionMultiplicities,
-                  rightSectionMultiplicities
-                ),
-                aMatch
-              ) =>
-            aMatch match
-              case Match.AllSides(
-                    baseSection,
-                    leftSection,
-                    rightSection
-                  ) =>
-                (
-                  baseSectionMultiplicities.updatedWith(baseSection)(
-                    tallyAllSides
-                  ),
-                  leftSectionMultiplicities.updatedWith(leftSection)(
-                    tallyAllSides
-                  ),
-                  rightSectionMultiplicities.updatedWith(rightSection)(
-                    tallyAllSides
-                  )
-                )
-              case Match.BaseAndLeft(
-                    baseSection,
-                    leftSection
-                  ) =>
-                (
-                  baseSectionMultiplicities.updatedWith(baseSection)(
-                    tallyPairwise
-                  ),
-                  leftSectionMultiplicities.updatedWith(leftSection)(
-                    tallyPairwise
-                  ),
-                  rightSectionMultiplicities
-                )
-              case Match.BaseAndRight(
-                    baseSection,
-                    rightSection
-                  ) =>
-                (
-                  baseSectionMultiplicities.updatedWith(baseSection)(
-                    tallyPairwise
-                  ),
-                  leftSectionMultiplicities,
-                  rightSectionMultiplicities.updatedWith(rightSection)(
-                    tallyPairwise
-                  )
-                )
-              case Match.LeftAndRight(
-                    leftSection,
-                    rightSection
-                  ) =>
-                (
-                  baseSectionMultiplicities,
-                  leftSectionMultiplicities.updatedWith(leftSection)(
-                    tallyPairwise
-                  ),
-                  rightSectionMultiplicities.updatedWith(rightSection)(
-                    tallyPairwise
-                  )
-                )
-        }
-
-        assert(
-          unbalancedBaseSectionMultiplicities.isEmpty,
-          s"Found unbalanced base section multiplicities, these are:\n${pprintCustomised(unbalancedBaseSectionMultiplicities)}"
-        )
-        assert(
-          unbalancedLeftSectionMultiplicities.isEmpty,
-          s"Found unbalanced left section multiplicities, these are:\n${pprintCustomised(unbalancedLeftSectionMultiplicities)}"
-        )
-        assert(
-          unbalancedRightSectionMultiplicities.isEmpty,
-          s"Found unbalanced right section multiplicities, these are:\n${pprintCustomised(unbalancedRightSectionMultiplicities)}"
-        )
-      end checkInvariant
-
-      private def reconciliationPostcondition(): Unit =
-        baseSectionsByPath.values.flatMap(_.iterator).foreach { baseSection =>
-          assert(!baseSubsumes(baseSection))
-        }
-        leftSectionsByPath.values.flatMap(_.iterator).foreach { leftSection =>
-          assert(!leftSubsumes(leftSection))
-        }
-        rightSectionsByPath.values.flatMap(_.iterator).foreach { rightSection =>
-          assert(!rightSubsumes(rightSection))
-        }
-
-        // No match should be redundant - i.e. no match should involve sections
-        // that all belong to another match. This goes without saying for
-        // all-sides matches, as any redundancy would imply equivalent
-        // all-sides matches being associated with the same sections - this
-        // isn't allowed by a `MultiDict` instance. The same applies for
-        // pairwise matches of the same kind; pairwise matches of different
-        // kinds can't make each other redundant.
-        // What we have to watch out for are pairwise matches having *both*
-        // sections also belonging to an all-sides match. Note that it *is*
-        // legitimate to have a pairwise match sharing just one section with an
-        // all-sides match; they are just ambiguous matches.
-
-        val matchesBySectionPairs =
-          sectionsAndTheirMatches.values.toSet.foldLeft(
-            MultiDict.empty[(Section[Element], Section[Element]), Match[
-              Section[Element]
-            ]]
-          )((matchesBySectionPairs, aMatch) =>
-            aMatch match
-              case Match.AllSides(baseSection, leftSection, rightSection) =>
-                matchesBySectionPairs + ((
-                  baseSection,
-                  leftSection
-                ) -> aMatch) + ((baseSection, rightSection) -> aMatch) + ((
-                  leftSection,
-                  rightSection
-                ) -> aMatch)
-              case Match.BaseAndLeft(baseSection, leftSection) =>
-                matchesBySectionPairs + ((
-                  baseSection,
-                  leftSection
-                ) -> aMatch)
-              case Match.BaseAndRight(baseSection, rightSection) =>
-                matchesBySectionPairs + ((
-                  baseSection,
-                  rightSection
-                ) -> aMatch)
-              case Match.LeftAndRight(leftSection, rightSection) =>
-                matchesBySectionPairs + ((
-                  leftSection,
-                  rightSection
-                ) -> aMatch)
-          )
-
-        matchesBySectionPairs.keySet.foreach { sectionPair =>
-          val matches = matchesBySectionPairs.get(sectionPair)
-
-          val (allSides, pairwiseMatches) =
-            matches.partition(_.isAnAllSidesMatch)
-
-          if allSides.nonEmpty then
-            assert(
-              pairwiseMatches.isEmpty,
-              s"Found redundancy between pairwise matches: ${pprintCustomised(pairwiseMatches)} and an all-sides match in: ${pprintCustomised(allSides)}."
-            )
-          end if
-        }
-
-        if parallelMatchesGroupIdsByMatch.nonEmpty then
-          assert(
-            parallelMatchesGroupIdsByMatch.keySet == matches,
-            s"If groups of parallel matches have been discovered, they should cover the overall population of matches exactly."
-          )
-
-          parallelMatchesGroupIdsByMatch.toSeq
-            .groupBy(_._2)
-            .values
-            .foreach { group =>
-              val matchesInGroup = group.map(_._1)
-
-              val basePaths = matchesInGroup.flatMap(pathOnBase).toSet
-              assert(
-                basePaths.size <= 1,
-                s"Base paths for parallel matches group should be consistent, but are: $basePaths. Matches size: ${matchesInGroup.size}. Up to 10 matches are: ${pprintCustomised(matchesInGroup.take(10)).toString.take(1000)}"
-              )
-
-              val leftPaths = matchesInGroup.flatMap(pathOnLeft).toSet
-              assert(
-                leftPaths.size <= 1,
-                s"Left paths for parallel matches group should be consistent, but are: $leftPaths. Matches size: ${matchesInGroup.size}. Up to 10 matches are: ${pprintCustomised(matchesInGroup.take(10)).toString.take(1000)}"
-              )
-
-              val rightPaths = matchesInGroup.flatMap(pathOnRight).toSet
-              assert(
-                rightPaths.size <= 1,
-                s"Right paths for parallel matches group should be consistent, but are: $rightPaths. Matches size: ${matchesInGroup.size}. Up to 10 matches are: ${pprintCustomised(matchesInGroup.take(10)).toString.take(1000)}"
-              )
-
-              def checkOrder(
-                  side1Name: String,
-                  side2Name: String,
-                  offsetOnSide1: GenericMatch[Element] => Option[Int],
-                  offsetOnSide2: GenericMatch[Element] => Option[Int]
-              ): Unit =
-                val matchesOnBothSides = matchesInGroup
-                  .filter(m =>
-                    offsetOnSide1(m).isDefined && offsetOnSide2(m).isDefined
-                  )
-
-                for
-                  first  <- matchesOnBothSides
-                  second <- matchesOnBothSides
-                  if first != second
-                  offset1First  = offsetOnSide1(first).get
-                  offset1Second = offsetOnSide1(second).get
-                  if offset1First <= offset1Second
-                  offset2First  = offsetOnSide2(first).get
-                  offset2Second = offsetOnSide2(second).get
-                do
-                  assert(
-                    offset2First <= offset2Second,
-                    s"Relative order of matches in parallel group should be consistent between $side1Name and $side2Name, but $first and $second are out of order. Matches size: ${matchesInGroup.size}. Up to 10 matches are: ${pprintCustomised(matchesInGroup.take(10)).toString.take(1000)}"
-                  )
-                end for
-              end checkOrder
-
-              checkOrder("base", "left", offsetOnBase, offsetOnLeft)
-              checkOrder("base", "right", offsetOnBase, offsetOnRight)
-              checkOrder("left", "right", offsetOnLeft, offsetOnRight)
-            }
-        end if
-      end reconciliationPostcondition
-
-      private def pareDownOrSuppressCompletely[MatchType <: GenericMatch[
-        Element
-      ]](
-          aMatch: MatchType
-      ): ParallelMatchesGroupIdTracking[Option[ParedDownMatch[MatchType]]] =
-        // NOTE: one thing to watch out is when fragments resulting from
-        // larger pairwise matches being eaten into collide with equivalent
-        // pairwise matches found by fingerprint matching. This can take the
-        // form of the fragments coming first due to larger all-sides matches,
-        // or the pairwise matches from fingerprint matching can be followed
-        // by fragmentation if the all-sides eating into the larger pairwise
-        // matches also come from the same fingerprinting that yielded the
-        // pairwise matching. Intercepting this here addresses both cases. {
-        val result: Option[ParedDownMatch[MatchType]] = aMatch match
-          case Match.AllSides(baseSection, leftSection, rightSection) =>
-            val trivialSubsumptionSize = baseSection.size
-
-            val subsumingOnBase =
-              subsumingMatches(
-                sectionsAndTheirMatches
-              )(
-                baseSources,
-                baseSectionsByPath
-              )(
-                baseSection,
-                includeTrivialSubsumption = false
-              )
-
-            val subsumingOnLeft =
-              subsumingMatches(
-                sectionsAndTheirMatches
-              )(
-                leftSources,
-                leftSectionsByPath
-              )(
-                leftSection,
-                includeTrivialSubsumption = false
-              )
-
-            val subsumingOnRight =
-              subsumingMatches(
-                sectionsAndTheirMatches
-              )(
-                rightSources,
-                rightSectionsByPath
-              )(
-                rightSection,
-                includeTrivialSubsumption = false
-              )
-
-            val allSidesSubsumingOnLeft =
-              subsumingOnLeft.filter(_.isAnAllSidesMatch)
-            val allSidesSubsumingOnRight =
-              subsumingOnRight.filter(_.isAnAllSidesMatch)
-            val allSidesSubsumingOnBase =
-              subsumingOnBase.filter(_.isAnAllSidesMatch)
-
-            val subsumedByAnAllSidesMatchOnMoreThanOneSide =
-              (allSidesSubsumingOnLeft intersect allSidesSubsumingOnRight).nonEmpty
-                || (allSidesSubsumingOnBase intersect allSidesSubsumingOnLeft).nonEmpty
-                || (allSidesSubsumingOnBase intersect allSidesSubsumingOnRight).nonEmpty
-
-            if !subsumedByAnAllSidesMatchOnMoreThanOneSide then
-              val subsumedBySomeMatchOnJustTheBase =
-                (subsumingOnBase diff (subsumingOnLeft union subsumingOnRight)).nonEmpty
-              val subsumedBySomeMatchOnJustTheLeft =
-                (subsumingOnLeft diff (subsumingOnBase union subsumingOnRight)).nonEmpty
-              val subsumedBySomeMatchOnJustTheRight =
-                (subsumingOnRight diff (subsumingOnBase union subsumingOnLeft)).nonEmpty
-
-              // NOTE: an all-sides match could be subsumed by *some* match on
-              // just one side for two or three sides; they would be
-              // *different* matches, each doing a one-sided subsumption.
-              (
-                subsumedBySomeMatchOnJustTheBase,
-                subsumedBySomeMatchOnJustTheLeft,
-                subsumedBySomeMatchOnJustTheRight
-              ) match
-                case (false, false, false) => Some(aMatch)
-                case (true, false, false)  =>
-                  Option.unless(
-                    leftSubsumes(leftSection) || rightSubsumes(
-                      rightSection
-                    )
-                  )(Match.LeftAndRight(leftSection, rightSection))
-                case (false, true, false) =>
-                  Option.unless(
-                    baseSubsumes(baseSection) || rightSubsumes(
-                      rightSection
-                    )
-                  )(Match.BaseAndRight(baseSection, rightSection))
-                case (false, false, true) =>
-                  Option.unless(
-                    baseSubsumes(baseSection) || leftSubsumes(
-                      leftSection
-                    )
-                  )(Match.BaseAndLeft(baseSection, leftSection))
-                case _ => None
-              end match
-            else None
-            end if
-
-          case Match.BaseAndLeft(baseSection, leftSection) =>
-            Option.unless(
-              baseSubsumes(baseSection) || leftSubsumes(
-                leftSection
-              )
-            )(aMatch)
-
-          case Match.BaseAndRight(baseSection, rightSection) =>
-            Option.unless(
-              baseSubsumes(baseSection) || rightSubsumes(
-                rightSection
-              )
-            )(aMatch)
-
-          case Match.LeftAndRight(leftSection, rightSection) =>
-            Option.unless(
-              leftSubsumes(leftSection) || rightSubsumes(
-                rightSection
-              )
-            )(aMatch)
-
-          case _ => None
-
-        result.traverse(paredDownMatch =>
-          recordReplacement(aMatch, paredDownMatch) as paredDownMatch
-        )
-      end pareDownOrSuppressCompletely
-
-      private def pairwiseMatchesSubsumingOnBothSidesWithBiteEdges(
-          allSides: Match.AllSides[Section[Element]]
-      ): Set[(PairwiseMatch, BiteEdge, BiteEdge)] =
-        val subsumingOnBase =
-          subsumingPairwiseMatchesIncludingTriviallySubsuming(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            allSides.baseElement
-          )
-        val subsumingOnLeft =
-          subsumingPairwiseMatchesIncludingTriviallySubsuming(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            allSides.leftElement
-          )
-        val subsumingOnRight =
-          subsumingPairwiseMatchesIncludingTriviallySubsuming(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            allSides.rightElement
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft).map {
-          case subsuming: Match.BaseAndLeft[Section[Element]] =>
-            (
-              subsuming,
-              BiteEdge.Start(startOffsetRelativeToMeal =
-                allSides.baseElement.startOffset - subsuming.baseElement.startOffset
-              ),
-              BiteEdge.End(onePastEndOffsetRelativeToMeal =
-                allSides.baseElement.onePastEndOffset - subsuming.baseElement.startOffset
-              )
-            )
-        } union (subsumingOnBase intersect subsumingOnRight).map {
-          case subsuming: Match.BaseAndRight[Section[Element]] =>
-            (
-              subsuming,
-              BiteEdge.Start(startOffsetRelativeToMeal =
-                allSides.baseElement.startOffset - subsuming.baseElement.startOffset
-              ),
-              BiteEdge.End(onePastEndOffsetRelativeToMeal =
-                allSides.baseElement.onePastEndOffset - subsuming.baseElement.startOffset
-              )
-            )
-        } union (subsumingOnLeft intersect subsumingOnRight).map {
-          case subsuming: Match.LeftAndRight[Section[Element]] =>
-            (
-              subsuming,
-              BiteEdge.Start(startOffsetRelativeToMeal =
-                allSides.leftElement.startOffset - subsuming.leftElement.startOffset
-              ),
-              BiteEdge.End(onePastEndOffsetRelativeToMeal =
-                allSides.leftElement.onePastEndOffset - subsuming.leftElement.startOffset
-              )
-            )
-        }
-      end pairwiseMatchesSubsumingOnBothSidesWithBiteEdges
 
       def parallelMatchesOnly: MatchesAndTheirSections =
         // PLAN:
@@ -2221,6 +1583,99 @@ object MatchAnalysis extends StrictLogging:
 
         withoutTheseMatches(redundantMatches)
       end withoutRedundantPairwiseMatches
+
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(allSides)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
+            )
+        }
+      end withoutTheseMatches
 
       private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
         aMatch match
@@ -2518,6 +1973,594 @@ object MatchAnalysis extends StrictLogging:
           .union(subsumingOnBase intersect subsumingOnRight)
           .union(subsumingOnLeft intersect subsumingOnRight)
       end pairwiseMatchesSubsumingOnBothSides
+
+      private def checkInvariant(): Unit =
+        // We expect to tally either two lots of a given pairwise match or three
+        // lots of a given all-sides match; we therefore scale the
+        // raw multiplicities of the section to take this into account.
+        val multiplicityScaleSubdivisibleByTwoOrThree = 6
+
+        val multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch =
+          multiplicityScaleSubdivisibleByTwoOrThree / 3
+
+        val multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch =
+          multiplicityScaleSubdivisibleByTwoOrThree / 2
+
+        val baseSectionMultiplicities = baseSectionsByPath.values
+          .flatMap(_.iterator)
+          .groupBy(identity)
+          .map((section, group) =>
+            section -> multiplicityScaleSubdivisibleByTwoOrThree * group.size
+          )
+
+        val leftSectionMultiplicities = leftSectionsByPath.values
+          .flatMap(_.iterator)
+          .groupBy(identity)
+          .map((section, group) =>
+            section -> multiplicityScaleSubdivisibleByTwoOrThree * group.size
+          )
+
+        val rightSectionMultiplicities = rightSectionsByPath.values
+          .flatMap(_.iterator)
+          .groupBy(identity)
+          .map((section, group) =>
+            section -> multiplicityScaleSubdivisibleByTwoOrThree * group.size
+          )
+
+        val tallyAllSides: Option[Int] => Option[Int] = {
+          case Some(multiplicity) =>
+            // Once we've accounted for the multiplicity, remove the entry.
+            Option.unless(
+              multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch == multiplicity
+            )(
+              multiplicity - multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch
+            )
+          // If we have an occurrence and there is no entry, start a negative
+          // count.
+          case None =>
+            Some(
+              -multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch
+            )
+        }
+
+        val tallyPairwise: Option[Int] => Option[Int] = {
+          case Some(multiplicity) =>
+            // Once we've accounted for the multiplicity, remove the entry.
+            Option.unless(
+              multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch == multiplicity
+            )(
+              multiplicity - multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch
+            )
+          // If we have an occurrence and there is no entry, start a negative
+          // count.
+          case None =>
+            Some(-multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch)
+        }
+
+        val (
+          unbalancedBaseSectionMultiplicities,
+          unbalancedLeftSectionMultiplicities,
+          unbalancedRightSectionMultiplicities
+        ) = sectionsAndTheirMatches.values.foldLeft(
+          (
+            baseSectionMultiplicities,
+            leftSectionMultiplicities,
+            rightSectionMultiplicities
+          )
+        ) {
+          case (
+                (
+                  baseSectionMultiplicities,
+                  leftSectionMultiplicities,
+                  rightSectionMultiplicities
+                ),
+                aMatch
+              ) =>
+            aMatch match
+              case Match.AllSides(
+                    baseSection,
+                    leftSection,
+                    rightSection
+                  ) =>
+                (
+                  baseSectionMultiplicities.updatedWith(baseSection)(
+                    tallyAllSides
+                  ),
+                  leftSectionMultiplicities.updatedWith(leftSection)(
+                    tallyAllSides
+                  ),
+                  rightSectionMultiplicities.updatedWith(rightSection)(
+                    tallyAllSides
+                  )
+                )
+              case Match.BaseAndLeft(
+                    baseSection,
+                    leftSection
+                  ) =>
+                (
+                  baseSectionMultiplicities.updatedWith(baseSection)(
+                    tallyPairwise
+                  ),
+                  leftSectionMultiplicities.updatedWith(leftSection)(
+                    tallyPairwise
+                  ),
+                  rightSectionMultiplicities
+                )
+              case Match.BaseAndRight(
+                    baseSection,
+                    rightSection
+                  ) =>
+                (
+                  baseSectionMultiplicities.updatedWith(baseSection)(
+                    tallyPairwise
+                  ),
+                  leftSectionMultiplicities,
+                  rightSectionMultiplicities.updatedWith(rightSection)(
+                    tallyPairwise
+                  )
+                )
+              case Match.LeftAndRight(
+                    leftSection,
+                    rightSection
+                  ) =>
+                (
+                  baseSectionMultiplicities,
+                  leftSectionMultiplicities.updatedWith(leftSection)(
+                    tallyPairwise
+                  ),
+                  rightSectionMultiplicities.updatedWith(rightSection)(
+                    tallyPairwise
+                  )
+                )
+        }
+
+        assert(
+          unbalancedBaseSectionMultiplicities.isEmpty,
+          s"Found unbalanced base section multiplicities, these are:\n${pprintCustomised(unbalancedBaseSectionMultiplicities)}"
+        )
+        assert(
+          unbalancedLeftSectionMultiplicities.isEmpty,
+          s"Found unbalanced left section multiplicities, these are:\n${pprintCustomised(unbalancedLeftSectionMultiplicities)}"
+        )
+        assert(
+          unbalancedRightSectionMultiplicities.isEmpty,
+          s"Found unbalanced right section multiplicities, these are:\n${pprintCustomised(unbalancedRightSectionMultiplicities)}"
+        )
+      end checkInvariant
+
+      private def reconciliationPostcondition(): Unit =
+        baseSectionsByPath.values.flatMap(_.iterator).foreach { baseSection =>
+          assert(!baseSubsumes(baseSection))
+        }
+        leftSectionsByPath.values.flatMap(_.iterator).foreach { leftSection =>
+          assert(!leftSubsumes(leftSection))
+        }
+        rightSectionsByPath.values.flatMap(_.iterator).foreach { rightSection =>
+          assert(!rightSubsumes(rightSection))
+        }
+
+        // No match should be redundant - i.e. no match should involve sections
+        // that all belong to another match. This goes without saying for
+        // all-sides matches, as any redundancy would imply equivalent
+        // all-sides matches being associated with the same sections - this
+        // isn't allowed by a `MultiDict` instance. The same applies for
+        // pairwise matches of the same kind; pairwise matches of different
+        // kinds can't make each other redundant.
+        // What we have to watch out for are pairwise matches having *both*
+        // sections also belonging to an all-sides match. Note that it *is*
+        // legitimate to have a pairwise match sharing just one section with an
+        // all-sides match; they are just ambiguous matches.
+
+        val matchesBySectionPairs =
+          sectionsAndTheirMatches.values.toSet.foldLeft(
+            MultiDict.empty[(Section[Element], Section[Element]), Match[
+              Section[Element]
+            ]]
+          )((matchesBySectionPairs, aMatch) =>
+            aMatch match
+              case Match.AllSides(baseSection, leftSection, rightSection) =>
+                matchesBySectionPairs + ((
+                  baseSection,
+                  leftSection
+                ) -> aMatch) + ((baseSection, rightSection) -> aMatch) + ((
+                  leftSection,
+                  rightSection
+                ) -> aMatch)
+              case Match.BaseAndLeft(baseSection, leftSection) =>
+                matchesBySectionPairs + ((
+                  baseSection,
+                  leftSection
+                ) -> aMatch)
+              case Match.BaseAndRight(baseSection, rightSection) =>
+                matchesBySectionPairs + ((
+                  baseSection,
+                  rightSection
+                ) -> aMatch)
+              case Match.LeftAndRight(leftSection, rightSection) =>
+                matchesBySectionPairs + ((
+                  leftSection,
+                  rightSection
+                ) -> aMatch)
+          )
+
+        matchesBySectionPairs.keySet.foreach { sectionPair =>
+          val matches = matchesBySectionPairs.get(sectionPair)
+
+          val (allSides, pairwiseMatches) =
+            matches.partition(_.isAnAllSidesMatch)
+
+          if allSides.nonEmpty then
+            assert(
+              pairwiseMatches.isEmpty,
+              s"Found redundancy between pairwise matches: ${pprintCustomised(pairwiseMatches)} and an all-sides match in: ${pprintCustomised(allSides)}."
+            )
+          end if
+        }
+
+        if parallelMatchesGroupIdsByMatch.nonEmpty then
+          assert(
+            parallelMatchesGroupIdsByMatch.keySet == matches,
+            s"If groups of parallel matches have been discovered, they should cover the overall population of matches exactly."
+          )
+
+          parallelMatchesGroupIdsByMatch.toSeq
+            .groupBy(_._2)
+            .values
+            .foreach { group =>
+              val matchesInGroup = group.map(_._1)
+
+              case class SidePerspective(path: Path, startOffset: Int)
+
+              case class MatchSynopsis(
+                  base: Option[SidePerspective],
+                  left: Option[SidePerspective],
+                  right: Option[SidePerspective]
+              )
+
+              object MatchSynopsis:
+                def apply(aMatch: GenericMatch[Element]): MatchSynopsis =
+                  MatchSynopsis(
+                    base = (pathOnBase(aMatch), startOffsetOnBase(aMatch))
+                      .mapN(SidePerspective.apply),
+                    left = (pathOnLeft(aMatch), startOffsetOnLeft(aMatch))
+                      .mapN(SidePerspective.apply),
+                    right = (pathOnRight(aMatch), startOffsetOnRight(aMatch))
+                      .mapN(SidePerspective.apply)
+                  )
+              end MatchSynopsis
+
+              val basePaths = matchesInGroup.flatMap(pathOnBase).toSet
+              assert(
+                basePaths.size <= 1,
+                s"""Base paths for a group of parallel matches should be the same,
+                   |but vary: $basePaths.
+                   |Matches are: ${pprintCustomised(
+                    matchesInGroup.map(MatchSynopsis.apply)
+                  )}""".stripMargin
+              )
+
+              val leftPaths = matchesInGroup.flatMap(pathOnLeft).toSet
+              assert(
+                leftPaths.size <= 1,
+                s"""Left paths for a group of parallel matches should be the same,
+                   |but vary: $leftPaths.
+                   |Matches are: ${pprintCustomised(
+                    matchesInGroup.map(MatchSynopsis.apply)
+                  )}""".stripMargin
+              )
+
+              val rightPaths = matchesInGroup.flatMap(pathOnRight).toSet
+              assert(
+                rightPaths.size <= 1,
+                s"""Right paths for a group of parallel matches should be the same,
+                   |but vary: $rightPaths.
+                   |Matches are: ${pprintCustomised(
+                    matchesInGroup.map(MatchSynopsis.apply)
+                  )}""".stripMargin
+              )
+
+              def checkOrder(
+                  side1Name: String,
+                  side2Name: String,
+                  offsetOnSide1: GenericMatch[Element] => Option[Int],
+                  offsetOnSide2: GenericMatch[Element] => Option[Int]
+              ): Unit =
+                val matchesOnBothSides = matchesInGroup
+                  .filter(m =>
+                    offsetOnSide1(m).isDefined && offsetOnSide2(m).isDefined
+                  )
+
+                for
+                  first  <- matchesOnBothSides
+                  second <- matchesOnBothSides
+                  if first != second
+                  offset1First  = offsetOnSide1(first).get
+                  offset1Second = offsetOnSide1(second).get
+                  if offset1First <= offset1Second
+                  offset2First  = offsetOnSide2(first).get
+                  offset2Second = offsetOnSide2(second).get
+                do
+                  assert(
+                    offset2First <= offset2Second,
+                    s"""
+                       |Relative order of matches in parallel group should be consistent between $side1Name and $side2Name,
+                       |but $first and $second are out of order.
+                       |Matches are: ${pprintCustomised(
+                        matchesInGroup.map(MatchSynopsis.apply)
+                      )}""".stripMargin
+                  )
+                end for
+              end checkOrder
+
+              checkOrder("base", "left", startOffsetOnBase, startOffsetOnLeft)
+              checkOrder("base", "right", startOffsetOnBase, startOffsetOnRight)
+              checkOrder("left", "right", startOffsetOnLeft, startOffsetOnRight)
+            }
+        end if
+      end reconciliationPostcondition
+
+      private def pathOnBase(aMatch: GenericMatch[Element]): Option[Path] =
+        aMatch match
+          case Match.AllSides(baseSection, _, _) =>
+            Some(baseSources.pathFor(baseSection))
+          case Match.BaseAndLeft(baseSection, _) =>
+            Some(baseSources.pathFor(baseSection))
+          case Match.BaseAndRight(baseSection, _) =>
+            Some(baseSources.pathFor(baseSection))
+          case _ => None
+
+      private def pathOnLeft(aMatch: GenericMatch[Element]): Option[Path] =
+        aMatch match
+          case Match.AllSides(_, leftSection, _) =>
+            Some(leftSources.pathFor(leftSection))
+          case Match.BaseAndLeft(_, leftSection) =>
+            Some(leftSources.pathFor(leftSection))
+          case Match.LeftAndRight(leftSection, _) =>
+            Some(leftSources.pathFor(leftSection))
+          case _ => None
+
+      private def pathOnRight(aMatch: GenericMatch[Element]): Option[Path] =
+        aMatch match
+          case Match.AllSides(_, _, rightSection) =>
+            Some(rightSources.pathFor(rightSection))
+          case Match.BaseAndRight(_, rightSection) =>
+            Some(rightSources.pathFor(rightSection))
+          case Match.LeftAndRight(_, rightSection) =>
+            Some(rightSources.pathFor(rightSection))
+          case _ => None
+
+      private def startOffsetOnBase(
+          aMatch: GenericMatch[Element]
+      ): Option[Int] =
+        aMatch match
+          case Match.AllSides(baseSection, _, _) =>
+            Some(baseSection.startOffset)
+          case Match.BaseAndLeft(baseSection, _) =>
+            Some(baseSection.startOffset)
+          case Match.BaseAndRight(baseSection, _) =>
+            Some(baseSection.startOffset)
+          case _ => None
+
+      private def startOffsetOnLeft(
+          aMatch: GenericMatch[Element]
+      ): Option[Int] =
+        aMatch match
+          case Match.AllSides(_, leftSection, _) =>
+            Some(leftSection.startOffset)
+          case Match.BaseAndLeft(_, leftSection) =>
+            Some(leftSection.startOffset)
+          case Match.LeftAndRight(leftSection, _) =>
+            Some(leftSection.startOffset)
+          case _ => None
+
+      private def startOffsetOnRight(
+          aMatch: GenericMatch[Element]
+      ): Option[Int] =
+        aMatch match
+          case Match.AllSides(_, _, rightSection) =>
+            Some(rightSection.startOffset)
+          case Match.BaseAndRight(_, rightSection) =>
+            Some(rightSection.startOffset)
+          case Match.LeftAndRight(_, rightSection) =>
+            Some(rightSection.startOffset)
+          case _ => None
+
+      private def pareDownOrSuppressCompletely[MatchType <: GenericMatch[
+        Element
+      ]](
+          aMatch: MatchType
+      ): ParallelMatchesGroupIdTracking[Option[ParedDownMatch[MatchType]]] =
+        // NOTE: one thing to watch out is when fragments resulting from
+        // larger pairwise matches being eaten into collide with equivalent
+        // pairwise matches found by fingerprint matching. This can take the
+        // form of the fragments coming first due to larger all-sides matches,
+        // or the pairwise matches from fingerprint matching can be followed
+        // by fragmentation if the all-sides eating into the larger pairwise
+        // matches also come from the same fingerprinting that yielded the
+        // pairwise matching. Intercepting this here addresses both cases. {
+        val result: Option[ParedDownMatch[MatchType]] = aMatch match
+          case Match.AllSides(baseSection, leftSection, rightSection) =>
+            val trivialSubsumptionSize = baseSection.size
+
+            val subsumingOnBase =
+              subsumingMatches(
+                sectionsAndTheirMatches
+              )(
+                baseSources,
+                baseSectionsByPath
+              )(
+                baseSection,
+                includeTrivialSubsumption = false
+              )
+
+            val subsumingOnLeft =
+              subsumingMatches(
+                sectionsAndTheirMatches
+              )(
+                leftSources,
+                leftSectionsByPath
+              )(
+                leftSection,
+                includeTrivialSubsumption = false
+              )
+
+            val subsumingOnRight =
+              subsumingMatches(
+                sectionsAndTheirMatches
+              )(
+                rightSources,
+                rightSectionsByPath
+              )(
+                rightSection,
+                includeTrivialSubsumption = false
+              )
+
+            val allSidesSubsumingOnLeft =
+              subsumingOnLeft.filter(_.isAnAllSidesMatch)
+            val allSidesSubsumingOnRight =
+              subsumingOnRight.filter(_.isAnAllSidesMatch)
+            val allSidesSubsumingOnBase =
+              subsumingOnBase.filter(_.isAnAllSidesMatch)
+
+            val subsumedByAnAllSidesMatchOnMoreThanOneSide =
+              (allSidesSubsumingOnLeft intersect allSidesSubsumingOnRight).nonEmpty
+                || (allSidesSubsumingOnBase intersect allSidesSubsumingOnLeft).nonEmpty
+                || (allSidesSubsumingOnBase intersect allSidesSubsumingOnRight).nonEmpty
+
+            if !subsumedByAnAllSidesMatchOnMoreThanOneSide then
+              val subsumedBySomeMatchOnJustTheBase =
+                (subsumingOnBase diff (subsumingOnLeft union subsumingOnRight)).nonEmpty
+              val subsumedBySomeMatchOnJustTheLeft =
+                (subsumingOnLeft diff (subsumingOnBase union subsumingOnRight)).nonEmpty
+              val subsumedBySomeMatchOnJustTheRight =
+                (subsumingOnRight diff (subsumingOnBase union subsumingOnLeft)).nonEmpty
+
+              // NOTE: an all-sides match could be subsumed by *some* match on
+              // just one side for two or three sides; they would be
+              // *different* matches, each doing a one-sided subsumption.
+              (
+                subsumedBySomeMatchOnJustTheBase,
+                subsumedBySomeMatchOnJustTheLeft,
+                subsumedBySomeMatchOnJustTheRight
+              ) match
+                case (false, false, false) => Some(aMatch)
+                case (true, false, false)  =>
+                  Option.unless(
+                    leftSubsumes(leftSection) || rightSubsumes(
+                      rightSection
+                    )
+                  )(Match.LeftAndRight(leftSection, rightSection))
+                case (false, true, false) =>
+                  Option.unless(
+                    baseSubsumes(baseSection) || rightSubsumes(
+                      rightSection
+                    )
+                  )(Match.BaseAndRight(baseSection, rightSection))
+                case (false, false, true) =>
+                  Option.unless(
+                    baseSubsumes(baseSection) || leftSubsumes(
+                      leftSection
+                    )
+                  )(Match.BaseAndLeft(baseSection, leftSection))
+                case _ => None
+              end match
+            else None
+            end if
+
+          case Match.BaseAndLeft(baseSection, leftSection) =>
+            Option.unless(
+              baseSubsumes(baseSection) || leftSubsumes(
+                leftSection
+              )
+            )(aMatch)
+
+          case Match.BaseAndRight(baseSection, rightSection) =>
+            Option.unless(
+              baseSubsumes(baseSection) || rightSubsumes(
+                rightSection
+              )
+            )(aMatch)
+
+          case Match.LeftAndRight(leftSection, rightSection) =>
+            Option.unless(
+              leftSubsumes(leftSection) || rightSubsumes(
+                rightSection
+              )
+            )(aMatch)
+
+          case _ => None
+
+        result.traverse(paredDownMatch =>
+          recordReplacement(aMatch, paredDownMatch) as paredDownMatch
+        )
+      end pareDownOrSuppressCompletely
+
+      private def pairwiseMatchesSubsumingOnBothSidesWithBiteEdges(
+          allSides: Match.AllSides[Section[Element]]
+      ): Set[(PairwiseMatch, BiteEdge, BiteEdge)] =
+        val subsumingOnBase =
+          subsumingPairwiseMatchesIncludingTriviallySubsuming(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            allSides.baseElement
+          )
+        val subsumingOnLeft =
+          subsumingPairwiseMatchesIncludingTriviallySubsuming(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            allSides.leftElement
+          )
+        val subsumingOnRight =
+          subsumingPairwiseMatchesIncludingTriviallySubsuming(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            allSides.rightElement
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft).map {
+          case subsuming: Match.BaseAndLeft[Section[Element]] =>
+            (
+              subsuming,
+              BiteEdge.Start(startOffsetRelativeToMeal =
+                allSides.baseElement.startOffset - subsuming.baseElement.startOffset
+              ),
+              BiteEdge.End(onePastEndOffsetRelativeToMeal =
+                allSides.baseElement.onePastEndOffset - subsuming.baseElement.startOffset
+              )
+            )
+        } union (subsumingOnBase intersect subsumingOnRight).map {
+          case subsuming: Match.BaseAndRight[Section[Element]] =>
+            (
+              subsuming,
+              BiteEdge.Start(startOffsetRelativeToMeal =
+                allSides.baseElement.startOffset - subsuming.baseElement.startOffset
+              ),
+              BiteEdge.End(onePastEndOffsetRelativeToMeal =
+                allSides.baseElement.onePastEndOffset - subsuming.baseElement.startOffset
+              )
+            )
+        } union (subsumingOnLeft intersect subsumingOnRight).map {
+          case subsuming: Match.LeftAndRight[Section[Element]] =>
+            (
+              subsuming,
+              BiteEdge.Start(startOffsetRelativeToMeal =
+                allSides.leftElement.startOffset - subsuming.leftElement.startOffset
+              ),
+              BiteEdge.End(onePastEndOffsetRelativeToMeal =
+                allSides.leftElement.onePastEndOffset - subsuming.leftElement.startOffset
+              )
+            )
+        }
+      end pairwiseMatchesSubsumingOnBothSidesWithBiteEdges
 
       @tailrec
       private final def withAllSmallFryMatches(

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -25,7 +25,12 @@ import de.sciss.fingertree.RangedSeq
 
 import java.lang.Byte as JavaByte
 import scala.annotation.tailrec
-import scala.collection.immutable.{MultiDict, SortedMap, SortedMultiSet}
+import scala.collection.immutable.{
+  MultiDict,
+  SortedMap,
+  SortedMultiSet,
+  SortedSet
+}
 import scala.collection.mutable
 import scala.collection.parallel.CollectionConverters.*
 import scala.util.{Success, Using}
@@ -737,47 +742,35 @@ object MatchAnalysis extends StrictLogging:
                     .map(_ -> parallelMatchesGroupIdsByMatch.get(allSides))
               })
 
-              sortedBiteEdges = matchesBySortedBiteEdge.keySet.toSeq
+              sortedBiteEdges = matchesBySortedBiteEdge.keySet
 
               fragmentsFromPairwiseMatch: Seq[PairwiseMatch] =
                 pairwiseMatch match
                   case Match.BaseAndLeft(baseSection, leftSection) =>
-                    (eatIntoSection(
+                    (sortedBiteEdges.eatIntoSection(
                       baseSources,
-                      sortedBiteEdges
-                    )(
                       baseSection
-                    ) zip eatIntoSection(
+                    ) zip sortedBiteEdges.eatIntoSection(
                       leftSources,
-                      sortedBiteEdges
-                    )(
                       leftSection
                     ))
                       .map(Match.BaseAndLeft.apply)
 
                   case Match.BaseAndRight(baseSection, rightSection) =>
-                    (eatIntoSection(
+                    (sortedBiteEdges.eatIntoSection(
                       baseSources,
-                      sortedBiteEdges
-                    )(
                       baseSection
-                    ) zip eatIntoSection(
+                    ) zip sortedBiteEdges.eatIntoSection(
                       rightSources,
-                      sortedBiteEdges
-                    )(
                       rightSection
                     )).map(Match.BaseAndRight.apply)
 
                   case Match.LeftAndRight(leftSection, rightSection) =>
-                    (eatIntoSection(
+                    (sortedBiteEdges.eatIntoSection(
                       leftSources,
-                      sortedBiteEdges
-                    )(
                       leftSection
-                    ) zip eatIntoSection(
+                    ) zip sortedBiteEdges.eatIntoSection(
                       rightSources,
-                      sortedBiteEdges
-                    )(
                       rightSection
                     )).map(Match.LeftAndRight.apply)
 
@@ -791,90 +784,96 @@ object MatchAnalysis extends StrictLogging:
           }
           .map(_.toSet)
 
-      // Breaks up a section by eating into it with smaller bites, yielding the
-      // fragment sections. There are preconditions buried in the implementation
-      // that require the bite edges to be sorted in terms of their offsets and
-      // not exceed the section's boundaries.
-      private def eatIntoSection(
-          side: Sources[Path, Element],
-          biteEdges: Seq[BiteEdge]
-      )(
-          section: Section[Element]
-      ): Seq[Section[Element]] =
-        val mealOnePastEndOffset: Int = section.onePastEndOffset
+      // There are preconditions buried in the implementations that require the
+      // bite edges to be sorted in terms of their offsets and not exceed the
+      // section's boundaries.
+      extension (biteEdges: SortedSet[BiteEdge])
+        // Breaks up a section by eating into it with smaller bites, yielding
+        // the fragment sections.
+        private def eatIntoSection(
+            side: Sources[Path, Element],
+            section: Section[Element]
+        ) =
+          val mealOnePastEndOffset: Int = section.onePastEndOffset
 
-        val path = side.pathFor(section)
+          val path = side.pathFor(section)
 
-        case class State(
-            mealStartOffset: Int,
-            biteDepth: Int
-        ):
-          @tailrec
-          final def apply(
-              biteEdges: Seq[BiteEdge],
-              fragments: Vector[Section[Element]]
-          ): Vector[Section[Element]] =
-            biteEdges match
-              case Seq() =>
-                if mealOnePastEndOffset > mealStartOffset then
-                  fragments.appended(
-                    side.section(path)(
-                      startOffset = mealStartOffset,
-                      size = mealOnePastEndOffset - mealStartOffset
+          case class State(
+              mealStartOffset: Int,
+              biteDepth: Int
+          ):
+            @tailrec
+            final def apply(
+                biteEdges: Seq[BiteEdge],
+                fragments: Vector[Section[Element]]
+            ): Vector[Section[Element]] =
+              biteEdges match
+                case Seq() =>
+                  if mealOnePastEndOffset > mealStartOffset then
+                    fragments.appended(
+                      side.section(path)(
+                        startOffset = mealStartOffset,
+                        size = mealOnePastEndOffset - mealStartOffset
+                      )
                     )
-                  )
-                else fragments
-              case Seq(
-                    BiteEdge.Start(startOffsetRelativeToMeal),
-                    remainingBiteEdges*
-                  ) =>
-                val startOffset =
-                  section.startOffset + startOffsetRelativeToMeal
+                  else fragments
+                case Seq(
+                      BiteEdge.Start(startOffsetRelativeToMeal),
+                      remainingBiteEdges*
+                    ) =>
+                  val startOffset =
+                    section.startOffset + startOffsetRelativeToMeal
 
-                require(startOffset >= mealStartOffset)
-                require(mealOnePastEndOffset > startOffset)
-                this
-                  .copy(
-                    mealStartOffset = startOffset,
-                    biteDepth = 1 + biteDepth
-                  )
-                  .apply(
-                    remainingBiteEdges,
-                    fragments =
-                      if 0 == biteDepth && startOffset > mealStartOffset
-                      then
-                        fragments.appended(
-                          side.section(path)(
-                            startOffset = mealStartOffset,
-                            size = startOffset - mealStartOffset
+                  require(startOffset >= mealStartOffset)
+                  require(mealOnePastEndOffset > startOffset)
+                  this
+                    .copy(
+                      mealStartOffset = startOffset,
+                      biteDepth = 1 + biteDepth
+                    )
+                    .apply(
+                      remainingBiteEdges,
+                      fragments =
+                        if 0 == biteDepth && startOffset > mealStartOffset
+                        then
+                          fragments.appended(
+                            side.section(path)(
+                              startOffset = mealStartOffset,
+                              size = startOffset - mealStartOffset
+                            )
                           )
-                        )
-                      else fragments
-                  )
-              case Seq(
-                    BiteEdge.End(onePastEndOffsetRelativeToMeal),
-                    remainingBiteEdges*
-                  ) =>
-                require(0 < biteDepth)
+                        else fragments
+                    )
+                case Seq(
+                      BiteEdge.End(onePastEndOffsetRelativeToMeal),
+                      remainingBiteEdges*
+                    ) =>
+                  assume(0 < biteDepth)
 
-                val onePastEndOffset =
-                  section.startOffset + onePastEndOffsetRelativeToMeal
+                  val onePastEndOffset =
+                    section.startOffset + onePastEndOffsetRelativeToMeal
 
-                require(mealStartOffset <= onePastEndOffset)
-                require(onePastEndOffset <= mealOnePastEndOffset)
-                this
-                  .copy(
-                    mealStartOffset = onePastEndOffset,
-                    biteDepth = biteDepth - 1
-                  )
-                  .apply(remainingBiteEdges, fragments)
-        end State
+                  require(mealStartOffset <= onePastEndOffset)
+                  require(onePastEndOffset <= mealOnePastEndOffset)
+                  this
+                    .copy(
+                      mealStartOffset = onePastEndOffset,
+                      biteDepth = biteDepth - 1
+                    )
+                    .apply(remainingBiteEdges, fragments)
+          end State
 
-        State(
-          mealStartOffset = section.startOffset,
-          biteDepth = 0
-        )(biteEdges, fragments = Vector.empty)
-      end eatIntoSection
+          State(
+            mealStartOffset = section.startOffset,
+            biteDepth = 0
+          )(biteEdges.toSeq, fragments = Vector.empty)
+        end eatIntoSection
+
+        private def assignParallelMatchesGroupIdsForFragments(
+            matchesBySortedBiteEdge: Map[BiteEdge, Set[ParallelMatchesGroupId]],
+            sectionSize: Int
+        ): Seq[Set[ParallelMatchesGroupId]] = ???
+      end extension
 
       private def recordReplacements(
           original: GenericMatch[Element],
@@ -893,12 +892,6 @@ object MatchAnalysis extends StrictLogging:
             partialResult.add(replacement, groupId)
           )
         }
-
-      private def assignParallelMatchesGroupIdsForFragments(
-          biteEdges: Seq[BiteEdge]
-      )(
-          matchesBySortedBiteEdge: Map[BiteEdge, Set[ParallelMatchesGroupId]]
-      ): Seq[Set[ParallelMatchesGroupId]] = ???
 
       trait PathInclusions:
         def isIncludedOnBase(basePath: Path): Boolean
@@ -1198,99 +1191,6 @@ object MatchAnalysis extends StrictLogging:
         else this
         end if
       end purgedOfMatchesWithOverlappingSections
-
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(allSides)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(baseAndLeft)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(baseAndRight)
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(leftAndRight)
-            )
-        }
-      end withoutTheseMatches
 
       def reconcileMatches: MatchesAndTheirSections =
         val matches = sectionsAndTheirMatches.values.toSet
@@ -1633,6 +1533,99 @@ object MatchAnalysis extends StrictLogging:
 
         withoutTheseMatches(redundantMatches)
       end withoutRedundantPairwiseMatches
+
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(allSides)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(baseAndLeft)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(baseAndRight)
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(leftAndRight)
+            )
+        }
+      end withoutTheseMatches
 
       private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
         aMatch match

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1380,30 +1380,33 @@ object MatchAnalysis extends StrictLogging:
                             .flatMap { case (_, matchesInGroup) =>
                               val subGroupsByPaths = matchesInGroup.groupBy {
                                 aMatch =>
-                                  val pathOnBase = aMatch match
+                                  val pathOnBase = (aMatch match
                                     case Match.AllSides(baseSection, _, _) =>
-                                      Some(baseSources.pathFor(baseSection))
+                                      Some(baseSection)
                                     case Match.BaseAndLeft(baseSection, _) =>
-                                      Some(baseSources.pathFor(baseSection))
+                                      Some(baseSection)
                                     case Match.BaseAndRight(baseSection, _) =>
-                                      Some(baseSources.pathFor(baseSection))
+                                      Some(baseSection)
                                     case _ => None
-                                  val pathOnLeft = aMatch match
+                                  ).map(baseSources.pathFor)
+                                  val pathOnLeft = (aMatch match
                                     case Match.AllSides(_, leftSection, _) =>
-                                      Some(leftSources.pathFor(leftSection))
+                                      Some(leftSection)
                                     case Match.BaseAndLeft(_, leftSection) =>
-                                      Some(leftSources.pathFor(leftSection))
+                                      Some(leftSection)
                                     case Match.LeftAndRight(leftSection, _) =>
-                                      Some(leftSources.pathFor(leftSection))
+                                      Some(leftSection)
                                     case _ => None
-                                  val pathOnRight = aMatch match
+                                  ).map(leftSources.pathFor)
+                                  val pathOnRight = (aMatch match
                                     case Match.AllSides(_, _, rightSection) =>
-                                      Some(rightSources.pathFor(rightSection))
+                                      Some(rightSection)
                                     case Match.BaseAndRight(_, rightSection) =>
-                                      Some(rightSources.pathFor(rightSection))
+                                      Some(rightSection)
                                     case Match.LeftAndRight(_, rightSection) =>
-                                      Some(rightSources.pathFor(rightSection))
+                                      Some(rightSection)
                                     case _ => None
+                                  ).map(rightSources.pathFor)
                                   (pathOnBase, pathOnLeft, pathOnRight)
                               }
 
@@ -1678,31 +1681,40 @@ object MatchAnalysis extends StrictLogging:
               .mapValues(_.map(_._1))
 
           matchesByGroupId.foreach { case (groupId, matchesInGroup) =>
-            val basePaths = matchesInGroup.collect {
-              case Match.AllSides(baseSection, _, _)  => baseSources.pathFor(baseSection)
-              case Match.BaseAndLeft(baseSection, _)  => baseSources.pathFor(baseSection)
-              case Match.BaseAndRight(baseSection, _) => baseSources.pathFor(baseSection)
-            }.toSet
+            val basePaths = matchesInGroup
+              .collect {
+                case Match.AllSides(baseSection, _, _)  => baseSection
+                case Match.BaseAndLeft(baseSection, _)  => baseSection
+                case Match.BaseAndRight(baseSection, _) => baseSection
+              }
+              .map(baseSources.pathFor)
+              .toSet
             assert(
               basePaths.size <= 1,
               s"Group $groupId has multiple base paths: $basePaths"
             )
 
-            val leftPaths = matchesInGroup.collect {
-              case Match.AllSides(_, leftSection, _)  => leftSources.pathFor(leftSection)
-              case Match.BaseAndLeft(_, leftSection)  => leftSources.pathFor(leftSection)
-              case Match.LeftAndRight(leftSection, _) => leftSources.pathFor(leftSection)
-            }.toSet
+            val leftPaths = matchesInGroup
+              .collect {
+                case Match.AllSides(_, leftSection, _)  => leftSection
+                case Match.BaseAndLeft(_, leftSection)  => leftSection
+                case Match.LeftAndRight(leftSection, _) => leftSection
+              }
+              .map(leftSources.pathFor)
+              .toSet
             assert(
               leftPaths.size <= 1,
               s"Group $groupId has multiple left paths: $leftPaths"
             )
 
-            val rightPaths = matchesInGroup.collect {
-              case Match.AllSides(_, _, rightSection) => rightSources.pathFor(rightSection)
-              case Match.BaseAndRight(_, rightSection) => rightSources.pathFor(rightSection)
-              case Match.LeftAndRight(_, rightSection) => rightSources.pathFor(rightSection)
-            }.toSet
+            val rightPaths = matchesInGroup
+              .collect {
+                case Match.AllSides(_, _, rightSection)  => rightSection
+                case Match.BaseAndRight(_, rightSection) => rightSection
+                case Match.LeftAndRight(_, rightSection) => rightSection
+              }
+              .map(rightSources.pathFor)
+              .toSet
             assert(
               rightPaths.size <= 1,
               s"Group $groupId has multiple right paths: $rightPaths"

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -736,13 +736,13 @@ object MatchAnalysis extends StrictLogging:
               parallelMatchesGroupIdsByMatch <- State
                 .get[GroupsOfParallelMatches]
 
-              matchesBySortedBiteEdge = SortedMap.from(bites.flatMap {
+              groupIdsBySortedBiteEdge = SortedMap.from(bites.flatMap {
                 case (allSides, biteStart, biteEnd) =>
                   Seq(biteStart, biteEnd)
                     .map(_ -> parallelMatchesGroupIdsByMatch.get(allSides))
               })
 
-              sortedBiteEdges = matchesBySortedBiteEdge.keySet
+              sortedBiteEdges = groupIdsBySortedBiteEdge.keySet
 
               fragmentsFromPairwiseMatch: Seq[PairwiseMatch] =
                 pairwiseMatch match

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1684,48 +1684,73 @@ object MatchAnalysis extends StrictLogging:
                   firstSideStartOffset: GenericMatch[Element] => Option[Int],
                   secondSideStartOffset: GenericMatch[Element] => Option[Int]
               ): Unit =
-                val commonMatches = matchesInGroup.filter(aMatch =>
-                  firstSideStartOffset(aMatch).isDefined &&
-                    secondSideStartOffset(aMatch).isDefined
-                )
+                extension (matches: Seq[GenericMatch[Element]])
+                  private def sortBySide(
+                      startOffsetOf: GenericMatch[Element] => Option[Int]
+                  ): Seq[GenericMatch[Element]] =
+                    matches
+                      .flatMap(aMatch =>
+                        startOffsetOf(aMatch)
+                          .map(offset => aMatch -> offset)
+                      )
+                      .sortBy(_._2)
+                      .map(_._1)
+                end extension
 
-                if commonMatches.size > 1 then
-                  // Canonical order to break ties in a way that is consistent
-                  // across all sides.
-                  val commonMatchesInCanonicalOrder =
-                    commonMatches.toSeq.sortBy(MatchSynopsis.apply(_).toString)
+                // NOTE: in the next two bindings, we have to sort first
+                // according to the other side's perspective. This is to avoid
+                // situations where several matches happen to have the same
+                // start off set on one side but different offsets on the other.
+                // As sorting is stable, that could lead to the side with
+                // colliding offsets having the 'wrong' initial order that would
+                // be preserved by the sort. Tip of the hat to Jules for
+                // suggesting the pitfall in the first place.
 
-                  val commonMatchesOrderedFromFirstSidePerspective =
-                    commonMatchesInCanonicalOrder
-                      .sortBy(aMatch => firstSideStartOffset(aMatch).get)
-                  val commonMatchesOrderedFromSecondSidePerspective =
-                    commonMatchesInCanonicalOrder
-                      .sortBy(aMatch => secondSideStartOffset(aMatch).get)
+                val matchesOrderedFromFirstSidePerspective =
+                  matchesInGroup
+                    .sortBySide(secondSideStartOffset)
+                    .sortBySide(firstSideStartOffset)
 
-                  assert(
-                    commonMatchesOrderedFromFirstSidePerspective == commonMatchesOrderedFromSecondSidePerspective,
-                    s"""
-                       |Expected a consistent ordering of matches relevant to the sides $firstSide and $secondSide.
-                       |Total of ${commonMatches.size} common matches, up to 10 follow...
-                       |On the $firstSide they are:
-                       |${pprintCustomised(
-                        commonMatchesOrderedFromFirstSidePerspective
-                          .take(10)
-                          .map(
-                            MatchSynopsis.apply
-                          )
-                      )}
-                       |and on the $secondSide they are:
-                       |${pprintCustomised(
-                        commonMatchesOrderedFromSecondSidePerspective
-                          .take(10)
-                          .map(
-                            MatchSynopsis.apply
-                          )
-                      )}
-                       |""".stripMargin
+                val matchesOrderedFromSecondSidePerspective =
+                  matchesInGroup
+                    .sortBySide(firstSideStartOffset)
+                    .sortBySide(secondSideStartOffset)
+
+                val commonMatches =
+                  matchesOrderedFromFirstSidePerspective.toSet intersect matchesOrderedFromSecondSidePerspective.toSet
+
+                val commonMatchesOrderedFromFirstSidePerspective =
+                  matchesOrderedFromFirstSidePerspective.filter(
+                    commonMatches.contains
                   )
-                end if
+                val commonMatchesOrderedFromSecondSidePerspective =
+                  matchesOrderedFromSecondSidePerspective.filter(
+                    commonMatches.contains
+                  )
+
+                assert(
+                  commonMatchesOrderedFromFirstSidePerspective == commonMatchesOrderedFromSecondSidePerspective,
+                  s"""
+                     |Expected a consistent ordering of matches relevant to the sides $firstSide and $secondSide.
+                     |Total of ${commonMatches.size} common matches, up to 10 follow...
+                     |On the $firstSide they are:
+                     |${pprintCustomised(
+                      commonMatchesOrderedFromFirstSidePerspective
+                        .take(10)
+                        .map(
+                          MatchSynopsis.apply
+                        )
+                    )}
+                     |and on the $secondSide they are:
+                     |${pprintCustomised(
+                      commonMatchesOrderedFromSecondSidePerspective
+                        .take(10)
+                        .map(
+                          MatchSynopsis.apply
+                        )
+                    )}
+                     |""".stripMargin
+                )
               end checkOrderIsConsistentAcrossSides
 
               checkOrderIsConsistentAcrossSides(

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1186,99 +1186,6 @@ object MatchAnalysis extends StrictLogging:
         end if
       end purgedOfMatchesWithOverlappingSections
 
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(allSides)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
-            )
-        }
-      end withoutTheseMatches
-
       def reconcileMatches: MatchesAndTheirSections =
         val matches = sectionsAndTheirMatches.values.toSet
 
@@ -1681,22 +1588,33 @@ object MatchAnalysis extends StrictLogging:
                   firstSideStartOffset: GenericMatch[Element] => Option[Int],
                   secondSideStartOffset: GenericMatch[Element] => Option[Int]
               ): Unit =
+                def sortBy(
+                    startOffsetOf: GenericMatch[Element] => Option[
+                      ParallelMatchesGroupId
+                    ]
+                ): Seq[GenericMatch[Element]] =
+                  matchesInGroup
+                    .flatMap(aMatch =>
+                      startOffsetOf(aMatch)
+                        .map(offset => aMatch -> offset)
+                    )
+                    .sortBy(_._2)
+                    .map(_._1)
+
+                // NOTE: in the next two bindings, we have to sort first
+                // according to the other side's perspective. This is to avoid
+                // situations where several matches happen to have the same
+                // start offset on one side but different offsets on the other.
+                // As sorting is stable, that could lead to the side with
+                // colliding offsets having the 'wrong' initial order that would
+                // be preserved by the sort. Tip of the hat to Jules for
+                // spotting the pitfall in the first place.
+
                 val matchesOrderedFromFirstSidePerspective =
-                  matchesInGroup
-                    .flatMap(aMatch =>
-                      firstSideStartOffset(aMatch)
-                        .map(offset => aMatch -> offset)
-                    )
-                    .sortBy(_._2)
-                    .map(_._1)
+                  sortBy(secondSideStartOffset).sortBy(firstSideStartOffset)
+
                 val matchesOrderedFromSecondSidePerspective =
-                  matchesInGroup
-                    .flatMap(aMatch =>
-                      secondSideStartOffset(aMatch)
-                        .map(offset => aMatch -> offset)
-                    )
-                    .sortBy(_._2)
-                    .map(_._1)
+                  sortBy(firstSideStartOffset).sortBy(secondSideStartOffset)
 
                 val commonMatches =
                   matchesOrderedFromFirstSidePerspective.toSet intersect matchesOrderedFromSecondSidePerspective.toSet
@@ -2301,6 +2219,99 @@ object MatchAnalysis extends StrictLogging:
 
         withoutTheseMatches(redundantMatches)
       end withoutRedundantPairwiseMatches
+
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(allSides)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
+            )
+        }
+      end withoutTheseMatches
 
       private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
         aMatch match

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -25,7 +25,7 @@ import de.sciss.fingertree.RangedSeq
 
 import java.lang.Byte as JavaByte
 import scala.annotation.tailrec
-import scala.collection.immutable.{MultiDict, SortedMultiSet}
+import scala.collection.immutable.{MultiDict, SortedMap, SortedMultiSet}
 import scala.collection.mutable
 import scala.collection.parallel.CollectionConverters.*
 import scala.util.{Success, Using}
@@ -183,11 +183,15 @@ object MatchAnalysis extends StrictLogging:
 
     type ParallelMatchesGroupId = Int
 
+    type GroupsOfParallelMatches =
+      MultiDict[GenericMatch[Element], ParallelMatchesGroupId]
+
     val tiebreakContentSamplingLimit = 5
 
     object MatchesAndTheirSections:
       type ParallelMatchesGroupIdTracking[X] =
-        State[MultiDict[GenericMatch[Element], ParallelMatchesGroupId], X]
+        State[GroupsOfParallelMatches, X]
+
       lazy val empty: MatchesAndTheirSections = MatchesAndTheirSections(
         baseSectionsByPath = Map.empty,
         leftSectionsByPath = Map.empty,
@@ -228,6 +232,35 @@ object MatchAnalysis extends StrictLogging:
           }.get
         else empty
       end withAllMatchesOfAtLeastTheSureFireWindowSize
+
+      given Ordering[BiteEdge] = Ordering.fromLessThan {
+        case (
+              BiteEdge.Start(startOffset),
+              BiteEdge.End(onePastEndOffset)
+            ) =>
+          // Bites should have positive width, so that way a start comes
+          // strictly before the end of its bite.
+          startOffset < onePastEndOffset
+        case (
+              BiteEdge.End(onePastEndOffset),
+              BiteEdge.Start(startOffset)
+            ) =>
+          // If two bites abut, then the end position of the preceding bite
+          // will be equal to the start position of the following bite.
+          onePastEndOffset <= startOffset
+        case (
+              BiteEdge.Start(firstStartOffset),
+              BiteEdge.Start(secondStartOffset)
+            ) =>
+          // Bites should have positive width, so this is a strict equality.
+          firstStartOffset < secondStartOffset
+        case (
+              BiteEdge.End(firstOnePastEndOffset),
+              BiteEdge.End(secondOnePastEndOffset)
+            ) =>
+          // Bites should have positive width, so this is a strict equality.
+          firstOnePastEndOffset < secondOnePastEndOffset
+      }
 
       private def fingerprintedInclusionsByPath(
           sources: Sources[Path, Element]
@@ -694,92 +727,69 @@ object MatchAnalysis extends StrictLogging:
       ): ParallelMatchesGroupIdTracking[Set[PairwiseMatch]] =
         pairwiseMatchesToBeEaten.sets.toSeq
           .flatTraverse { case (pairwiseMatch, bites) =>
-            val sortedBiteEdges = sortedBiteEdgesFrom(bites.flatMap {
-              case (_, biteStart, biteEnd) => Seq(biteStart, biteEnd)
-            })
+            for
+              parallelMatchesGroupIdsByMatch <- State
+                .get[GroupsOfParallelMatches]
 
-            val fragmentsFromPairwiseMatch: Seq[PairwiseMatch] =
-              pairwiseMatch match
-                case Match.BaseAndLeft(baseSection, leftSection) =>
-                  (eatIntoSection(
-                    baseSources,
-                    sortedBiteEdges
-                  )(
-                    baseSection
-                  ) zip eatIntoSection(
-                    leftSources,
-                    sortedBiteEdges
-                  )(
-                    leftSection
-                  ))
-                    .map(Match.BaseAndLeft.apply)
+              matchesBySortedBiteEdge = SortedMap.from(bites.flatMap {
+                case (allSides, biteStart, biteEnd) =>
+                  Seq(biteStart, biteEnd)
+                    .map(_ -> parallelMatchesGroupIdsByMatch.get(allSides))
+              })
 
-                case Match.BaseAndRight(baseSection, rightSection) =>
-                  (eatIntoSection(
-                    baseSources,
-                    sortedBiteEdges
-                  )(
-                    baseSection
-                  ) zip eatIntoSection(
-                    rightSources,
-                    sortedBiteEdges
-                  )(
-                    rightSection
-                  )).map(Match.BaseAndRight.apply)
+              sortedBiteEdges = matchesBySortedBiteEdge.keySet.toSeq
 
-                case Match.LeftAndRight(leftSection, rightSection) =>
-                  (eatIntoSection(
-                    leftSources,
-                    sortedBiteEdges
-                  )(
-                    leftSection
-                  ) zip eatIntoSection(
-                    rightSources,
-                    sortedBiteEdges
-                  )(
-                    rightSection
-                  )).map(Match.LeftAndRight.apply)
+              fragmentsFromPairwiseMatch: Seq[PairwiseMatch] =
+                pairwiseMatch match
+                  case Match.BaseAndLeft(baseSection, leftSection) =>
+                    (eatIntoSection(
+                      baseSources,
+                      sortedBiteEdges
+                    )(
+                      baseSection
+                    ) zip eatIntoSection(
+                      leftSources,
+                      sortedBiteEdges
+                    )(
+                      leftSection
+                    ))
+                      .map(Match.BaseAndLeft.apply)
 
-            logger.debug(
-              s"Eating into pairwise match:\n${pprintCustomised(pairwiseMatch)} on behalf of all-sides matches:\n${pprintCustomised(bites)}, resulting in fragments:\n${pprintCustomised(fragmentsFromPairwiseMatch)}"
-            )
+                  case Match.BaseAndRight(baseSection, rightSection) =>
+                    (eatIntoSection(
+                      baseSources,
+                      sortedBiteEdges
+                    )(
+                      baseSection
+                    ) zip eatIntoSection(
+                      rightSources,
+                      sortedBiteEdges
+                    )(
+                      rightSection
+                    )).map(Match.BaseAndRight.apply)
 
-            recordReplacements(
-              pairwiseMatch,
+                  case Match.LeftAndRight(leftSection, rightSection) =>
+                    (eatIntoSection(
+                      leftSources,
+                      sortedBiteEdges
+                    )(
+                      leftSection
+                    ) zip eatIntoSection(
+                      rightSources,
+                      sortedBiteEdges
+                    )(
+                      rightSection
+                    )).map(Match.LeftAndRight.apply)
+                    
+              _ <- recordReplacements(pairwiseMatch, fragmentsFromPairwiseMatch)
+            yield
+              logger.debug(
+                s"Eating into pairwise match:\n${pprintCustomised(pairwiseMatch)} on behalf of all-sides matches:\n${pprintCustomised(bites)}, resulting in fragments:\n${pprintCustomised(fragmentsFromPairwiseMatch)}"
+              )
+
               fragmentsFromPairwiseMatch
-            ) as fragmentsFromPairwiseMatch
           }
           .map(_.toSet)
-
-      def sortedBiteEdgesFrom(bites: collection.Set[BiteEdge]): Seq[BiteEdge] =
-        bites.toSeq.sortWith {
-          case (
-                BiteEdge.Start(startOffset),
-                BiteEdge.End(onePastEndOffset)
-              ) =>
-            // Bites should have positive width, so that way a start comes
-            // strictly before the end of its bite.
-            startOffset < onePastEndOffset
-          case (
-                BiteEdge.End(onePastEndOffset),
-                BiteEdge.Start(startOffset)
-              ) =>
-            // If two bites abut, then the end position of the preceding bite
-            // will be equal to the start position of the following bite.
-            onePastEndOffset <= startOffset
-          case (
-                BiteEdge.Start(firstStartOffset),
-                BiteEdge.Start(secondStartOffset)
-              ) =>
-            // Bites should have positive width, so this is a strict equality.
-            firstStartOffset < secondStartOffset
-          case (
-                BiteEdge.End(firstOnePastEndOffset),
-                BiteEdge.End(secondOnePastEndOffset)
-              ) =>
-            // Bites should have positive width, so this is a strict equality.
-            firstOnePastEndOffset < secondOnePastEndOffset
-        }
 
       // Breaks up a section by eating into it with smaller bites, yielding the
       // fragment sections.
@@ -935,9 +945,7 @@ object MatchAnalysis extends StrictLogging:
         baseFingerprintedInclusionsByPath: Map[Path, FingerprintedInclusions],
         leftFingerprintedInclusionsByPath: Map[Path, FingerprintedInclusions],
         rightFingerprintedInclusionsByPath: Map[Path, FingerprintedInclusions],
-        parallelMatchesGroupIdsByMatch: MultiDict[GenericMatch[
-          Element
-        ], ParallelMatchesGroupId]
+        parallelMatchesGroupIdsByMatch: GroupsOfParallelMatches
     ) extends MatchAnalysis[Path, Element]:
       import MatchesAndTheirSections.*
 
@@ -1388,6 +1396,499 @@ object MatchAnalysis extends StrictLogging:
         result
 
       end reconcileMatches
+
+      def parallelMatchesOnly: MatchesAndTheirSections =
+        // PLAN:
+
+        // 1. Build up sources composed of matched sections concatenated
+        // together by path preserving their original order.
+
+        val baseMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(baseSection, _, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndLeft(baseSection, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndRight(baseSection, _))
+                  if section == baseSection =>
+                section
+            }
+
+        val leftMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, leftSection, _))
+                  if section == leftSection =>
+                section
+              case (section, Match.BaseAndLeft(_, leftSection))
+                  if section == leftSection =>
+                section
+              case (section, Match.LeftAndRight(leftSection, _))
+                  if section == leftSection =>
+                section
+            }
+
+        val rightMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, _, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.BaseAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.LeftAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+            }
+
+        case class MetaMatchContentSources(
+            override val contentsByPath: Map[Path, IndexedSeq[
+              Section[Element]
+            ]],
+            override val label: String
+        ) extends MappedContentSources[Path, Section[Element]]
+
+        def sourcesForMetaMatching(label: String)(
+            sources: Sources[Path, Element],
+            matchedSections: Iterable[Section[Element]]
+        ) = MetaMatchContentSources(
+          contentsByPath = matchedSections
+            .groupBy(sources.pathFor)
+            .map((path, sections) =>
+              path -> sections.toIndexedSeq.sortBy(_.startOffset)
+            ),
+          label = label
+        )
+
+        val baseSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-base")(
+            baseSources,
+            baseMatchedSections
+          )
+        val leftSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-left")(
+            leftSources,
+            leftMatchedSections
+          )
+        val rightSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-right")(
+            rightSources,
+            rightMatchedSections
+          )
+
+        // 2. Apply `MatchAnalysis.of` to these sections, using the
+        // potential match key of the section to underpin equality and
+        // hashing.
+
+        object metaMatchConfiguration extends AbstractConfiguration:
+          override val minimumMatchSize: Int                    = 1
+          override val thresholdSizeFractionForMatching: Double = 0
+          override val minimumAmbiguousMatchSize: Int           = 1
+          override val ambiguousMatchesThreshold: Int           = Int.MaxValue
+          override val progressRecording: ProgressRecording     =
+            configuration.progressRecording
+        end metaMatchConfiguration
+
+        given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
+
+        given Funnel[Section[Element]] with
+          override def funnel(
+              from: Section[Element],
+              into: PrimitiveSink
+          ): Unit =
+            from.content.foreach(summon[Funnel[Element]].funnel(_, into))
+
+        end given
+
+        val metaMatchAnalysis = of(
+          baseSourcesForMetaMatching,
+          leftSourcesForMetaMatching,
+          rightSourcesForMetaMatching
+        )(metaMatchConfiguration)
+
+        // 3. The resulting meta-matches provide parallel sequences of sections
+        // that are unzipped to yield corresponding all-sides and pairwise
+        // matches.
+
+        val metaMatches = metaMatchAnalysis.matches
+
+        // NOTE: because meta-matching starts with matched *sections* and
+        // ignores gaps, we have to guard against sections that would have
+        // formed the sides of a suppressed outer match making a second attempt
+        // at building a match.
+        val groupsOfBackTranslatedParallelMatches = metaMatches
+          .map {
+            case Match.AllSides(
+                  baseMetaSection,
+                  leftMetaSection,
+                  rightMetaSection
+                ) =>
+              (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (baseSection, leftSection, rightSection)
+                      if !isSubsumedNonTriviallyByAnAllSidesMatch(
+                        baseSection,
+                        leftSection,
+                        rightSection
+                      ) =>
+                    Match.AllSides(baseSection, leftSection, rightSection)
+                }
+            case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
+              (baseMetaSection.content lazyZip leftMetaSection.content)
+                .collect {
+                  case (baseSection, leftSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+                        baseSection,
+                        leftSection
+                      ) =>
+                    Match.BaseAndLeft(baseSection, leftSection)
+                }
+            case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
+              (baseMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (baseSection, rightSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+                        baseSection,
+                        rightSection
+                      ) =>
+                    Match.BaseAndRight(baseSection, rightSection)
+                }
+            case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
+              (leftMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (leftSection, rightSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+                        leftSection,
+                        rightSection
+                      ) =>
+                    Match.LeftAndRight(leftSection, rightSection)
+                }
+          }
+          .filter(_.nonEmpty)
+          .toSeq
+
+        // 4. Put the back-translated matches into their own disjoint sets, then
+        // unify those matches that come from the same group of parallel
+        // matches, then unify all-sides matches with pairwise matches that
+        // subsume them, regardless of the original group.
+
+        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
+        // the back-translated matches, because the thinning out of ambiguous
+        // matches performed by the meta-matching and back translation above
+        // means there are new opportunities for matches to be generated - while
+        // the vast majority of these are redundant pairwise matches, there are
+        // some that are vital to capture things such as moves with migrated
+        // edits / deletions - the test
+        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
+        // an example of this.
+        val backTranslatedMatchesAndTheirSections =
+          MatchesAndTheirSections.empty
+            .withMatches(
+              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
+              haveTrimmedMatches = false
+            )
+            .matchesAndTheirSections
+            .withoutRedundantPairwiseMatches
+
+        val backTranslatedMatches =
+          backTranslatedMatchesAndTheirSections.matches
+
+        val parallelMatchesGroupIdsByMatch =
+          MultiDict.from(
+            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
+              (parallelMatches, groupId) => parallelMatches.map(_ -> groupId)
+            )
+          )
+
+        backTranslatedMatchesAndTheirSections
+          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
+      end parallelMatchesOnly
+
+      // Cleans up the state when a putative all-sides match that would have
+      // been ambiguous on one side with another all-sides match was partially
+      // suppressed by a larger pairwise match. This situation results in a
+      // pairwise match that shares its sections on both sides with the other
+      // all-sides match; remove any such redundant pairwise matches.
+      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
+        val redundantMatches =
+          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
+
+        if redundantMatches.nonEmpty then
+          logger.debug(
+            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
+          )
+        end if
+
+        withoutTheseMatches(redundantMatches)
+      end withoutRedundantPairwiseMatches
+
+      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
+        aMatch match
+          case Match.BaseAndLeft(baseSection, leftSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(leftSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.BaseAndRight(baseSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.LeftAndRight(leftSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(leftSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case _: Match.AllSides[Section[Element]] => false
+
+      private def isSubsumedNonTriviallyByAnAllSidesMatch(
+          baseSection: Section[Element],
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAnAllSidesMatch
+
+      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+          baseSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+          baseSection: Section[Element],
+          leftSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
+
+      private def withMatches(
+          matches: Set[GenericMatch[Element]],
+          haveTrimmedMatches: Boolean
+      ): MatchingResult =
+        val updatedMatchesAndTheirSections =
+          matches.foldLeft(this)(_ withMatch _)
+
+        val pathInclusions =
+          if !haveTrimmedMatches then
+            case class PathInclusionsImplementation(
+                basePaths: Set[Path],
+                leftPaths: Set[Path],
+                rightPaths: Set[Path]
+            ) extends PathInclusions:
+              override def isIncludedOnBase(basePath: Path): Boolean =
+                basePaths.contains(basePath)
+
+              override def isIncludedOnLeft(leftPath: Path): Boolean =
+                leftPaths.contains(leftPath)
+
+              override def isIncludedOnRight(rightPath: Path): Boolean =
+                rightPaths.contains(rightPath)
+
+              def addPathOnBaseFor(
+                  baseSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
+              def addPathOnLeftFor(
+                  leftSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
+              def addPathOnRightFor(
+                  rightSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(rightPaths =
+                  rightPaths + rightSources.pathFor(rightSection)
+                )
+            end PathInclusionsImplementation
+
+            matches.foldLeft(
+              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
+            )((partialPathInclusions, aMatch) =>
+              aMatch match
+                case Match.AllSides(baseSection, leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.BaseAndLeft(baseSection, leftSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                case Match.BaseAndRight(baseSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.LeftAndRight(leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+            )
+          else PathInclusions.all
+
+        MatchingResult(
+          matchesAndTheirSections = updatedMatchesAndTheirSections,
+          numberOfMatchesForTheGivenWindowSize = matches.size,
+          estimatedWindowSizeForOptimalMatch =
+            estimateOptimalMatchSize(matches),
+          pathInclusions = pathInclusions
+        )
+      end withMatches
+
+      private def withMatch(
+          aMatch: GenericMatch[Element]
+      ): MatchesAndTheirSections =
+        aMatch match
+          case Match.AllSides(baseSection, leftSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
+              baseFingerprintedInclusionsByPath =
+                knockOutFromBaseFingerprintedInclusions(baseSection),
+              leftFingerprintedInclusionsByPath =
+                knockOutFromLeftFingerprintedInclusions(leftSection),
+              rightFingerprintedInclusionsByPath =
+                knockOutFromRightFingerprintedInclusions(rightSection)
+            )
+          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
+            )
+          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
+            )
+          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
+            copy(
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
+            )
+        end match
+      end withMatch
 
       private def checkInvariant(): Unit =
         // We expect to tally either two lots of a given pairwise match or three
@@ -2029,499 +2530,6 @@ object MatchAnalysis extends StrictLogging:
             )
         }
       end pairwiseMatchesSubsumingOnBothSidesWithBiteEdges
-
-      def parallelMatchesOnly: MatchesAndTheirSections =
-        // PLAN:
-
-        // 1. Build up sources composed of matched sections concatenated
-        // together by path preserving their original order.
-
-        val baseMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(baseSection, _, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndLeft(baseSection, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndRight(baseSection, _))
-                  if section == baseSection =>
-                section
-            }
-
-        val leftMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, leftSection, _))
-                  if section == leftSection =>
-                section
-              case (section, Match.BaseAndLeft(_, leftSection))
-                  if section == leftSection =>
-                section
-              case (section, Match.LeftAndRight(leftSection, _))
-                  if section == leftSection =>
-                section
-            }
-
-        val rightMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, _, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.BaseAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.LeftAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-            }
-
-        case class MetaMatchContentSources(
-            override val contentsByPath: Map[Path, IndexedSeq[
-              Section[Element]
-            ]],
-            override val label: String
-        ) extends MappedContentSources[Path, Section[Element]]
-
-        def sourcesForMetaMatching(label: String)(
-            sources: Sources[Path, Element],
-            matchedSections: Iterable[Section[Element]]
-        ) = MetaMatchContentSources(
-          contentsByPath = matchedSections
-            .groupBy(sources.pathFor)
-            .map((path, sections) =>
-              path -> sections.toIndexedSeq.sortBy(_.startOffset)
-            ),
-          label = label
-        )
-
-        val baseSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-base")(
-            baseSources,
-            baseMatchedSections
-          )
-        val leftSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-left")(
-            leftSources,
-            leftMatchedSections
-          )
-        val rightSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-right")(
-            rightSources,
-            rightMatchedSections
-          )
-
-        // 2. Apply `MatchAnalysis.of` to these sections, using the
-        // potential match key of the section to underpin equality and
-        // hashing.
-
-        object metaMatchConfiguration extends AbstractConfiguration:
-          override val minimumMatchSize: Int                    = 1
-          override val thresholdSizeFractionForMatching: Double = 0
-          override val minimumAmbiguousMatchSize: Int           = 1
-          override val ambiguousMatchesThreshold: Int           = Int.MaxValue
-          override val progressRecording: ProgressRecording     =
-            configuration.progressRecording
-        end metaMatchConfiguration
-
-        given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
-
-        given Funnel[Section[Element]] with
-          override def funnel(
-              from: Section[Element],
-              into: PrimitiveSink
-          ): Unit =
-            from.content.foreach(summon[Funnel[Element]].funnel(_, into))
-
-        end given
-
-        val metaMatchAnalysis = of(
-          baseSourcesForMetaMatching,
-          leftSourcesForMetaMatching,
-          rightSourcesForMetaMatching
-        )(metaMatchConfiguration)
-
-        // 3. The resulting meta-matches provide parallel sequences of sections
-        // that are unzipped to yield corresponding all-sides and pairwise
-        // matches.
-
-        val metaMatches = metaMatchAnalysis.matches
-
-        // NOTE: because meta-matching starts with matched *sections* and
-        // ignores gaps, we have to guard against sections that would have
-        // formed the sides of a suppressed outer match making a second attempt
-        // at building a match.
-        val groupsOfBackTranslatedParallelMatches = metaMatches
-          .map {
-            case Match.AllSides(
-                  baseMetaSection,
-                  leftMetaSection,
-                  rightMetaSection
-                ) =>
-              (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAnAllSidesMatch(
-                        baseSection,
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.AllSides(baseSection, leftSection, rightSection)
-                }
-            case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
-              (baseMetaSection.content lazyZip leftMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-                        baseSection,
-                        leftSection
-                      ) =>
-                    Match.BaseAndLeft(baseSection, leftSection)
-                }
-            case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
-              (baseMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-                        baseSection,
-                        rightSection
-                      ) =>
-                    Match.BaseAndRight(baseSection, rightSection)
-                }
-            case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
-              (leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.LeftAndRight(leftSection, rightSection)
-                }
-          }
-          .filter(_.nonEmpty)
-          .toSeq
-
-        // 4. Put the back-translated matches into their own disjoint sets, then
-        // unify those matches that come from the same group of parallel
-        // matches, then unify all-sides matches with pairwise matches that
-        // subsume them, regardless of the original group.
-
-        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
-        // the back-translated matches, because the thinning out of ambiguous
-        // matches performed by the meta-matching and back translation above
-        // means there are new opportunities for matches to be generated - while
-        // the vast majority of these are redundant pairwise matches, there are
-        // some that are vital to capture things such as moves with migrated
-        // edits / deletions - the test
-        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
-        // an example of this.
-        val backTranslatedMatchesAndTheirSections =
-          MatchesAndTheirSections.empty
-            .withMatches(
-              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
-              haveTrimmedMatches = false
-            )
-            .matchesAndTheirSections
-            .withoutRedundantPairwiseMatches
-
-        val backTranslatedMatches =
-          backTranslatedMatchesAndTheirSections.matches
-
-        val parallelMatchesGroupIdsByMatch =
-          MultiDict.from(
-            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
-              (parallelMatches, groupId) => parallelMatches.map(_ -> groupId)
-            )
-          )
-
-        backTranslatedMatchesAndTheirSections
-          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
-      end parallelMatchesOnly
-
-      // Cleans up the state when a putative all-sides match that would have
-      // been ambiguous on one side with another all-sides match was partially
-      // suppressed by a larger pairwise match. This situation results in a
-      // pairwise match that shares its sections on both sides with the other
-      // all-sides match; remove any such redundant pairwise matches.
-      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
-        val redundantMatches =
-          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
-
-        if redundantMatches.nonEmpty then
-          logger.debug(
-            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
-          )
-        end if
-
-        withoutTheseMatches(redundantMatches)
-      end withoutRedundantPairwiseMatches
-
-      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
-        aMatch match
-          case Match.BaseAndLeft(baseSection, leftSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(leftSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.BaseAndRight(baseSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.LeftAndRight(leftSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(leftSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case _: Match.AllSides[Section[Element]] => false
-
-      private def isSubsumedNonTriviallyByAnAllSidesMatch(
-          baseSection: Section[Element],
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAnAllSidesMatch
-
-      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-          baseSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-          baseSection: Section[Element],
-          leftSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
-
-      private def withMatches(
-          matches: Set[GenericMatch[Element]],
-          haveTrimmedMatches: Boolean
-      ): MatchingResult =
-        val updatedMatchesAndTheirSections =
-          matches.foldLeft(this)(_ withMatch _)
-
-        val pathInclusions =
-          if !haveTrimmedMatches then
-            case class PathInclusionsImplementation(
-                basePaths: Set[Path],
-                leftPaths: Set[Path],
-                rightPaths: Set[Path]
-            ) extends PathInclusions:
-              override def isIncludedOnBase(basePath: Path): Boolean =
-                basePaths.contains(basePath)
-
-              override def isIncludedOnLeft(leftPath: Path): Boolean =
-                leftPaths.contains(leftPath)
-
-              override def isIncludedOnRight(rightPath: Path): Boolean =
-                rightPaths.contains(rightPath)
-
-              def addPathOnBaseFor(
-                  baseSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
-              def addPathOnLeftFor(
-                  leftSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
-              def addPathOnRightFor(
-                  rightSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(rightPaths =
-                  rightPaths + rightSources.pathFor(rightSection)
-                )
-            end PathInclusionsImplementation
-
-            matches.foldLeft(
-              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
-            )((partialPathInclusions, aMatch) =>
-              aMatch match
-                case Match.AllSides(baseSection, leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.BaseAndLeft(baseSection, leftSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                case Match.BaseAndRight(baseSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.LeftAndRight(leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-            )
-          else PathInclusions.all
-
-        MatchingResult(
-          matchesAndTheirSections = updatedMatchesAndTheirSections,
-          numberOfMatchesForTheGivenWindowSize = matches.size,
-          estimatedWindowSizeForOptimalMatch =
-            estimateOptimalMatchSize(matches),
-          pathInclusions = pathInclusions
-        )
-      end withMatches
-
-      private def withMatch(
-          aMatch: GenericMatch[Element]
-      ): MatchesAndTheirSections =
-        aMatch match
-          case Match.AllSides(baseSection, leftSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
-              baseFingerprintedInclusionsByPath =
-                knockOutFromBaseFingerprintedInclusions(baseSection),
-              leftFingerprintedInclusionsByPath =
-                knockOutFromLeftFingerprintedInclusions(leftSection),
-              rightFingerprintedInclusionsByPath =
-                knockOutFromRightFingerprintedInclusions(rightSection)
-            )
-          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
-            )
-          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
-            )
-          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
-            copy(
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
-            )
-        end match
-      end withMatch
 
       private def pairwiseMatchesSubsumingOnBothSides(
           allSides: Match.AllSides[Section[Element]]

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1650,8 +1650,9 @@ object MatchAnalysis extends StrictLogging:
                 basePaths.size <= 1,
                 s"""Base paths for a group of parallel matches should be the same,
                    |but vary: $basePaths.
-                   |Matches are: ${pprintCustomised(
-                    matchesInGroup.map(MatchSynopsis.apply)
+                   |Total of ${matchesInGroup.size} matches, up to 10 follow:
+                   |${pprintCustomised(
+                    matchesInGroup.take(10).map(MatchSynopsis.apply)
                   )}""".stripMargin
               )
 
@@ -1660,8 +1661,9 @@ object MatchAnalysis extends StrictLogging:
                 leftPaths.size <= 1,
                 s"""Left paths for a group of parallel matches should be the same,
                    |but vary: $leftPaths.
-                   |Matches are: ${pprintCustomised(
-                    matchesInGroup.map(MatchSynopsis.apply)
+                   |Total of ${matchesInGroup.size} matches, up to 10 follow:
+                   |${pprintCustomised(
+                    matchesInGroup.take(10).map(MatchSynopsis.apply)
                   )}""".stripMargin
               )
 
@@ -1670,8 +1672,9 @@ object MatchAnalysis extends StrictLogging:
                 rightPaths.size <= 1,
                 s"""Right paths for a group of parallel matches should be the same,
                    |but vary: $rightPaths.
-                   |Matches are: ${pprintCustomised(
-                    matchesInGroup.map(MatchSynopsis.apply)
+                   |Total of ${matchesInGroup.size} matches, up to 10 follow:
+                   |${pprintCustomised(
+                    matchesInGroup.take(10).map(MatchSynopsis.apply)
                   )}""".stripMargin
               )
 
@@ -1681,53 +1684,33 @@ object MatchAnalysis extends StrictLogging:
                   firstSideStartOffset: GenericMatch[Element] => Option[Int],
                   secondSideStartOffset: GenericMatch[Element] => Option[Int]
               ): Unit =
-                val matchesOrderedFromFirstSidePerspective =
-                  matchesInGroup
-                    .flatMap(aMatch =>
-                      firstSideStartOffset(aMatch)
-                        .map(offset => aMatch -> offset)
-                    )
-                    .sortBy(_._2)
-                    .map(_._1)
-                val matchesOrderedFromSecondSidePerspective =
-                  matchesInGroup
-                    .flatMap(aMatch =>
-                      secondSideStartOffset(aMatch)
-                        .map(offset => aMatch -> offset)
-                    )
-                    .sortBy(_._2)
-                    .map(_._1)
-
-                val commonMatches =
-                  matchesOrderedFromFirstSidePerspective.toSet intersect matchesOrderedFromSecondSidePerspective.toSet
-
-                val commonMatchesOrderedFromFirstSidePerspective =
-                  matchesOrderedFromFirstSidePerspective.filter(
-                    commonMatches.contains
-                  )
-                val commonMatchesOrderedFromSecondSidePerspective =
-                  matchesOrderedFromSecondSidePerspective.filter(
-                    commonMatches.contains
+                val matchesWithOffsets = matchesInGroup
+                  .flatMap(aMatch =>
+                    for
+                      offset1 <- firstSideStartOffset(aMatch)
+                      offset2 <- secondSideStartOffset(aMatch)
+                    yield (aMatch, offset1, offset2)
                   )
 
-                assert(
-                  commonMatchesOrderedFromFirstSidePerspective == commonMatchesOrderedFromSecondSidePerspective,
-                  s"""
-                     |Expected a consistent ordering of matches relevant to the sides $firstSide and $secondSide,
-                     |on the $firstSide they are:
-                     |${pprintCustomised(
-                      commonMatchesOrderedFromFirstSidePerspective.map(
-                        MatchSynopsis.apply
-                      )
-                    )}
-                     |and on the $secondSide they are:
-                     |${pprintCustomised(
-                      commonMatchesOrderedFromSecondSidePerspective.map(
-                        MatchSynopsis.apply
-                      )
-                    )}
-                     |""".stripMargin
-                )
+                for
+                  (matchA, offset1A, offset2A) <- matchesWithOffsets
+                  (matchB, offset1B, offset2B) <- matchesWithOffsets
+                  if matchA != matchB
+                  if offset1A <= offset1B
+                do
+                  assert(
+                    offset2A <= offset2B,
+                    s"""
+                       |Expected a consistent ordering of matches relevant to the sides $firstSide and $secondSide.
+                       |Total of ${matchesWithOffsets.size} common matches, up to 10 follow...
+                       |Relative order should be consistent between $firstSide and $secondSide,
+                       |but $matchA and $matchB are out of order.
+                       |Matches are:
+                       |${pprintCustomised(
+                        matchesWithOffsets.take(10).map(_._1).map(MatchSynopsis.apply)
+                      )}""".stripMargin
+                  )
+                end for
               end checkOrderIsConsistentAcrossSides
 
               checkOrderIsConsistentAcrossSides(

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -185,9 +185,14 @@ object MatchAnalysis extends StrictLogging:
 
     val tiebreakContentSamplingLimit = 5
 
+    val matchToId = mutable.Map.empty[GenericMatch[Element], Int]
+    given matchOrder: Order[GenericMatch[Element]] =
+      Order.by(m => matchToId.getOrElseUpdate(m, matchToId.size))
+
     object MatchesAndTheirSections:
+      type ParallelMatchesGrouping = DisjointSets[GenericMatch[Element]]
       type ParallelMatchesGroupIdTracking[X] =
-        State[Map[GenericMatch[Element], ParallelMatchesGroupId], X]
+        State[ParallelMatchesGrouping, X]
       lazy val empty: MatchesAndTheirSections = MatchesAndTheirSections(
         baseSectionsByPath = Map.empty,
         leftSectionsByPath = Map.empty,
@@ -761,13 +766,14 @@ object MatchAnalysis extends StrictLogging:
           original: GenericMatch[Element],
           replacement: GenericMatch[Element]
       ): ParallelMatchesGroupIdTracking[Unit] =
-        State.modify { groupIds =>
-          groupIds
-            .get(original)
-            .fold(ifEmpty = groupIds)(groupId =>
-              groupIds + (replacement -> groupId)
-            )
-        }
+        for
+          _ <- State.modify[ParallelMatchesGrouping](_ + replacement)
+          _ <- State.modify[ParallelMatchesGrouping](sets =>
+            if sets.contains(original) then
+              sets.union(original, replacement)._1
+            else sets
+          )
+        yield ()
 
       def sortedBiteEdgesFrom(bites: collection.Set[BiteEdge]): Seq[BiteEdge] =
         bites.toSeq.sortWith {
@@ -897,6 +903,10 @@ object MatchAnalysis extends StrictLogging:
         val minimumMatchSizeConsidered: Int
         def thresholdSize(fileSize: Int): Int
       end MatchSearchingContext
+
+      enum MatchSide:
+        case Base, Left, Right
+      end MatchSide
 
       enum BiteEdge:
         case Start(startOffsetRelativeToMeal: Int)
@@ -1279,6 +1289,142 @@ object MatchAnalysis extends StrictLogging:
         }
       end withoutTheseMatches
 
+      private def pathOnBase(aMatch: GenericMatch[Element]): Option[Path] =
+        aMatch match
+          case Match.AllSides(baseSection, _, _)  => Some(baseSources.pathFor(baseSection))
+          case Match.BaseAndLeft(baseSection, _)  => Some(baseSources.pathFor(baseSection))
+          case Match.BaseAndRight(baseSection, _) => Some(baseSources.pathFor(baseSection))
+          case _                                  => None
+
+      private def pathOnLeft(aMatch: GenericMatch[Element]): Option[Path] =
+        aMatch match
+          case Match.AllSides(_, leftSection, _)  => Some(leftSources.pathFor(leftSection))
+          case Match.BaseAndLeft(_, leftSection)  => Some(leftSources.pathFor(leftSection))
+          case Match.LeftAndRight(leftSection, _) => Some(leftSources.pathFor(leftSection))
+          case _                                  => None
+
+      private def pathOnRight(aMatch: GenericMatch[Element]): Option[Path] =
+        aMatch match
+          case Match.AllSides(_, _, rightSection) => Some(rightSources.pathFor(rightSection))
+          case Match.BaseAndRight(_, rightSection) => Some(rightSources.pathFor(rightSection))
+          case Match.LeftAndRight(_, rightSection) => Some(rightSources.pathFor(rightSection))
+          case _                                   => None
+
+      private def arePathCompatible(
+          first: GenericMatch[Element],
+          second: GenericMatch[Element]
+      ): Boolean =
+        val baseCompatible = (pathOnBase(first), pathOnBase(second)) match
+          case (Some(p1), Some(p2)) => p1 == p2
+          case _                    => true
+
+        val leftCompatible = (pathOnLeft(first), pathOnLeft(second)) match
+          case (Some(p1), Some(p2)) => p1 == p2
+          case _                    => true
+
+        val rightCompatible = (pathOnRight(first), pathOnRight(second)) match
+          case (Some(p1), Some(p2)) => p1 == p2
+          case _                    => true
+
+        baseCompatible && leftCompatible && rightCompatible
+      end arePathCompatible
+
+      private def sidesOf(
+          aMatch: GenericMatch[Element]
+      ): Set[MatchSide] = aMatch match
+        case _: Match.AllSides[Section[Element]] =>
+          Set(MatchSide.Base, MatchSide.Left, MatchSide.Right)
+        case _: Match.BaseAndLeft[Section[Element]] =>
+          Set(MatchSide.Base, MatchSide.Left)
+        case _: Match.BaseAndRight[Section[Element]] =>
+          Set(MatchSide.Base, MatchSide.Right)
+        case _: Match.LeftAndRight[Section[Element]] =>
+          Set(MatchSide.Left, MatchSide.Right)
+
+      private def offsetOf(aMatch: GenericMatch[Element], side: MatchSide): Int =
+        side match
+          case MatchSide.Base =>
+            aMatch match
+              case m: Match.AllSides[Section[Element]]     => m.baseElement.startOffset
+              case m: Match.BaseAndLeft[Section[Element]]  => m.baseElement.startOffset
+              case m: Match.BaseAndRight[Section[Element]] => m.baseElement.startOffset
+              case _ => throw new RuntimeException("Match doesn't have Base side")
+          case MatchSide.Left =>
+            aMatch match
+              case m: Match.AllSides[Section[Element]]     => m.leftElement.startOffset
+              case m: Match.BaseAndLeft[Section[Element]]  => m.leftElement.startOffset
+              case m: Match.LeftAndRight[Section[Element]] => m.leftElement.startOffset
+              case _ => throw new RuntimeException("Match doesn't have Left side")
+          case MatchSide.Right =>
+            aMatch match
+              case m: Match.AllSides[Section[Element]]      => m.rightElement.startOffset
+              case m: Match.BaseAndRight[Section[Element]] => m.rightElement.startOffset
+              case m: Match.LeftAndRight[Section[Element]] => m.rightElement.startOffset
+              case _ => throw new RuntimeException("Match doesn't have Right side")
+
+      private def isOrderConsistent(group: Iterable[GenericMatch[Element]]): Boolean =
+        val sides = Seq(MatchSide.Base, MatchSide.Left, MatchSide.Right)
+        val orderings = sides.flatMap { s =>
+          val matchesWithSide = group.filter(sidesOf(_).contains(s)).toSeq
+          if (matchesWithSide.size > 1) {
+            val sorted = matchesWithSide.sortBy(offsetOf(_, s))
+            Some(s -> sorted)
+          } else None
+        }.toMap
+
+        orderings.forall { case (s1, o1) =>
+          orderings.forall { case (s2, o2) =>
+            if (s1 == s2) true
+            else {
+              val common = o1.filter(m => sidesOf(m).contains(s2))
+              val commonInO2 = o2.filter(m => sidesOf(m).contains(s1))
+              common == commonInO2
+            }
+          }
+        }
+
+      private def parallelConsistentSubgroups(
+          matches: Iterable[GenericMatch[Element]]
+      ): Iterable[Set[GenericMatch[Element]]] =
+        val subgroups =
+          mutable.Buffer.empty[mutable.Set[GenericMatch[Element]]]
+
+        // Sort matches to ensure stable results and possibly better grouping
+        val sortedMatches = matches.toSeq.sortBy(m =>
+          (
+            pathOnBase(m).map(_.toString).getOrElse(""),
+            pathOnLeft(m).map(_.toString).getOrElse(""),
+            pathOnRight(m).map(_.toString).getOrElse(""),
+            -sidesOf(m).size // Prioritize all-sides matches for greedy grouping
+          )
+        )
+
+        sortedMatches.foreach { m =>
+          subgroups.find { subgroup =>
+            val mIsAllSides = m.isAnAllSidesMatch
+            val subgroupHasAllSides =
+              subgroup.exists(_.isAnAllSidesMatch)
+            val flavourCompatible =
+              mIsAllSides || subgroupHasAllSides || subgroup.forall(sm =>
+                // Same pairwise flavour
+                (sm, m) match
+                  case (_: Match.BaseAndLeft[?], _: Match.BaseAndLeft[?])   => true
+                  case (_: Match.BaseAndRight[?], _: Match.BaseAndRight[?]) => true
+                  case (_: Match.LeftAndRight[?], _: Match.LeftAndRight[?]) => true
+                  case _                                                   => false
+              )
+
+            flavourCompatible &&
+            subgroup.forall(arePathCompatible(m, _)) &&
+            isOrderConsistent(subgroup.toSeq :+ m)
+          } match
+            case Some(subgroup) => subgroup.add(m)
+            case None           => subgroups.addOne(mutable.Set(m))
+        }
+
+        subgroups.map(_.toSet)
+      end parallelConsistentSubgroups
+
       def reconcileMatches: MatchesAndTheirSections =
         val matches = sectionsAndTheirMatches.values.toSet
 
@@ -1314,7 +1460,18 @@ object MatchAnalysis extends StrictLogging:
 
               for
                 // Reset the state for each iteration of `reconcileUsing`.
-                _ <- State.set(parallelMatchesGroupIdsByMatch)
+                _ <- State.set[ParallelMatchesGrouping] {
+                  val initialGrouping =
+                    DisjointSets(matches.toSeq*)
+                  val groups =
+                    parallelMatchesGroupIdsByMatch.toSeq.groupBy(_._2).values
+                  groups.foldLeft(initialGrouping) { (accDs, groupMatches) =>
+                    val ms = groupMatches.map(_._1)
+                    if ms.size > 1 then
+                      ms.tail.foldLeft(accDs)((d, m) => d.union(ms.head, m)._1)
+                    else accDs
+                  }
+                }
 
                 fragments <- fragmentsOf(pairwiseMatchesToBeEaten).map(
                   _.diff(matches.asInstanceOf[Set[PairwiseMatch]])
@@ -1330,6 +1487,24 @@ object MatchAnalysis extends StrictLogging:
                 // NOTE: prefer `traverse` + `flatten` to `flatTraverse` as it
                 // manages flattening `Option` values into an enclosing `Set`
                 // nicely. The same holds a bit later on too.
+                _ <- matches
+                  .filter(_.isAnAllSidesMatch)
+                  .toSeq
+                  .traverse_ {
+                    case allSidesMatch: Match.AllSides[Section[Element]] =>
+                      pairwiseMatchesSubsumingOnBothSides(allSidesMatch)
+                        .filter(arePathCompatible(allSidesMatch, _))
+                        .toSeq
+                        .traverse_(pairwiseMatch =>
+                          State.modify[ParallelMatchesGrouping](sets =>
+                            if sets.contains(allSidesMatch) && sets
+                                .contains(pairwiseMatch)
+                            then sets.union(allSidesMatch, pairwiseMatch)._1
+                            else sets
+                          )
+                        )
+                  }
+
                 paredDownMatches <- matches
                   .traverse(
                     takingFragmentationIntoAccount.pareDownOrSuppressCompletely
@@ -1359,147 +1534,25 @@ object MatchAnalysis extends StrictLogging:
                       reconciled = rebuilt.withoutRedundantPairwiseMatches
                       _          = reconciled.checkInvariant()
                       _          = progressRecordingSession.upTo(0)
-                      updatedParallelMatchesGroupsIdsByMatch <- State.get
+                      updatedParallelMatchesGrouping <-
+                        State.get[ParallelMatchesGrouping]
                     yield
                       val matches = reconciled.matches
-
-                      val initialParallelMatchesGroupIdsByMatch =
-                        updatedParallelMatchesGroupsIdsByMatch.view
-                          .filterKeys(matches.contains)
-                          .toMap
-
-                      val disjointSetsOfMatches =
-                        val initialParallelMatchIds =
-                          matches.zipWithIndex.toMap
-
-                        given matchOrdering: Order[Match[Section[Element]]] =
-                          Order.by(initialParallelMatchIds.apply)
-
-                        DisjointSets(
-                          matches.toSeq*
+                      val groupIdsByMatch = updatedParallelMatchesGrouping
+                        .toSets._2
+                        .toScalaMap
+                        .values
+                        .flatMap(group =>
+                          parallelConsistentSubgroups(
+                            group.toScalaSet.filter(matches.contains)
+                          )
                         )
-                      end disjointSetsOfMatches
-
-                      val coalescenceWorkflow =
-                        for
-                          _ <- initialParallelMatchesGroupIdsByMatch.toSeq
-                            .groupBy(_._2)
-                            .view
-                            .mapValues(_.map(_._1))
-                            .values
-                            .toSeq
-                            .traverse_ { group =>
-                              group
-                                .zip(group.tail)
-                                .traverse_ {
-                                  case (
-                                        precedingGroupMember,
-                                        succeedingGroupMember
-                                      ) =>
-                                    DisjointSets
-                                      .union(
-                                        precedingGroupMember,
-                                        succeedingGroupMember
-                                      )
-                                }
-                            }
-                          _ <- matches
-                            .filter(_.isAnAllSidesMatch)
-                            .traverse_ {
-                              case allSidesMatch: Match.AllSides[
-                                    Section[Element]
-                                  ] =>
-                                reconciled
-                                  .pairwiseMatchesSubsumingOnBothSides(
-                                    allSidesMatch
-                                  )
-                                  .traverse_ { pairwiseMatch =>
-                                    val allSidesPaths = (
-                                      Some(
-                                        baseSources.pathFor(
-                                          allSidesMatch.baseElement
-                                        )
-                                      ),
-                                      Some(
-                                        leftSources.pathFor(
-                                          allSidesMatch.leftElement
-                                        )
-                                      ),
-                                      Some(
-                                        rightSources.pathFor(
-                                          allSidesMatch.rightElement
-                                        )
-                                      )
-                                    )
-                                    val pairwisePaths = pairwiseMatch match
-                                      case Match.BaseAndLeft(
-                                            baseSection,
-                                            leftSection
-                                          ) =>
-                                        (
-                                          Some(baseSources.pathFor(baseSection)),
-                                          Some(leftSources.pathFor(leftSection)),
-                                          None
-                                        )
-                                      case Match.BaseAndRight(
-                                            baseSection,
-                                            rightSection
-                                          ) =>
-                                        (
-                                          Some(baseSources.pathFor(baseSection)),
-                                          None,
-                                          Some(
-                                            rightSources.pathFor(rightSection)
-                                          )
-                                        )
-                                      case Match.LeftAndRight(
-                                            leftSection,
-                                            rightSection
-                                          ) =>
-                                        (
-                                          None,
-                                          Some(leftSources.pathFor(leftSection)),
-                                          Some(
-                                            rightSources.pathFor(rightSection)
-                                          )
-                                        )
-                                    end pairwisePaths
-
-                                    val isPathConsistent =
-                                      (allSidesPaths._1, pairwisePaths._1)
-                                        .mapN(_ == _)
-                                        .getOrElse(true) &&
-                                        (allSidesPaths._2, pairwisePaths._2)
-                                          .mapN(_ == _)
-                                          .getOrElse(true) &&
-                                        (allSidesPaths._3, pairwisePaths._3)
-                                          .mapN(_ == _)
-                                          .getOrElse(true)
-
-                                    if isPathConsistent then
-                                      DisjointSets.union(
-                                        allSidesMatch,
-                                        pairwiseMatch
-                                      )
-                                    else State.pure(false)
-                                    end if
-                                  }
-                            }
-                          sets <- DisjointSets.toSets
-                        yield sets
-
-                      val parallelMatchesGroupIdsByMatch = coalescenceWorkflow
-                        .runA(disjointSetsOfMatches)
-                        .value
-                        .toList
-                        .map(_._2.toIterator)
                         .zipWithIndex
-                        .flatMap((group, id) => group.map(_ -> id))
+                        .flatMap { (subgroup, id) => subgroup.map(_ -> id) }
                         .toMap
-
                       Right(
                         reconciled.copy(parallelMatchesGroupIdsByMatch =
-                          parallelMatchesGroupIdsByMatch
+                          groupIdsByMatch
                         )
                       )
                   else
@@ -1513,7 +1566,9 @@ object MatchAnalysis extends StrictLogging:
               .tailRecM(matches.collect {
                 case allSides: Match.AllSides[Section[Element]] => allSides
               })(reconcileUsing)
-              .runA(Map.empty)
+              .runA(
+                DisjointSets(Seq.empty[GenericMatch[Element]]*)
+              )
               .value
           }: @unchecked
 
@@ -1752,52 +1807,49 @@ object MatchAnalysis extends StrictLogging:
             s"If groups of parallel matches have been discovered, they should cover the overall population of matches exactly."
           )
 
-          val matchesByGroupId =
-            parallelMatchesGroupIdsByMatch.toSeq
-              .groupBy(_._2)
-              .view
-              .mapValues(_.map(_._1))
+          parallelMatchesGroupIdsByMatch.toSeq
+            .groupBy(_._2)
+            .values
+            .foreach { group =>
+              val matchesInGroup = group.map(_._1)
 
-          matchesByGroupId.foreach { case (groupId, matchesInGroup) =>
-            val basePaths = matchesInGroup
-              .collect {
-                case Match.AllSides(baseSection, _, _)  => baseSection
-                case Match.BaseAndLeft(baseSection, _)  => baseSection
-                case Match.BaseAndRight(baseSection, _) => baseSection
-              }
-              .map(baseSources.pathFor)
-              .toSet
-            assert(
-              basePaths.size <= 1,
-              s"Group $groupId has multiple base paths: $basePaths"
-            )
+              val basePaths = matchesInGroup.flatMap(pathOnBase).toSet
+              assert(
+                basePaths.size <= 1,
+                s"Base paths for parallel matches group should be consistent, but are: $basePaths."
+              )
 
-            val leftPaths = matchesInGroup
-              .collect {
-                case Match.AllSides(_, leftSection, _)  => leftSection
-                case Match.BaseAndLeft(_, leftSection)  => leftSection
-                case Match.LeftAndRight(leftSection, _) => leftSection
-              }
-              .map(leftSources.pathFor)
-              .toSet
-            assert(
-              leftPaths.size <= 1,
-              s"Group $groupId has multiple left paths: $leftPaths"
-            )
+              val leftPaths = matchesInGroup.flatMap(pathOnLeft).toSet
+              assert(
+                leftPaths.size <= 1,
+                s"Left paths for parallel matches group should be consistent, but are: $leftPaths."
+              )
 
-            val rightPaths = matchesInGroup
-              .collect {
-                case Match.AllSides(_, _, rightSection)  => rightSection
-                case Match.BaseAndRight(_, rightSection) => rightSection
-                case Match.LeftAndRight(_, rightSection) => rightSection
-              }
-              .map(rightSources.pathFor)
-              .toSet
-            assert(
-              rightPaths.size <= 1,
-              s"Group $groupId has multiple right paths: $rightPaths"
-            )
-          }
+              val rightPaths = matchesInGroup.flatMap(pathOnRight).toSet
+              assert(
+                rightPaths.size <= 1,
+                s"Right paths for parallel matches group should be consistent, but are: $rightPaths."
+              )
+
+              assert(
+                isOrderConsistent(matchesInGroup),
+                s"Ordering for parallel matches group should be consistent, matches are: ${pprintCustomised(matchesInGroup)}"
+              )
+
+              val hasAllSidesMatch = matchesInGroup.exists(_.isAnAllSidesMatch)
+              if !hasAllSidesMatch then
+                val flavours = matchesInGroup.map {
+                  case _: Match.BaseAndLeft[?]  => 1
+                  case _: Match.BaseAndRight[?] => 2
+                  case _: Match.LeftAndRight[?] => 3
+                  case _: Match.AllSides[?]    => 0
+                }.toSet
+                assert(
+                  flavours.size <= 1,
+                  s"A parallel matches group without an all-sides match should be homogeneous in flavour, but has flavours: $flavours"
+                )
+              end if
+            }
         end if
       end reconciliationPostcondition
 
@@ -2235,11 +2287,31 @@ object MatchAnalysis extends StrictLogging:
                   .zip(group.tail)
                   // Zipping views together makes an `Iterable`, so ...
                   .toSeq
+                  .filter((precedingGroupMember, succeedingGroupMember) =>
+                    backTranslatedMatchesAndTheirSections.arePathCompatible(
+                      precedingGroupMember,
+                      succeedingGroupMember
+                    )
+                  )
                   .traverse_ {
                     case (precedingGroupMember, succeedingGroupMember) =>
                       DisjointSets
                         .union(precedingGroupMember, succeedingGroupMember)
                   }
+              }
+            _ <- backTranslatedMatches
+              .filter(_.isAnAllSidesMatch)
+              .traverse_ {
+                case allSidesMatch: Match.AllSides[Section[Element]] =>
+                  backTranslatedMatchesAndTheirSections
+                    .pairwiseMatchesSubsumingOnBothSides(allSidesMatch)
+                    .filter(
+                      backTranslatedMatchesAndTheirSections
+                        .arePathCompatible(allSidesMatch, _)
+                    )
+                    .traverse_(
+                      DisjointSets.union(allSidesMatch, _)
+                    )
               }
             sets <- DisjointSets.toSets
           yield sets

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1416,9 +1416,39 @@ object MatchAnalysis extends StrictLogging:
         result.reconciliationPostcondition()
 
         val groupsOfParallelMatches =
-          result.parallelMatchesGroupIdsByMatch.groupBy(_._2).map {
-            (groupId, group) => groupId -> group.map(_._1).toSet
-          }
+          given Ordering[GenericMatch[Element]] with
+            override def compare(
+                x: GenericMatch[Element],
+                y: GenericMatch[Element]
+            ): Int =
+              (startOffsetOnLeft(x), startOffsetOnLeft(y)) match
+                case (Some(xLeftStartOffset), Some(yLeftStartOffset)) =>
+                  Ordering[Int].compare(xLeftStartOffset, yLeftStartOffset)
+                case _ =>
+                  (startOffsetOnRight(x), startOffsetOnRight(y)) match
+                    case (Some(xRightStartOffset), Some(yRightStartOffset)) =>
+                      Ordering[Int].compare(
+                        xRightStartOffset,
+                        yRightStartOffset
+                      )
+                    case _ =>
+                      ((
+                        startOffsetOnBase(x),
+                        startOffsetOnBase(y)
+                      ): @unchecked) match
+                        case (Some(xBaseStartOffset), Some(yBaseStartOffset)) =>
+                          Ordering[Int].compare(
+                            xBaseStartOffset,
+                            yBaseStartOffset
+                          )
+          end given
+
+          SortedMap.from(
+            result.parallelMatchesGroupIdsByMatch.groupBy(_._2).map {
+              (groupId, group) => groupId -> SortedSet.from(group.map(_._1))
+            }
+          )
+        end groupsOfParallelMatches
         logger.debug(
           s"Groups of parallel matches after reconciliation:\n${pprintCustomised(groupsOfParallelMatches)}"
         )
@@ -1426,6 +1456,608 @@ object MatchAnalysis extends StrictLogging:
         result
 
       end reconcileMatches
+
+      def parallelMatchesOnly: MatchesAndTheirSections =
+        // PLAN:
+
+        // 1. Build up sources composed of matched sections concatenated
+        // together by path preserving their original order.
+
+        val baseMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(baseSection, _, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndLeft(baseSection, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndRight(baseSection, _))
+                  if section == baseSection =>
+                section
+            }
+
+        val leftMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, leftSection, _))
+                  if section == leftSection =>
+                section
+              case (section, Match.BaseAndLeft(_, leftSection))
+                  if section == leftSection =>
+                section
+              case (section, Match.LeftAndRight(leftSection, _))
+                  if section == leftSection =>
+                section
+            }
+
+        val rightMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, _, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.BaseAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.LeftAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+            }
+
+        case class MetaMatchContentSources(
+            override val contentsByPath: Map[Path, IndexedSeq[
+              Section[Element]
+            ]],
+            override val label: String
+        ) extends MappedContentSources[Path, Section[Element]]
+
+        def sourcesForMetaMatching(label: String)(
+            sources: Sources[Path, Element],
+            matchedSections: Iterable[Section[Element]]
+        ) = MetaMatchContentSources(
+          contentsByPath = matchedSections
+            .groupBy(sources.pathFor)
+            .map((path, sections) =>
+              path -> sections.toIndexedSeq
+                .sortBy(section =>
+                  // NOTE: use the negative of the section size as a tiebreaker
+                  // if more than one section has the same start offset. This
+                  // makes sure that a subsuming section comes *before* any
+                  // sections that it might subsume, so it can't interpose
+                  // itself within what would have been a run of parallel
+                  // subsumed sections; that way we don't accidentally split
+                  // what should be larger meta-matches. That can occur when the
+                  // subsuming section is contributed by a larger pairwise match
+                  // that subsumes several all-sides matches, and the first
+                  // all-sides match aligns with the start of the pairwise
+                  // match. The test
+                  // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation`
+                  // has an example of this.
+                  section.startOffset -> -section.size
+                )
+            ),
+          label = label
+        )
+
+        val baseSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-base")(
+            baseSources,
+            baseMatchedSections
+          )
+        val leftSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-left")(
+            leftSources,
+            leftMatchedSections
+          )
+        val rightSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-right")(
+            rightSources,
+            rightMatchedSections
+          )
+
+        // 2. Apply `MatchAnalysis.of` to these sections, using the
+        // potential match key of the section to underpin equality and
+        // hashing.
+
+        object metaMatchConfiguration extends AbstractConfiguration:
+          override val minimumMatchSize: Int                    = 1
+          override val thresholdSizeFractionForMatching: Double = 0
+          override val minimumAmbiguousMatchSize: Int           = 1
+          override val ambiguousMatchesThreshold: Int           = Int.MaxValue
+          override val progressRecording: ProgressRecording     =
+            configuration.progressRecording
+        end metaMatchConfiguration
+
+        given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
+
+        given Funnel[Section[Element]] with
+          override def funnel(
+              from: Section[Element],
+              into: PrimitiveSink
+          ): Unit =
+            from.content.foreach(summon[Funnel[Element]].funnel(_, into))
+
+        end given
+
+        val metaMatchAnalysis = of(
+          baseSourcesForMetaMatching,
+          leftSourcesForMetaMatching,
+          rightSourcesForMetaMatching
+        )(metaMatchConfiguration)
+
+        // 3. The resulting meta-matches provide parallel sequences of sections
+        // that are unzipped to yield corresponding all-sides and pairwise
+        // matches.
+
+        val metaMatches = metaMatchAnalysis.matches
+
+        // NOTE: because meta-matching starts with matched *sections* and
+        // ignores gaps, we have to guard against sections that would have
+        // formed the sides of a suppressed outer match making a second attempt
+        // at building a match.
+        val groupsOfBackTranslatedParallelMatches = metaMatches
+          .map {
+            case Match.AllSides(
+                  baseMetaSection,
+                  leftMetaSection,
+                  rightMetaSection
+                ) =>
+              (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (baseSection, leftSection, rightSection)
+                      if !isSubsumedNonTriviallyByAnAllSidesMatch(
+                        baseSection,
+                        leftSection,
+                        rightSection
+                      ) =>
+                    Match.AllSides(baseSection, leftSection, rightSection)
+                }
+            case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
+              (baseMetaSection.content lazyZip leftMetaSection.content)
+                .collect {
+                  case (baseSection, leftSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+                        baseSection,
+                        leftSection
+                      ) =>
+                    Match.BaseAndLeft(baseSection, leftSection)
+                }
+            case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
+              (baseMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (baseSection, rightSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+                        baseSection,
+                        rightSection
+                      ) =>
+                    Match.BaseAndRight(baseSection, rightSection)
+                }
+            case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
+              (leftMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (leftSection, rightSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+                        leftSection,
+                        rightSection
+                      ) =>
+                    Match.LeftAndRight(leftSection, rightSection)
+                }
+          }
+          .filter(_.nonEmpty)
+          .toSeq
+
+        // 4. Put the back-translated matches into their own disjoint sets, then
+        // unify those matches that come from the same group of parallel
+        // matches, then unify all-sides matches with pairwise matches that
+        // subsume them, regardless of the original group.
+
+        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
+        // the back-translated matches, because the thinning out of ambiguous
+        // matches performed by the meta-matching and back translation above
+        // means there are new opportunities for matches to be generated - while
+        // the vast majority of these are redundant pairwise matches, there are
+        // some that are vital to capture things such as moves with migrated
+        // edits / deletions - the test
+        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
+        // an example of this.
+        val backTranslatedMatchesAndTheirSections =
+          MatchesAndTheirSections.empty
+            .withMatches(
+              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
+              haveTrimmedMatches = false
+            )
+            .matchesAndTheirSections
+            .withoutRedundantPairwiseMatches
+
+        val backTranslatedMatches =
+          backTranslatedMatchesAndTheirSections.matches
+
+        val parallelMatchesGroupIdsByMatch =
+          MultiDict.from(
+            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
+              (parallelMatches, groupId) => parallelMatches.map(_ -> groupId)
+            )
+          )
+
+        backTranslatedMatchesAndTheirSections
+          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
+      end parallelMatchesOnly
+
+      // Cleans up the state when a putative all-sides match that would have
+      // been ambiguous on one side with another all-sides match was partially
+      // suppressed by a larger pairwise match. This situation results in a
+      // pairwise match that shares its sections on both sides with the other
+      // all-sides match; remove any such redundant pairwise matches.
+      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
+        val redundantMatches =
+          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
+
+        if redundantMatches.nonEmpty then
+          logger.debug(
+            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
+          )
+        end if
+
+        withoutTheseMatches(redundantMatches)
+      end withoutRedundantPairwiseMatches
+
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(allSides)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(baseAndLeft)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(baseAndRight)
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(leftAndRight)
+            )
+        }
+      end withoutTheseMatches
+
+      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
+        aMatch match
+          case Match.BaseAndLeft(baseSection, leftSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(leftSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.BaseAndRight(baseSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.LeftAndRight(leftSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(leftSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case _: Match.AllSides[Section[Element]] => false
+
+      private def isSubsumedNonTriviallyByAnAllSidesMatch(
+          baseSection: Section[Element],
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAnAllSidesMatch
+
+      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+          baseSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+          baseSection: Section[Element],
+          leftSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
+
+      private def withMatches(
+          matches: Set[GenericMatch[Element]],
+          haveTrimmedMatches: Boolean
+      ): MatchingResult =
+        val updatedMatchesAndTheirSections =
+          matches.foldLeft(this)(_ withMatch _)
+
+        val pathInclusions =
+          if !haveTrimmedMatches then
+            case class PathInclusionsImplementation(
+                basePaths: Set[Path],
+                leftPaths: Set[Path],
+                rightPaths: Set[Path]
+            ) extends PathInclusions:
+              override def isIncludedOnBase(basePath: Path): Boolean =
+                basePaths.contains(basePath)
+
+              override def isIncludedOnLeft(leftPath: Path): Boolean =
+                leftPaths.contains(leftPath)
+
+              override def isIncludedOnRight(rightPath: Path): Boolean =
+                rightPaths.contains(rightPath)
+
+              def addPathOnBaseFor(
+                  baseSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
+              def addPathOnLeftFor(
+                  leftSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
+              def addPathOnRightFor(
+                  rightSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(rightPaths =
+                  rightPaths + rightSources.pathFor(rightSection)
+                )
+            end PathInclusionsImplementation
+
+            matches.foldLeft(
+              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
+            )((partialPathInclusions, aMatch) =>
+              aMatch match
+                case Match.AllSides(baseSection, leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.BaseAndLeft(baseSection, leftSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                case Match.BaseAndRight(baseSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.LeftAndRight(leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+            )
+          else PathInclusions.all
+
+        MatchingResult(
+          matchesAndTheirSections = updatedMatchesAndTheirSections,
+          numberOfMatchesForTheGivenWindowSize = matches.size,
+          estimatedWindowSizeForOptimalMatch =
+            estimateOptimalMatchSize(matches),
+          pathInclusions = pathInclusions
+        )
+      end withMatches
+
+      private def withMatch(
+          aMatch: GenericMatch[Element]
+      ): MatchesAndTheirSections =
+        aMatch match
+          case Match.AllSides(baseSection, leftSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
+              baseFingerprintedInclusionsByPath =
+                knockOutFromBaseFingerprintedInclusions(baseSection),
+              leftFingerprintedInclusionsByPath =
+                knockOutFromLeftFingerprintedInclusions(leftSection),
+              rightFingerprintedInclusionsByPath =
+                knockOutFromRightFingerprintedInclusions(rightSection)
+            )
+          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
+            )
+          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
+            )
+          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
+            copy(
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
+            )
+        end match
+      end withMatch
 
       private def checkInvariant(): Unit =
         // We expect to tally either two lots of a given pairwise match or three
@@ -2105,608 +2737,6 @@ object MatchAnalysis extends StrictLogging:
             )
         }
       end pairwiseMatchesSubsumingOnBothSidesWithBiteEdges
-
-      def parallelMatchesOnly: MatchesAndTheirSections =
-        // PLAN:
-
-        // 1. Build up sources composed of matched sections concatenated
-        // together by path preserving their original order.
-
-        val baseMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(baseSection, _, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndLeft(baseSection, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndRight(baseSection, _))
-                  if section == baseSection =>
-                section
-            }
-
-        val leftMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, leftSection, _))
-                  if section == leftSection =>
-                section
-              case (section, Match.BaseAndLeft(_, leftSection))
-                  if section == leftSection =>
-                section
-              case (section, Match.LeftAndRight(leftSection, _))
-                  if section == leftSection =>
-                section
-            }
-
-        val rightMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, _, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.BaseAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.LeftAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-            }
-
-        case class MetaMatchContentSources(
-            override val contentsByPath: Map[Path, IndexedSeq[
-              Section[Element]
-            ]],
-            override val label: String
-        ) extends MappedContentSources[Path, Section[Element]]
-
-        def sourcesForMetaMatching(label: String)(
-            sources: Sources[Path, Element],
-            matchedSections: Iterable[Section[Element]]
-        ) = MetaMatchContentSources(
-          contentsByPath = matchedSections
-            .groupBy(sources.pathFor)
-            .map((path, sections) =>
-              path -> sections.toIndexedSeq
-                .sortBy(section =>
-                  // NOTE: use the negative of the section size as a tiebreaker
-                  // if more than one section has the same start offset. This
-                  // makes sure that a subsuming section comes *before* any
-                  // sections that it might subsume, so it can't interpose
-                  // itself within what would have been a run of parallel
-                  // subsumed sections; that way we don't accidentally split
-                  // what should be larger meta-matches. That can occur when the
-                  // subsuming section is contributed by a larger pairwise match
-                  // that subsumes several all-sides matches, and the first
-                  // all-sides match aligns with the start of the pairwise
-                  // match. The test
-                  // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation`
-                  // has an example of this.
-                  section.startOffset -> -section.size
-                )
-            ),
-          label = label
-        )
-
-        val baseSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-base")(
-            baseSources,
-            baseMatchedSections
-          )
-        val leftSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-left")(
-            leftSources,
-            leftMatchedSections
-          )
-        val rightSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-right")(
-            rightSources,
-            rightMatchedSections
-          )
-
-        // 2. Apply `MatchAnalysis.of` to these sections, using the
-        // potential match key of the section to underpin equality and
-        // hashing.
-
-        object metaMatchConfiguration extends AbstractConfiguration:
-          override val minimumMatchSize: Int                    = 1
-          override val thresholdSizeFractionForMatching: Double = 0
-          override val minimumAmbiguousMatchSize: Int           = 1
-          override val ambiguousMatchesThreshold: Int           = Int.MaxValue
-          override val progressRecording: ProgressRecording     =
-            configuration.progressRecording
-        end metaMatchConfiguration
-
-        given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
-
-        given Funnel[Section[Element]] with
-          override def funnel(
-              from: Section[Element],
-              into: PrimitiveSink
-          ): Unit =
-            from.content.foreach(summon[Funnel[Element]].funnel(_, into))
-
-        end given
-
-        val metaMatchAnalysis = of(
-          baseSourcesForMetaMatching,
-          leftSourcesForMetaMatching,
-          rightSourcesForMetaMatching
-        )(metaMatchConfiguration)
-
-        // 3. The resulting meta-matches provide parallel sequences of sections
-        // that are unzipped to yield corresponding all-sides and pairwise
-        // matches.
-
-        val metaMatches = metaMatchAnalysis.matches
-
-        // NOTE: because meta-matching starts with matched *sections* and
-        // ignores gaps, we have to guard against sections that would have
-        // formed the sides of a suppressed outer match making a second attempt
-        // at building a match.
-        val groupsOfBackTranslatedParallelMatches = metaMatches
-          .map {
-            case Match.AllSides(
-                  baseMetaSection,
-                  leftMetaSection,
-                  rightMetaSection
-                ) =>
-              (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAnAllSidesMatch(
-                        baseSection,
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.AllSides(baseSection, leftSection, rightSection)
-                }
-            case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
-              (baseMetaSection.content lazyZip leftMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-                        baseSection,
-                        leftSection
-                      ) =>
-                    Match.BaseAndLeft(baseSection, leftSection)
-                }
-            case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
-              (baseMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-                        baseSection,
-                        rightSection
-                      ) =>
-                    Match.BaseAndRight(baseSection, rightSection)
-                }
-            case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
-              (leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.LeftAndRight(leftSection, rightSection)
-                }
-          }
-          .filter(_.nonEmpty)
-          .toSeq
-
-        // 4. Put the back-translated matches into their own disjoint sets, then
-        // unify those matches that come from the same group of parallel
-        // matches, then unify all-sides matches with pairwise matches that
-        // subsume them, regardless of the original group.
-
-        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
-        // the back-translated matches, because the thinning out of ambiguous
-        // matches performed by the meta-matching and back translation above
-        // means there are new opportunities for matches to be generated - while
-        // the vast majority of these are redundant pairwise matches, there are
-        // some that are vital to capture things such as moves with migrated
-        // edits / deletions - the test
-        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
-        // an example of this.
-        val backTranslatedMatchesAndTheirSections =
-          MatchesAndTheirSections.empty
-            .withMatches(
-              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
-              haveTrimmedMatches = false
-            )
-            .matchesAndTheirSections
-            .withoutRedundantPairwiseMatches
-
-        val backTranslatedMatches =
-          backTranslatedMatchesAndTheirSections.matches
-
-        val parallelMatchesGroupIdsByMatch =
-          MultiDict.from(
-            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
-              (parallelMatches, groupId) => parallelMatches.map(_ -> groupId)
-            )
-          )
-
-        backTranslatedMatchesAndTheirSections
-          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
-      end parallelMatchesOnly
-
-      // Cleans up the state when a putative all-sides match that would have
-      // been ambiguous on one side with another all-sides match was partially
-      // suppressed by a larger pairwise match. This situation results in a
-      // pairwise match that shares its sections on both sides with the other
-      // all-sides match; remove any such redundant pairwise matches.
-      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
-        val redundantMatches =
-          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
-
-        if redundantMatches.nonEmpty then
-          logger.debug(
-            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
-          )
-        end if
-
-        withoutTheseMatches(redundantMatches)
-      end withoutRedundantPairwiseMatches
-
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(allSides)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(baseAndLeft)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(baseAndRight)
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(leftAndRight)
-            )
-        }
-      end withoutTheseMatches
-
-      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
-        aMatch match
-          case Match.BaseAndLeft(baseSection, leftSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(leftSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.BaseAndRight(baseSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.LeftAndRight(leftSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(leftSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case _: Match.AllSides[Section[Element]] => false
-
-      private def isSubsumedNonTriviallyByAnAllSidesMatch(
-          baseSection: Section[Element],
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAnAllSidesMatch
-
-      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-          baseSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-          baseSection: Section[Element],
-          leftSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
-
-      private def withMatches(
-          matches: Set[GenericMatch[Element]],
-          haveTrimmedMatches: Boolean
-      ): MatchingResult =
-        val updatedMatchesAndTheirSections =
-          matches.foldLeft(this)(_ withMatch _)
-
-        val pathInclusions =
-          if !haveTrimmedMatches then
-            case class PathInclusionsImplementation(
-                basePaths: Set[Path],
-                leftPaths: Set[Path],
-                rightPaths: Set[Path]
-            ) extends PathInclusions:
-              override def isIncludedOnBase(basePath: Path): Boolean =
-                basePaths.contains(basePath)
-
-              override def isIncludedOnLeft(leftPath: Path): Boolean =
-                leftPaths.contains(leftPath)
-
-              override def isIncludedOnRight(rightPath: Path): Boolean =
-                rightPaths.contains(rightPath)
-
-              def addPathOnBaseFor(
-                  baseSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
-              def addPathOnLeftFor(
-                  leftSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
-              def addPathOnRightFor(
-                  rightSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(rightPaths =
-                  rightPaths + rightSources.pathFor(rightSection)
-                )
-            end PathInclusionsImplementation
-
-            matches.foldLeft(
-              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
-            )((partialPathInclusions, aMatch) =>
-              aMatch match
-                case Match.AllSides(baseSection, leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.BaseAndLeft(baseSection, leftSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                case Match.BaseAndRight(baseSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.LeftAndRight(leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-            )
-          else PathInclusions.all
-
-        MatchingResult(
-          matchesAndTheirSections = updatedMatchesAndTheirSections,
-          numberOfMatchesForTheGivenWindowSize = matches.size,
-          estimatedWindowSizeForOptimalMatch =
-            estimateOptimalMatchSize(matches),
-          pathInclusions = pathInclusions
-        )
-      end withMatches
-
-      private def withMatch(
-          aMatch: GenericMatch[Element]
-      ): MatchesAndTheirSections =
-        aMatch match
-          case Match.AllSides(baseSection, leftSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
-              baseFingerprintedInclusionsByPath =
-                knockOutFromBaseFingerprintedInclusions(baseSection),
-              leftFingerprintedInclusionsByPath =
-                knockOutFromLeftFingerprintedInclusions(leftSection),
-              rightFingerprintedInclusionsByPath =
-                knockOutFromRightFingerprintedInclusions(rightSection)
-            )
-          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
-            )
-          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
-            )
-          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
-            copy(
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
-            )
-        end match
-      end withMatch
 
       private def pairwiseMatchesSubsumingOnBothSides(
           allSides: Match.AllSides[Section[Element]]

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -31,8 +31,8 @@ import scala.collection.immutable.{
   SortedMultiSet,
   SortedSet
 }
-import scala.collection.mutable
 import scala.collection.parallel.CollectionConverters.*
+import scala.collection.{immutable, mutable}
 import scala.util.{Success, Using}
 
 trait MatchAnalysis[Path, Element]:
@@ -188,14 +188,14 @@ object MatchAnalysis extends StrictLogging:
 
     type ParallelMatchesGroupId = Int
 
-    type GroupsOfParallelMatches =
+    type ParallelMatchesGroupIdsByMatch =
       MultiDict[GenericMatch[Element], ParallelMatchesGroupId]
 
     val tiebreakContentSamplingLimit = 5
 
     object MatchesAndTheirSections:
       type ParallelMatchesGroupIdTracking[X] =
-        State[GroupsOfParallelMatches, X]
+        State[ParallelMatchesGroupIdsByMatch, X]
 
       lazy val empty: MatchesAndTheirSections = MatchesAndTheirSections(
         baseSectionsByPath = Map.empty,
@@ -734,7 +734,7 @@ object MatchAnalysis extends StrictLogging:
           .flatTraverse { case (pairwiseMatch, bites) =>
             for
               parallelMatchesGroupIdsByMatch <- State
-                .get[GroupsOfParallelMatches]
+                .get[ParallelMatchesGroupIdsByMatch]
 
               groupIdsBySortedBiteEdge = SortedMap.from(bites.flatMap {
                 case (allSides, biteStart, biteEnd) =>
@@ -972,7 +972,7 @@ object MatchAnalysis extends StrictLogging:
           fragment: PairwiseMatch,
           groupIds: Set[ParallelMatchesGroupId]
       ): ParallelMatchesGroupIdTracking[Unit] =
-        State.modify[GroupsOfParallelMatches] { groupIdsByMatch =>
+        State.modify[ParallelMatchesGroupIdsByMatch] { groupIdsByMatch =>
           groupIds.foldLeft(groupIdsByMatch)((partialResult, groupId) =>
             partialResult.add(fragment, groupId)
           )
@@ -1040,7 +1040,7 @@ object MatchAnalysis extends StrictLogging:
         baseFingerprintedInclusionsByPath: Map[Path, FingerprintedInclusions],
         leftFingerprintedInclusionsByPath: Map[Path, FingerprintedInclusions],
         rightFingerprintedInclusionsByPath: Map[Path, FingerprintedInclusions],
-        parallelMatchesGroupIdsByMatch: GroupsOfParallelMatches
+        parallelMatchesGroupIdsByMatch: ParallelMatchesGroupIdsByMatch
     ) extends MatchAnalysis[Path, Element]:
       import MatchesAndTheirSections.*
 
@@ -1289,99 +1289,6 @@ object MatchAnalysis extends StrictLogging:
         end if
       end purgedOfMatchesWithOverlappingSections
 
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(allSides)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(baseAndLeft)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(baseAndRight)
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(leftAndRight)
-            )
-        }
-      end withoutTheseMatches
-
       def reconcileMatches: MatchesAndTheirSections =
         val matches = sectionsAndTheirMatches.values.toSet
 
@@ -1462,13 +1369,33 @@ object MatchAnalysis extends StrictLogging:
                       reconciled = rebuilt.withoutRedundantPairwiseMatches
                       _          = reconciled.checkInvariant()
                       _          = progressRecordingSession.upTo(0)
-                      updatedParallelMatchesGroupsIdsByMatch <- State.get
+                      updatedParallelMatchesGroupIdsByMatch <- State.get
                     yield
-                      val matches = reconciled.matches
+                      val matches                        = reconciled.matches
+                      val parallelMatchesGroupIdsByMatch =
+                        updatedParallelMatchesGroupIdsByMatch
+                          .filterSets((key, _) => matches.contains(key))
+
+                      val groupIdsWithPossibleGaps: Map[
+                        ParallelMatchesGroupId,
+                        ParallelMatchesGroupId
+                      ] =
+                        parallelMatchesGroupIdsByMatch.sets.values
+                          .foldLeft(
+                            Set.empty[ParallelMatchesGroupId]
+                          )(_ ++ _)
+                          .zipWithIndex
+                          .toMap
+
+                      val parallelMatchesWithReorganisedGroupIdsByMatch =
+                        parallelMatchesGroupIdsByMatch.mapSets(
+                          (aMatch, groupIds) =>
+                            aMatch -> groupIds.map(groupIdsWithPossibleGaps)
+                        )
+
                       Right(
                         reconciled.copy(parallelMatchesGroupIdsByMatch =
-                          updatedParallelMatchesGroupsIdsByMatch
-                            .filterSets((key, _) => matches.contains(key))
+                          parallelMatchesWithReorganisedGroupIdsByMatch
                         )
                       )
                   else
@@ -1488,518 +1415,17 @@ object MatchAnalysis extends StrictLogging:
 
         result.reconciliationPostcondition()
 
+        val groupsOfParallelMatches =
+          result.parallelMatchesGroupIdsByMatch.groupBy(_._2).map {
+            (groupId, group) => groupId -> group.map(_._1).toSet
+          }
+        logger.debug(
+          s"Groups of parallel matches after reconciliation:\n${pprintCustomised(groupsOfParallelMatches)}"
+        )
+
         result
 
       end reconcileMatches
-
-      def parallelMatchesOnly: MatchesAndTheirSections =
-        // PLAN:
-
-        // 1. Build up sources composed of matched sections concatenated
-        // together by path preserving their original order.
-
-        val baseMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(baseSection, _, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndLeft(baseSection, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndRight(baseSection, _))
-                  if section == baseSection =>
-                section
-            }
-
-        val leftMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, leftSection, _))
-                  if section == leftSection =>
-                section
-              case (section, Match.BaseAndLeft(_, leftSection))
-                  if section == leftSection =>
-                section
-              case (section, Match.LeftAndRight(leftSection, _))
-                  if section == leftSection =>
-                section
-            }
-
-        val rightMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, _, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.BaseAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.LeftAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-            }
-
-        case class MetaMatchContentSources(
-            override val contentsByPath: Map[Path, IndexedSeq[
-              Section[Element]
-            ]],
-            override val label: String
-        ) extends MappedContentSources[Path, Section[Element]]
-
-        def sourcesForMetaMatching(label: String)(
-            sources: Sources[Path, Element],
-            matchedSections: Iterable[Section[Element]]
-        ) = MetaMatchContentSources(
-          contentsByPath = matchedSections
-            .groupBy(sources.pathFor)
-            .map((path, sections) =>
-              path -> sections.toIndexedSeq
-                .sortBy(section =>
-                  // NOTE: use the negative of the section size as a tiebreaker
-                  // if more than one section has the same start offset. This
-                  // makes sure that a subsuming section comes *before* any
-                  // sections that it might subsume, so it can't interpose
-                  // itself within what would have been a run of parallel
-                  // subsumed sections; that way we don't accidentally split
-                  // what should be larger meta-matches. That can occur when the
-                  // subsuming section is contributed by a larger pairwise match
-                  // that subsumes several all-sides matches, and the first
-                  // all-sides match aligns with the start of the pairwise
-                  // match. The test
-                  // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation`
-                  // has an example of this.
-                  section.startOffset -> -section.size
-                )
-            ),
-          label = label
-        )
-
-        val baseSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-base")(
-            baseSources,
-            baseMatchedSections
-          )
-        val leftSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-left")(
-            leftSources,
-            leftMatchedSections
-          )
-        val rightSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-right")(
-            rightSources,
-            rightMatchedSections
-          )
-
-        // 2. Apply `MatchAnalysis.of` to these sections, using the
-        // potential match key of the section to underpin equality and
-        // hashing.
-
-        object metaMatchConfiguration extends AbstractConfiguration:
-          override val minimumMatchSize: Int                    = 1
-          override val thresholdSizeFractionForMatching: Double = 0
-          override val minimumAmbiguousMatchSize: Int           = 1
-          override val ambiguousMatchesThreshold: Int           = Int.MaxValue
-          override val progressRecording: ProgressRecording     =
-            configuration.progressRecording
-        end metaMatchConfiguration
-
-        given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
-
-        given Funnel[Section[Element]] with
-          override def funnel(
-              from: Section[Element],
-              into: PrimitiveSink
-          ): Unit =
-            from.content.foreach(summon[Funnel[Element]].funnel(_, into))
-
-        end given
-
-        val metaMatchAnalysis = of(
-          baseSourcesForMetaMatching,
-          leftSourcesForMetaMatching,
-          rightSourcesForMetaMatching
-        )(metaMatchConfiguration)
-
-        // 3. The resulting meta-matches provide parallel sequences of sections
-        // that are unzipped to yield corresponding all-sides and pairwise
-        // matches.
-
-        val metaMatches = metaMatchAnalysis.matches
-
-        // NOTE: because meta-matching starts with matched *sections* and
-        // ignores gaps, we have to guard against sections that would have
-        // formed the sides of a suppressed outer match making a second attempt
-        // at building a match.
-        val groupsOfBackTranslatedParallelMatches = metaMatches
-          .map {
-            case Match.AllSides(
-                  baseMetaSection,
-                  leftMetaSection,
-                  rightMetaSection
-                ) =>
-              (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAnAllSidesMatch(
-                        baseSection,
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.AllSides(baseSection, leftSection, rightSection)
-                }
-            case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
-              (baseMetaSection.content lazyZip leftMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-                        baseSection,
-                        leftSection
-                      ) =>
-                    Match.BaseAndLeft(baseSection, leftSection)
-                }
-            case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
-              (baseMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-                        baseSection,
-                        rightSection
-                      ) =>
-                    Match.BaseAndRight(baseSection, rightSection)
-                }
-            case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
-              (leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.LeftAndRight(leftSection, rightSection)
-                }
-          }
-          .filter(_.nonEmpty)
-          .toSeq
-
-        // 4. Put the back-translated matches into their own disjoint sets, then
-        // unify those matches that come from the same group of parallel
-        // matches, then unify all-sides matches with pairwise matches that
-        // subsume them, regardless of the original group.
-
-        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
-        // the back-translated matches, because the thinning out of ambiguous
-        // matches performed by the meta-matching and back translation above
-        // means there are new opportunities for matches to be generated - while
-        // the vast majority of these are redundant pairwise matches, there are
-        // some that are vital to capture things such as moves with migrated
-        // edits / deletions - the test
-        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
-        // an example of this.
-        val backTranslatedMatchesAndTheirSections =
-          MatchesAndTheirSections.empty
-            .withMatches(
-              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
-              haveTrimmedMatches = false
-            )
-            .matchesAndTheirSections
-            .withoutRedundantPairwiseMatches
-
-        val backTranslatedMatches =
-          backTranslatedMatchesAndTheirSections.matches
-
-        val parallelMatchesGroupIdsByMatch =
-          MultiDict.from(
-            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
-              (parallelMatches, groupId) => parallelMatches.map(_ -> groupId)
-            )
-          )
-
-        backTranslatedMatchesAndTheirSections
-          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
-      end parallelMatchesOnly
-
-      // Cleans up the state when a putative all-sides match that would have
-      // been ambiguous on one side with another all-sides match was partially
-      // suppressed by a larger pairwise match. This situation results in a
-      // pairwise match that shares its sections on both sides with the other
-      // all-sides match; remove any such redundant pairwise matches.
-      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
-        val redundantMatches =
-          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
-
-        if redundantMatches.nonEmpty then
-          logger.debug(
-            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
-          )
-        end if
-
-        withoutTheseMatches(redundantMatches)
-      end withoutRedundantPairwiseMatches
-
-      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
-        aMatch match
-          case Match.BaseAndLeft(baseSection, leftSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(leftSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.BaseAndRight(baseSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.LeftAndRight(leftSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(leftSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case _: Match.AllSides[Section[Element]] => false
-
-      private def isSubsumedNonTriviallyByAnAllSidesMatch(
-          baseSection: Section[Element],
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAnAllSidesMatch
-
-      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-          baseSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-          baseSection: Section[Element],
-          leftSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
-
-      private def withMatches(
-          matches: Set[GenericMatch[Element]],
-          haveTrimmedMatches: Boolean
-      ): MatchingResult =
-        val updatedMatchesAndTheirSections =
-          matches.foldLeft(this)(_ withMatch _)
-
-        val pathInclusions =
-          if !haveTrimmedMatches then
-            case class PathInclusionsImplementation(
-                basePaths: Set[Path],
-                leftPaths: Set[Path],
-                rightPaths: Set[Path]
-            ) extends PathInclusions:
-              override def isIncludedOnBase(basePath: Path): Boolean =
-                basePaths.contains(basePath)
-
-              override def isIncludedOnLeft(leftPath: Path): Boolean =
-                leftPaths.contains(leftPath)
-
-              override def isIncludedOnRight(rightPath: Path): Boolean =
-                rightPaths.contains(rightPath)
-
-              def addPathOnBaseFor(
-                  baseSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
-              def addPathOnLeftFor(
-                  leftSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
-              def addPathOnRightFor(
-                  rightSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(rightPaths =
-                  rightPaths + rightSources.pathFor(rightSection)
-                )
-            end PathInclusionsImplementation
-
-            matches.foldLeft(
-              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
-            )((partialPathInclusions, aMatch) =>
-              aMatch match
-                case Match.AllSides(baseSection, leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.BaseAndLeft(baseSection, leftSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                case Match.BaseAndRight(baseSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.LeftAndRight(leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-            )
-          else PathInclusions.all
-
-        MatchingResult(
-          matchesAndTheirSections = updatedMatchesAndTheirSections,
-          numberOfMatchesForTheGivenWindowSize = matches.size,
-          estimatedWindowSizeForOptimalMatch =
-            estimateOptimalMatchSize(matches),
-          pathInclusions = pathInclusions
-        )
-      end withMatches
-
-      private def withMatch(
-          aMatch: GenericMatch[Element]
-      ): MatchesAndTheirSections =
-        aMatch match
-          case Match.AllSides(baseSection, leftSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
-              baseFingerprintedInclusionsByPath =
-                knockOutFromBaseFingerprintedInclusions(baseSection),
-              leftFingerprintedInclusionsByPath =
-                knockOutFromLeftFingerprintedInclusions(leftSection),
-              rightFingerprintedInclusionsByPath =
-                knockOutFromRightFingerprintedInclusions(rightSection)
-            )
-          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
-            )
-          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
-            )
-          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
-            copy(
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
-            )
-        end match
-      end withMatch
 
       private def checkInvariant(): Unit =
         // We expect to tally either two lots of a given pairwise match or three
@@ -2614,9 +2040,15 @@ object MatchAnalysis extends StrictLogging:
         // NOTE: we have to be mindful that a pairwise match may have multiple
         // sites where the same content can be matched by a smaller all-sides
         // match that is ambiguous. That can lead to the biting all-sides match
-        // being a 'cross-over', where the two sides aren't correlated - each
-        // side of the all-sides match refers to a different site in the
-        // pairwise match.
+        // being a 'cross-over', where the two sides are misaligned - each side
+        // of the all-sides match refers to a different site in the pairwise
+        // match.
+        // NOTE: the above can also take place when only one of several
+        // potential ambiguous matches isn't suppressed elsewhere - in which
+        // case *no* fragmentation may occur. That leaves the misaligned
+        // all-sides match hanging around with the larger pairwise match still
+        // subsuming it, so it is left to `pareDownOrSuppressCompletely` to sort
+        // that out later on.
         (subsumingOnBase intersect subsumingOnLeft).flatMap {
           case subsuming: Match.BaseAndLeft[Section[Element]] =>
             val offsetRelativeToSubsumingOnBaseSide =
@@ -2673,6 +2105,608 @@ object MatchAnalysis extends StrictLogging:
             )
         }
       end pairwiseMatchesSubsumingOnBothSidesWithBiteEdges
+
+      def parallelMatchesOnly: MatchesAndTheirSections =
+        // PLAN:
+
+        // 1. Build up sources composed of matched sections concatenated
+        // together by path preserving their original order.
+
+        val baseMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(baseSection, _, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndLeft(baseSection, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndRight(baseSection, _))
+                  if section == baseSection =>
+                section
+            }
+
+        val leftMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, leftSection, _))
+                  if section == leftSection =>
+                section
+              case (section, Match.BaseAndLeft(_, leftSection))
+                  if section == leftSection =>
+                section
+              case (section, Match.LeftAndRight(leftSection, _))
+                  if section == leftSection =>
+                section
+            }
+
+        val rightMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, _, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.BaseAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.LeftAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+            }
+
+        case class MetaMatchContentSources(
+            override val contentsByPath: Map[Path, IndexedSeq[
+              Section[Element]
+            ]],
+            override val label: String
+        ) extends MappedContentSources[Path, Section[Element]]
+
+        def sourcesForMetaMatching(label: String)(
+            sources: Sources[Path, Element],
+            matchedSections: Iterable[Section[Element]]
+        ) = MetaMatchContentSources(
+          contentsByPath = matchedSections
+            .groupBy(sources.pathFor)
+            .map((path, sections) =>
+              path -> sections.toIndexedSeq
+                .sortBy(section =>
+                  // NOTE: use the negative of the section size as a tiebreaker
+                  // if more than one section has the same start offset. This
+                  // makes sure that a subsuming section comes *before* any
+                  // sections that it might subsume, so it can't interpose
+                  // itself within what would have been a run of parallel
+                  // subsumed sections; that way we don't accidentally split
+                  // what should be larger meta-matches. That can occur when the
+                  // subsuming section is contributed by a larger pairwise match
+                  // that subsumes several all-sides matches, and the first
+                  // all-sides match aligns with the start of the pairwise
+                  // match. The test
+                  // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation`
+                  // has an example of this.
+                  section.startOffset -> -section.size
+                )
+            ),
+          label = label
+        )
+
+        val baseSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-base")(
+            baseSources,
+            baseMatchedSections
+          )
+        val leftSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-left")(
+            leftSources,
+            leftMatchedSections
+          )
+        val rightSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-right")(
+            rightSources,
+            rightMatchedSections
+          )
+
+        // 2. Apply `MatchAnalysis.of` to these sections, using the
+        // potential match key of the section to underpin equality and
+        // hashing.
+
+        object metaMatchConfiguration extends AbstractConfiguration:
+          override val minimumMatchSize: Int                    = 1
+          override val thresholdSizeFractionForMatching: Double = 0
+          override val minimumAmbiguousMatchSize: Int           = 1
+          override val ambiguousMatchesThreshold: Int           = Int.MaxValue
+          override val progressRecording: ProgressRecording     =
+            configuration.progressRecording
+        end metaMatchConfiguration
+
+        given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
+
+        given Funnel[Section[Element]] with
+          override def funnel(
+              from: Section[Element],
+              into: PrimitiveSink
+          ): Unit =
+            from.content.foreach(summon[Funnel[Element]].funnel(_, into))
+
+        end given
+
+        val metaMatchAnalysis = of(
+          baseSourcesForMetaMatching,
+          leftSourcesForMetaMatching,
+          rightSourcesForMetaMatching
+        )(metaMatchConfiguration)
+
+        // 3. The resulting meta-matches provide parallel sequences of sections
+        // that are unzipped to yield corresponding all-sides and pairwise
+        // matches.
+
+        val metaMatches = metaMatchAnalysis.matches
+
+        // NOTE: because meta-matching starts with matched *sections* and
+        // ignores gaps, we have to guard against sections that would have
+        // formed the sides of a suppressed outer match making a second attempt
+        // at building a match.
+        val groupsOfBackTranslatedParallelMatches = metaMatches
+          .map {
+            case Match.AllSides(
+                  baseMetaSection,
+                  leftMetaSection,
+                  rightMetaSection
+                ) =>
+              (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (baseSection, leftSection, rightSection)
+                      if !isSubsumedNonTriviallyByAnAllSidesMatch(
+                        baseSection,
+                        leftSection,
+                        rightSection
+                      ) =>
+                    Match.AllSides(baseSection, leftSection, rightSection)
+                }
+            case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
+              (baseMetaSection.content lazyZip leftMetaSection.content)
+                .collect {
+                  case (baseSection, leftSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+                        baseSection,
+                        leftSection
+                      ) =>
+                    Match.BaseAndLeft(baseSection, leftSection)
+                }
+            case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
+              (baseMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (baseSection, rightSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+                        baseSection,
+                        rightSection
+                      ) =>
+                    Match.BaseAndRight(baseSection, rightSection)
+                }
+            case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
+              (leftMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (leftSection, rightSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+                        leftSection,
+                        rightSection
+                      ) =>
+                    Match.LeftAndRight(leftSection, rightSection)
+                }
+          }
+          .filter(_.nonEmpty)
+          .toSeq
+
+        // 4. Put the back-translated matches into their own disjoint sets, then
+        // unify those matches that come from the same group of parallel
+        // matches, then unify all-sides matches with pairwise matches that
+        // subsume them, regardless of the original group.
+
+        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
+        // the back-translated matches, because the thinning out of ambiguous
+        // matches performed by the meta-matching and back translation above
+        // means there are new opportunities for matches to be generated - while
+        // the vast majority of these are redundant pairwise matches, there are
+        // some that are vital to capture things such as moves with migrated
+        // edits / deletions - the test
+        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
+        // an example of this.
+        val backTranslatedMatchesAndTheirSections =
+          MatchesAndTheirSections.empty
+            .withMatches(
+              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
+              haveTrimmedMatches = false
+            )
+            .matchesAndTheirSections
+            .withoutRedundantPairwiseMatches
+
+        val backTranslatedMatches =
+          backTranslatedMatchesAndTheirSections.matches
+
+        val parallelMatchesGroupIdsByMatch =
+          MultiDict.from(
+            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
+              (parallelMatches, groupId) => parallelMatches.map(_ -> groupId)
+            )
+          )
+
+        backTranslatedMatchesAndTheirSections
+          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
+      end parallelMatchesOnly
+
+      // Cleans up the state when a putative all-sides match that would have
+      // been ambiguous on one side with another all-sides match was partially
+      // suppressed by a larger pairwise match. This situation results in a
+      // pairwise match that shares its sections on both sides with the other
+      // all-sides match; remove any such redundant pairwise matches.
+      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
+        val redundantMatches =
+          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
+
+        if redundantMatches.nonEmpty then
+          logger.debug(
+            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
+          )
+        end if
+
+        withoutTheseMatches(redundantMatches)
+      end withoutRedundantPairwiseMatches
+
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(allSides)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(baseAndLeft)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(baseAndRight)
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(leftAndRight)
+            )
+        }
+      end withoutTheseMatches
+
+      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
+        aMatch match
+          case Match.BaseAndLeft(baseSection, leftSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(leftSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.BaseAndRight(baseSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.LeftAndRight(leftSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(leftSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case _: Match.AllSides[Section[Element]] => false
+
+      private def isSubsumedNonTriviallyByAnAllSidesMatch(
+          baseSection: Section[Element],
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAnAllSidesMatch
+
+      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+          baseSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+          baseSection: Section[Element],
+          leftSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
+
+      private def withMatches(
+          matches: Set[GenericMatch[Element]],
+          haveTrimmedMatches: Boolean
+      ): MatchingResult =
+        val updatedMatchesAndTheirSections =
+          matches.foldLeft(this)(_ withMatch _)
+
+        val pathInclusions =
+          if !haveTrimmedMatches then
+            case class PathInclusionsImplementation(
+                basePaths: Set[Path],
+                leftPaths: Set[Path],
+                rightPaths: Set[Path]
+            ) extends PathInclusions:
+              override def isIncludedOnBase(basePath: Path): Boolean =
+                basePaths.contains(basePath)
+
+              override def isIncludedOnLeft(leftPath: Path): Boolean =
+                leftPaths.contains(leftPath)
+
+              override def isIncludedOnRight(rightPath: Path): Boolean =
+                rightPaths.contains(rightPath)
+
+              def addPathOnBaseFor(
+                  baseSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
+              def addPathOnLeftFor(
+                  leftSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
+              def addPathOnRightFor(
+                  rightSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(rightPaths =
+                  rightPaths + rightSources.pathFor(rightSection)
+                )
+            end PathInclusionsImplementation
+
+            matches.foldLeft(
+              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
+            )((partialPathInclusions, aMatch) =>
+              aMatch match
+                case Match.AllSides(baseSection, leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.BaseAndLeft(baseSection, leftSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                case Match.BaseAndRight(baseSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.LeftAndRight(leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+            )
+          else PathInclusions.all
+
+        MatchingResult(
+          matchesAndTheirSections = updatedMatchesAndTheirSections,
+          numberOfMatchesForTheGivenWindowSize = matches.size,
+          estimatedWindowSizeForOptimalMatch =
+            estimateOptimalMatchSize(matches),
+          pathInclusions = pathInclusions
+        )
+      end withMatches
+
+      private def withMatch(
+          aMatch: GenericMatch[Element]
+      ): MatchesAndTheirSections =
+        aMatch match
+          case Match.AllSides(baseSection, leftSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
+              baseFingerprintedInclusionsByPath =
+                knockOutFromBaseFingerprintedInclusions(baseSection),
+              leftFingerprintedInclusionsByPath =
+                knockOutFromLeftFingerprintedInclusions(leftSection),
+              rightFingerprintedInclusionsByPath =
+                knockOutFromRightFingerprintedInclusions(rightSection)
+            )
+          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
+            )
+          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
+            )
+          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
+            copy(
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
+            )
+        end match
+      end withMatch
 
       private def pairwiseMatchesSubsumingOnBothSides(
           allSides: Match.AllSides[Section[Element]]

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -745,50 +745,53 @@ object MatchAnalysis extends StrictLogging:
               sortedBiteEdges = groupIdsBySortedBiteEdge.keySet
 
               (
-                fragmentsFromPairwiseMatch: Vector[PairwiseMatch],
-                groupIdsForFragments: Vector[Set[ParallelMatchesGroupId]]
+                fragmentsFromPairwiseMatch,
+                groupIdsForFragments
               ) =
-                (pairwiseMatch match
-                  case Match.BaseAndLeft(baseSection, leftSection) =>
-                    (sortedBiteEdges.eatIntoSection(
-                      baseSources,
-                      baseSection
-                    ) zip sortedBiteEdges.eatIntoSection(
-                      leftSources,
-                      leftSection
-                    ))
-                      .map(Match.BaseAndLeft.apply) -> sortedBiteEdges
-                      .assignParallelMatchesGroupIdsForFragments(
-                        groupIdsBySortedBiteEdge,
-                        sectionSize = baseSection.size
+                {
+                  val triples = pairwiseMatch match
+                    case Match.BaseAndLeft(baseSection, leftSection) =>
+                      sortedBiteEdges.eatIntoSection(
+                        baseSources,
+                        baseSection,
+                        leftSources,
+                        leftSection,
+                        groupIdsBySortedBiteEdge
                       )
+                    case Match.BaseAndRight(baseSection, rightSection) =>
+                      sortedBiteEdges.eatIntoSection(
+                        baseSources,
+                        baseSection,
+                        rightSources,
+                        rightSection,
+                        groupIdsBySortedBiteEdge
+                      )
+                    case Match.LeftAndRight(leftSection, rightSection) =>
+                      sortedBiteEdges.eatIntoSection(
+                        leftSources,
+                        leftSection,
+                        rightSources,
+                        rightSection,
+                        groupIdsBySortedBiteEdge
+                      )
+                  end triples
 
-                  case Match.BaseAndRight(baseSection, rightSection) =>
-                    (sortedBiteEdges.eatIntoSection(
-                      baseSources,
-                      baseSection
-                    ) zip sortedBiteEdges.eatIntoSection(
-                      rightSources,
-                      rightSection
-                    )).map(Match.BaseAndRight.apply) -> sortedBiteEdges
-                      .assignParallelMatchesGroupIdsForFragments(
-                        groupIdsBySortedBiteEdge,
-                        sectionSize = baseSection.size
-                      )
+                  val fragments = triples.map {
+                    case (firstSection, secondSection, _) =>
+                      (pairwiseMatch match
+                        case Match.BaseAndLeft(_, _) =>
+                          Match.BaseAndLeft(firstSection, secondSection)
+                        case Match.BaseAndRight(_, _) =>
+                          Match.BaseAndRight(firstSection, secondSection)
+                        case Match.LeftAndRight(_, _) =>
+                          Match.LeftAndRight(firstSection, secondSection)
+                      ).asInstanceOf[PairwiseMatch]
+                  }
 
-                  case Match.LeftAndRight(leftSection, rightSection) =>
-                    (sortedBiteEdges.eatIntoSection(
-                      leftSources,
-                      leftSection
-                    ) zip sortedBiteEdges.eatIntoSection(
-                      rightSources,
-                      rightSection
-                    )).map(Match.LeftAndRight.apply) -> sortedBiteEdges
-                      .assignParallelMatchesGroupIdsForFragments(
-                        groupIdsBySortedBiteEdge,
-                        sectionSize = leftSection.size
-                      )
-                ): @unchecked
+                  val groupIds = triples.map(_._3)
+
+                  fragments -> groupIds
+                }
 
               _ <- fragmentsFromPairwiseMatch
                 .zip(groupIdsForFragments)
@@ -806,150 +809,112 @@ object MatchAnalysis extends StrictLogging:
       // bite edges to be sorted in terms of their offsets and not exceed the
       // section's boundaries.
       extension (biteEdges: SortedSet[BiteEdge])
-        // Breaks up a section by eating into it with smaller bites, yielding
-        // the fragment sections.
         private def eatIntoSection(
-            side: Sources[Path, Element],
-            section: Section[Element]
-        ): Vector[Section[Element]] =
-          // NOTE: here we work in terms of offsets into `section`, hence we
-          // must bias the offsets from the bite edges. Compare with
-          // `assignParallelMatchesGroupIdsForFragments`.
-
-          val mealOnePastEndOffset: Int = section.onePastEndOffset
-
-          val path = side.pathFor(section)
-
-          case class State(
-              mealStartOffset: Int,
-              biteDepth: Int
-          ):
-            @tailrec
-            final def apply(
-                biteEdges: Seq[BiteEdge],
-                fragments: Vector[Section[Element]]
-            ): Vector[Section[Element]] =
-              biteEdges match
-                case Seq() =>
-                  if mealOnePastEndOffset > mealStartOffset then
-                    fragments.appended(
-                      side.section(path)(
-                        startOffset = mealStartOffset,
-                        size = mealOnePastEndOffset - mealStartOffset
-                      )
-                    )
-                  else fragments
-                case Seq(
-                      BiteEdge.Start(startOffsetRelativeToMeal),
-                      remainingBiteEdges*
-                    ) =>
-                  val startOffset =
-                    section.startOffset + startOffsetRelativeToMeal
-
-                  require(startOffset >= mealStartOffset)
-                  require(mealOnePastEndOffset > startOffset)
-                  this
-                    .copy(
-                      mealStartOffset = startOffset,
-                      biteDepth = 1 + biteDepth
-                    )
-                    .apply(
-                      remainingBiteEdges,
-                      fragments =
-                        if 0 == biteDepth && startOffset > mealStartOffset
-                        then
-                          fragments.appended(
-                            side.section(path)(
-                              startOffset = mealStartOffset,
-                              size = startOffset - mealStartOffset
-                            )
-                          )
-                        else fragments
-                    )
-                case Seq(
-                      BiteEdge.End(onePastEndOffsetRelativeToMeal),
-                      remainingBiteEdges*
-                    ) =>
-                  assume(0 < biteDepth)
-
-                  val onePastEndOffset =
-                    section.startOffset + onePastEndOffsetRelativeToMeal
-
-                  require(mealStartOffset <= onePastEndOffset)
-                  require(onePastEndOffset <= mealOnePastEndOffset)
-                  this
-                    .copy(
-                      mealStartOffset = onePastEndOffset,
-                      biteDepth = biteDepth - 1
-                    )
-                    .apply(remainingBiteEdges, fragments)
-          end State
-
-          State(
-            mealStartOffset = section.startOffset,
-            biteDepth = 0
-          )(biteEdges.toSeq, fragments = Vector.empty)
-        end eatIntoSection
-
-        private def assignParallelMatchesGroupIdsForFragments(
+            firstSide: Sources[Path, Element],
+            firstSection: Section[Element],
+            secondSide: Sources[Path, Element],
+            secondSection: Section[Element],
             groupIdsBySortedBiteEdge: Map[BiteEdge, collection.Set[
               ParallelMatchesGroupId
-            ]],
-            sectionSize: Int
-        ): Vector[Set[ParallelMatchesGroupId]] =
+            ]]
+        ): Vector[
+          (Section[Element], Section[Element], Set[ParallelMatchesGroupId])
+        ] =
           // NOTE: here we work with zero-relative offsets from the start of the
           // meal, thus we can work directly with the offsets from the bite
-          // edges. Compare with `eatIntoSection`.
+          // edges.
+
+          val firstPath  = firstSide.pathFor(firstSection)
+          val secondPath = secondSide.pathFor(secondSection)
+
+          val sectionSize = firstSection.size
+          assume(sectionSize == secondSection.size)
 
           case class State(
               groupIdsFromPreviousBite: Set[ParallelMatchesGroupId],
-              mealStartOffset: Int,
+              mealStartOffsetRelativeToMeal: Int,
               biteDepth: Int
           ):
             @tailrec
             final def apply(
-                biteEdges: Seq[BiteEdge],
-                fragments: Vector[Set[ParallelMatchesGroupId]]
-            ): Vector[Set[ParallelMatchesGroupId]] =
-              biteEdges match
+                remainingBiteEdges: Seq[BiteEdge],
+                fragments: Vector[
+                  (
+                      Section[Element],
+                      Section[Element],
+                      Set[ParallelMatchesGroupId]
+                  )
+                ]
+            ): Vector[
+              (Section[Element], Section[Element], Set[ParallelMatchesGroupId])
+            ] =
+              remainingBiteEdges match
                 case Seq() =>
-                  if sectionSize > mealStartOffset then
-                    fragments.appended(groupIdsFromPreviousBite)
+                  if sectionSize > mealStartOffsetRelativeToMeal then
+                    val size = sectionSize - mealStartOffsetRelativeToMeal
+                    fragments.appended(
+                      (
+                        firstSide.section(firstPath)(
+                          firstSection.startOffset + mealStartOffsetRelativeToMeal,
+                          size
+                        ),
+                        secondSide.section(secondPath)(
+                          secondSection.startOffset + mealStartOffsetRelativeToMeal,
+                          size
+                        ),
+                        groupIdsFromPreviousBite
+                      )
+                    )
                   else fragments
+
                 case Seq(
                       biteEdge @ BiteEdge.Start(startOffsetRelativeToMeal),
-                      remainingBiteEdges*
+                      tail*
                     ) =>
-                  require(startOffsetRelativeToMeal >= mealStartOffset)
+                  require(
+                    startOffsetRelativeToMeal >= mealStartOffsetRelativeToMeal
+                  )
                   require(sectionSize > startOffsetRelativeToMeal)
+
+                  val updatedFragments =
+                    if 0 == biteDepth && startOffsetRelativeToMeal > mealStartOffsetRelativeToMeal
+                    then
+                      val size =
+                        startOffsetRelativeToMeal - mealStartOffsetRelativeToMeal
+                      fragments.appended(
+                        (
+                          firstSide.section(firstPath)(
+                            firstSection.startOffset + mealStartOffsetRelativeToMeal,
+                            size
+                          ),
+                          secondSide.section(secondPath)(
+                            secondSection.startOffset + mealStartOffsetRelativeToMeal,
+                            size
+                          ),
+                          groupIdsFromPreviousBite union groupIdsBySortedBiteEdge(
+                            biteEdge
+                          ).toSet
+                        )
+                      )
+                    else fragments
 
                   this
                     .copy(
                       groupIdsFromPreviousBite = Set.empty,
-                      mealStartOffset = startOffsetRelativeToMeal,
+                      mealStartOffsetRelativeToMeal = startOffsetRelativeToMeal,
                       biteDepth = 1 + biteDepth
                     )
-                    .apply(
-                      remainingBiteEdges,
-                      fragments =
-                        // NOTE: nested or overlapping bites to the right don't
-                        // contribute group ids to the *preceding* context.
-                        if 0 == biteDepth && startOffsetRelativeToMeal > mealStartOffset
-                        then
-                          fragments.appended(
-                            groupIdsFromPreviousBite union groupIdsBySortedBiteEdge(
-                              biteEdge
-                            )
-                          )
-                        else fragments
-                    )
+                    .apply(tail, updatedFragments)
+
                 case Seq(
                       biteEdge @ BiteEdge.End(onePastEndOffsetRelativeToMeal),
-                      remainingBiteEdges*
+                      tail*
                     ) =>
                   assume(0 < biteDepth)
 
-                  require(mealStartOffset <= onePastEndOffsetRelativeToMeal)
+                  require(
+                    mealStartOffsetRelativeToMeal <= onePastEndOffsetRelativeToMeal
+                  )
                   require(onePastEndOffsetRelativeToMeal <= sectionSize)
 
                   this
@@ -959,18 +924,21 @@ object MatchAnalysis extends StrictLogging:
                       // *succeeding* context.
                       groupIdsFromPreviousBite =
                         groupIdsBySortedBiteEdge(biteEdge).toSet,
-                      mealStartOffset = onePastEndOffsetRelativeToMeal,
+                      mealStartOffsetRelativeToMeal =
+                        onePastEndOffsetRelativeToMeal,
                       biteDepth = biteDepth - 1
                     )
-                    .apply(remainingBiteEdges, fragments)
+                    .apply(tail, fragments)
+              end match
+            end apply
           end State
 
           State(
             groupIdsFromPreviousBite = Set.empty,
-            mealStartOffset = 0,
+            mealStartOffsetRelativeToMeal = 0,
             biteDepth = 0
           )(biteEdges.toSeq, fragments = Vector.empty)
-        end assignParallelMatchesGroupIdsForFragments
+        end eatIntoSection
 
       end extension
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1684,37 +1684,48 @@ object MatchAnalysis extends StrictLogging:
                   firstSideStartOffset: GenericMatch[Element] => Option[Int],
                   secondSideStartOffset: GenericMatch[Element] => Option[Int]
               ): Unit =
-                val matchesWithOffsets = matchesInGroup
-                  .flatMap(aMatch =>
-                    for
-                      offset1 <- firstSideStartOffset(aMatch)
-                      offset2 <- secondSideStartOffset(aMatch)
-                    yield (aMatch, offset1, offset2)
-                  )
+                val commonMatches = matchesInGroup.filter(aMatch =>
+                  firstSideStartOffset(aMatch).isDefined &&
+                    secondSideStartOffset(aMatch).isDefined
+                )
 
-                for
-                  (matchA, offset1A, offset2A) <- matchesWithOffsets
-                  (matchB, offset1B, offset2B) <- matchesWithOffsets
-                  if matchA != matchB
-                  if offset1A <= offset1B
-                do
+                if commonMatches.size > 1 then
+                  // Canonical order to break ties in a way that is consistent
+                  // across all sides.
+                  val commonMatchesInCanonicalOrder =
+                    commonMatches.toSeq.sortBy(MatchSynopsis.apply(_).toString)
+
+                  val commonMatchesOrderedFromFirstSidePerspective =
+                    commonMatchesInCanonicalOrder
+                      .sortBy(aMatch => firstSideStartOffset(aMatch).get)
+                  val commonMatchesOrderedFromSecondSidePerspective =
+                    commonMatchesInCanonicalOrder
+                      .sortBy(aMatch => secondSideStartOffset(aMatch).get)
+
                   assert(
-                    offset2A <= offset2B,
+                    commonMatchesOrderedFromFirstSidePerspective == commonMatchesOrderedFromSecondSidePerspective,
                     s"""
                        |Expected a consistent ordering of matches relevant to the sides $firstSide and $secondSide.
-                       |Total of ${matchesWithOffsets.size} common matches, up to 10 follow...
-                       |Relative order should be consistent between $firstSide and $secondSide,
-                       |but ${pprintCustomised(
-                        MatchSynopsis(matchA)
-                      )} and ${pprintCustomised(
-                        MatchSynopsis(matchB)
-                      )} are out of order.
-                       |Matches are:
+                       |Total of ${commonMatches.size} common matches, up to 10 follow...
+                       |On the $firstSide they are:
                        |${pprintCustomised(
-                        matchesWithOffsets.take(10).map(_._1).map(MatchSynopsis.apply)
-                      )}""".stripMargin
+                        commonMatchesOrderedFromFirstSidePerspective
+                          .take(10)
+                          .map(
+                            MatchSynopsis.apply
+                          )
+                      )}
+                       |and on the $secondSide they are:
+                       |${pprintCustomised(
+                        commonMatchesOrderedFromSecondSidePerspective
+                          .take(10)
+                          .map(
+                            MatchSynopsis.apply
+                          )
+                      )}
+                       |""".stripMargin
                   )
-                end for
+                end if
               end checkOrderIsConsistentAcrossSides
 
               checkOrderIsConsistentAcrossSides(

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -922,16 +922,18 @@ object MatchAnalysis extends StrictLogging:
                     ) =>
                   require(startOffsetRelativeToMeal >= mealStartOffset)
                   require(sectionSize > startOffsetRelativeToMeal)
+
                   this
                     .copy(
-                      groupIdsFromPreviousBite =
-                        Set.empty, // TODO: review this - what about nested or overlapping bites?
+                      groupIdsFromPreviousBite = Set.empty,
                       mealStartOffset = startOffsetRelativeToMeal,
                       biteDepth = 1 + biteDepth
                     )
                     .apply(
                       remainingBiteEdges,
                       fragments =
+                        // NOTE: nested or overlapping bites to the right don't
+                        // contribute group ids to the *preceding* context.
                         if 0 == biteDepth && startOffsetRelativeToMeal > mealStartOffset
                         then
                           fragments.appended(
@@ -949,8 +951,12 @@ object MatchAnalysis extends StrictLogging:
 
                   require(mealStartOffset <= onePastEndOffsetRelativeToMeal)
                   require(onePastEndOffsetRelativeToMeal <= sectionSize)
+
                   this
                     .copy(
+                      // NOTE: nested or overlapping bites to the right
+                      // overwrite any prior contribution of group ids to the
+                      // *succeeding* context.
                       groupIdsFromPreviousBite =
                         groupIdsBySortedBiteEdge(biteEdge).toSet,
                       mealStartOffset = onePastEndOffsetRelativeToMeal,
@@ -1288,6 +1294,99 @@ object MatchAnalysis extends StrictLogging:
         else this
         end if
       end purgedOfMatchesWithOverlappingSections
+
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(allSides)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(baseAndLeft)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(baseAndRight)
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removeKey(leftAndRight)
+            )
+        }
+      end withoutTheseMatches
 
       def reconcileMatches: MatchesAndTheirSections =
         val matches = sectionsAndTheirMatches.values.toSet
@@ -1704,99 +1803,6 @@ object MatchAnalysis extends StrictLogging:
 
         withoutTheseMatches(redundantMatches)
       end withoutRedundantPairwiseMatches
-
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(allSides)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(baseAndLeft)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(baseAndRight)
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(leftAndRight)
-            )
-        }
-      end withoutTheseMatches
 
       private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
         aMatch match


### PR DESCRIPTION
Modified `MatchAnalysis.scala` to bolster the invariant for parallel matches. The new invariant checks that all matches in a group share consistent file paths for each side. This required adding a refinement step at the end of `reconcileMatches` to split groups that became path-inconsistent due to code motion splits during the reconciliation process. Verified with existing tests, specifically split code motion scenarios.

---
*PR created automatically by Jules for task [12478530646517858524](https://jules.google.com/task/12478530646517858524) started by @sageserpent-open*