### PR TITLE
Approximate per-file LCS using parallel match groups

### DIFF
--- a/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
@@ -151,6 +151,58 @@ end LongestCommonSubsequence
 
 object LongestCommonSubsequence:
 
+  def apply[Element](
+      base: IndexedSeq[Contribution[Element]],
+      left: IndexedSeq[Contribution[Element]],
+      right: IndexedSeq[Contribution[Element]]
+  )(elementSize: Element => Int): LongestCommonSubsequence[Element] =
+    def commonSubsequenceSize(
+        contributions: IndexedSeq[Contribution[Element]]
+    ): CommonSubsequenceSize =
+      contributions.foldLeft(CommonSubsequenceSize.zero) {
+        case (partialSize, Contribution.Common(element)) =>
+          partialSize.addCostOfASingleContribution(elementSize(element))
+        case (partialSize, _) => partialSize
+      }
+
+    def commonToLeftAndRightOnlySize(
+        contributions: IndexedSeq[Contribution[Element]]
+    ): CommonSubsequenceSize =
+      contributions.foldLeft(CommonSubsequenceSize.zero) {
+        case (partialSize, Contribution.CommonToLeftAndRightOnly(element)) =>
+          partialSize.addCostOfASingleContribution(elementSize(element))
+        case (partialSize, _) => partialSize
+      }
+
+    def commonToBaseAndLeftOnlySize(
+        contributions: IndexedSeq[Contribution[Element]]
+    ): CommonSubsequenceSize =
+      contributions.foldLeft(CommonSubsequenceSize.zero) {
+        case (partialSize, Contribution.CommonToBaseAndLeftOnly(element)) =>
+          partialSize.addCostOfASingleContribution(elementSize(element))
+        case (partialSize, _) => partialSize
+      }
+
+    def commonToBaseAndRightOnlySize(
+        contributions: IndexedSeq[Contribution[Element]]
+    ): CommonSubsequenceSize =
+      contributions.foldLeft(CommonSubsequenceSize.zero) {
+        case (partialSize, Contribution.CommonToBaseAndRightOnly(element)) =>
+          partialSize.addCostOfASingleContribution(elementSize(element))
+        case (partialSize, _) => partialSize
+      }
+
+    new LongestCommonSubsequence(
+      base = base,
+      left = left,
+      right = right,
+      commonSubsequenceSize = commonSubsequenceSize(base),
+      commonToLeftAndRightOnlySize = commonToLeftAndRightOnlySize(left),
+      commonToBaseAndLeftOnlySize = commonToBaseAndLeftOnlySize(base),
+      commonToBaseAndRightOnlySize = commonToBaseAndRightOnlySize(base)
+    )
+  end apply
+
   def defaultElementSize[Element](irrelevant: Element): Int = 1
 
   def of[Element: Eq: Sized](

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -58,6 +58,8 @@ trait MatchAnalysis[Path, Element]:
 
   def sectionsAndTheirMatches: MatchedSections[Element]
 
+  def parallelMatchesGroupIdsByMatch: MultiDict[GenericMatch[Element], Int]
+
   def matches: Set[GenericMatch[Element]] =
     sectionsAndTheirMatches.values.toSet
 end MatchAnalysis

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -12,7 +12,8 @@ import com.google.common.hash.{Funnel, HashFunction, PrimitiveSink}
 import com.sageserpent.kineticmerge
 import com.sageserpent.kineticmerge.core.MatchAnalysis.{
   GenericMatch,
-  MatchedSections
+  MatchedSections,
+  ParallelMatchesGroupIdsByMatch
 }
 import com.sageserpent.kineticmerge.{
   NoProgressRecording,
@@ -58,7 +59,7 @@ trait MatchAnalysis[Path, Element]:
 
   def sectionsAndTheirMatches: MatchedSections[Element]
 
-  def parallelMatchesGroupIdsByMatch: MultiDict[GenericMatch[Element], Int]
+  def parallelMatchesGroupIdsByMatch: ParallelMatchesGroupIdsByMatch[Element]
 
   def matches: Set[GenericMatch[Element]] =
     sectionsAndTheirMatches.values.toSet
@@ -68,6 +69,11 @@ object MatchAnalysis extends StrictLogging:
   type GenericMatch[Element]    = Match[Section[Element]]
   type MatchedSections[Element] =
     MultiDict[Section[Element], GenericMatch[Element]]
+
+  type ParallelMatchesGroupId = Int
+
+  type ParallelMatchesGroupIdsByMatch[Element] =
+    MultiDict[GenericMatch[Element], ParallelMatchesGroupId]
 
   /** Analyse matches between the sources of {@code base}, {@code left} and
     * {@code right}.
@@ -188,10 +194,8 @@ object MatchAnalysis extends StrictLogging:
 
     type FingerprintedInclusions = Diet[Int]
 
-    type ParallelMatchesGroupId = Int
-
     type ParallelMatchesGroupIdsByMatch =
-      MultiDict[GenericMatch[Element], ParallelMatchesGroupId]
+      MatchAnalysis.ParallelMatchesGroupIdsByMatch[Element]
 
     val tiebreakContentSamplingLimit = 5
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
@@ -101,154 +101,80 @@ object SectionedCode extends StrictLogging:
         )
 
       Right(new SectionedCode[Path, Element]:
-        private val lcsByPath: Map[Path, LongestCommonSubsequence[Section[
-          Element
-        ]]] =
-          val parallelMatchesGroupIdsByMatch =
-            matchesAndTheirSections.parallelMatchesGroupIdsByMatch
-          val tinyParallelMatchesGroupIdsByMatch =
-            tinyMatchesAndTheirSectionsOnly.parallelMatchesGroupIdsByMatch
+        private val lcsByPath: mutable.Map[Path, LongestCommonSubsequence[
+          Section[Element]
+        ]] = mutable.Map.empty
 
-          val tinyIdOffset =
-            1 + (parallelMatchesGroupIdsByMatch.values.toSeq.maxOption
-              .getOrElse(0))
+        override def base: Map[Path, File[Element]] = baseFilesByPath
 
-          def groupIdFor(m: Match[Section[Element]]): Option[Int] =
-            parallelMatchesGroupIdsByMatch
-              .get(m)
-              .headOption
-              .orElse(
-                tinyParallelMatchesGroupIdsByMatch
-                  .get(m)
-                  .headOption
-                  .map(_ + tinyIdOffset)
+        override def left: Map[Path, File[Element]] = leftFilesByPath
+
+        override def right: Map[Path, File[Element]] = rightFilesByPath
+
+        override def matchesFor(
+            section: Section[Element]
+        ): collection.Set[Match[Section[Element]]] =
+          sectionsAndTheirMatches.get(section)
+
+        override def lcsFor(
+            path: Path
+        ): LongestCommonSubsequence[Section[Element]] =
+          lcsByPath.getOrElseUpdate(
+            path, {
+              val baseSections =
+                baseFilesByPath
+                  .get(path)
+                  .map(_.sections)
+                  .getOrElse(IndexedSeq.empty)
+              val leftSections =
+                leftFilesByPath
+                  .get(path)
+                  .map(_.sections)
+                  .getOrElse(IndexedSeq.empty)
+              val rightSections =
+                rightFilesByPath
+                  .get(path)
+                  .map(_.sections)
+                  .getOrElse(IndexedSeq.empty)
+
+              given Sized[Section[Element]] = _.size
+
+              given Eq[Section[Element]] with
+                override def eqv(
+                    lhs: Section[Element],
+                    rhs: Section[Element]
+                ): Boolean =
+                  val matchesForLhs =
+                    matchesAndTheirSections.sectionsAndTheirMatches.get(lhs) ++
+                      tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
+                        .get(lhs)
+                  val matchesForRhs =
+                    matchesAndTheirSections.sectionsAndTheirMatches.get(rhs) ++
+                      tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
+                        .get(rhs)
+                  val bothBelongToTheSameMatches =
+                    matchesForLhs.intersect(matchesForRhs).nonEmpty
+
+                  bothBelongToTheSameMatches || (lhs.size == rhs.size && Eq[
+                    Seq[Element]
+                  ].eqv(lhs.content, rhs.content))
+              end given
+
+              LongestCommonSubsequence.of(
+                baseSections,
+                leftSections,
+                rightSections
+              )(using
+                Eq[Section[Element]],
+                summon[Sized[Section[Element]]],
+                com.sageserpent.kineticmerge.NoProgressRecording
               )
-
-          case class Block(
-              sections: IndexedSeq[Section[Element]]
+            }
           )
 
-          def sectionLcsFor(
-              path: Path
-          ): LongestCommonSubsequence[Section[Element]] = {
-            val baseSections =
-              baseFilesByPath
-                .get(path)
-                .map(_.sections)
-                .getOrElse(IndexedSeq.empty)
-            val leftSections =
-              leftFilesByPath
-                .get(path)
-                .map(_.sections)
-                .getOrElse(IndexedSeq.empty)
-            val rightSections =
-              rightFilesByPath
-                .get(path)
-                .map(_.sections)
-                .getOrElse(IndexedSeq.empty)
-
-            def groupIdsForSection(s: Section[Element]): Set[Int] =
-              (matchesAndTheirSections.sectionsAndTheirMatches.get(s) ++
-                tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches.get(s))
-                .flatMap(groupIdFor)
-                .toSet
-
-            def compress(
-                sections: IndexedSeq[Section[Element]]
-            ): IndexedSeq[Block] = {
-              val blocks = mutable.ArrayBuffer.empty[Block]
-              var currentGroupIds = Set.empty[Int]
-              val currentSections = mutable.ArrayBuffer.empty[Section[Element]]
-
-              for (s <- sections) {
-                val gIds = groupIdsForSection(s)
-                if (gIds.nonEmpty && gIds == currentGroupIds) {
-                  currentSections += s
-                } else {
-                  if (currentSections.nonEmpty) {
-                    blocks += Block(currentSections.toIndexedSeq)
-                    currentSections.clear()
-                  }
-                  if (gIds.nonEmpty) {
-                    currentSections += s
-                    currentGroupIds = gIds
-                  } else {
-                    blocks += Block(IndexedSeq(s))
-                    currentGroupIds = Set.empty
-                  }
-                }
-              }
-              if (currentSections.nonEmpty) {
-                blocks += Block(currentSections.toIndexedSeq)
-              }
-              blocks.toIndexedSeq
-            }
-
-            val baseBlocks = compress(baseSections)
-            val leftBlocks = compress(leftSections)
-            val rightBlocks = compress(rightSections)
-
-            given Sized[Block] = _.sections.map(_.size).sum
-
-            given Eq[Block] with
-              override def eqv(x: Block, y: Block): Boolean =
-                x.sections.size == y.sections.size &&
-                  x.sections.zip(y.sections).forall { (s1, s2) =>
-                    val ms1 =
-                      matchesAndTheirSections.sectionsAndTheirMatches.get(s1) ++
-                        tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
-                          .get(s1)
-                    val ms2 =
-                      matchesAndTheirSections.sectionsAndTheirMatches.get(s2) ++
-                        tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
-                          .get(s2)
-                    ms1.intersect(ms2).nonEmpty || (
-                      s1.size == s2.size && Eq[Seq[Element]].eqv(
-                        s1.content,
-                        s2.content
-                      )
-                    )
-                  }
-            end given
-
-            val blockLcs = LongestCommonSubsequence.of(
-              baseBlocks,
-              leftBlocks,
-              rightBlocks
-            )(using
-              Eq[Block],
-              summon[Sized[Block]],
-              com.sageserpent.kineticmerge.NoProgressRecording
-            )
-
-            def expand(
-                contributions: IndexedSeq[Contribution[Block]]
-            ): IndexedSeq[Contribution[Section[Element]]] =
-              contributions.flatMap {
-                case Contribution.Common(b) =>
-                  b.sections.map(Contribution.Common.apply)
-                case Contribution.Difference(b) =>
-                  b.sections.map(Contribution.Difference.apply)
-                case Contribution.CommonToBaseAndLeftOnly(b) =>
-                  b.sections.map(Contribution.CommonToBaseAndLeftOnly.apply)
-                case Contribution.CommonToBaseAndRightOnly(b) =>
-                  b.sections.map(Contribution.CommonToBaseAndRightOnly.apply)
-                case Contribution.CommonToLeftAndRightOnly(b) =>
-                  b.sections.map(Contribution.CommonToLeftAndRightOnly.apply)
-              }
-
-            given Sized[Section[Element]] = _.size
-
-            LongestCommonSubsequence(
-              expand(blockLcs.base),
-              expand(blockLcs.left),
-              expand(blockLcs.right)
-            )(summon[Sized[Section[Element]]].sizeOf)
-          }
-
-          val paths =
-            baseFilesByPath.keySet ++ leftFilesByPath.keySet ++ rightFilesByPath.keySet
-          paths.map(path => path -> sectionLcsFor(path)).toMap
+        export baseSources.pathFor as basePathFor
+        export leftSources.pathFor as leftPathFor
+        export rightSources.pathFor as rightPathFor
         {
           // Invariant: the matches are referenced only by their participating
           // sections.
@@ -298,25 +224,7 @@ object SectionedCode extends StrictLogging:
             s"Found rogue matches whose sections do not belong to the breakdown: ${pprintCustomised(rogueMatches)}."
           )
         }
-
-        override def base: Map[Path, File[Element]] = baseFilesByPath
-
-        override def left: Map[Path, File[Element]] = leftFilesByPath
-
-        override def right: Map[Path, File[Element]] = rightFilesByPath
-
-        override def matchesFor(
-            section: Section[Element]
-        ): collection.Set[Match[Section[Element]]] =
-          sectionsAndTheirMatches.get(section)
-
-        override def lcsFor(
-            path: Path
-        ): LongestCommonSubsequence[Section[Element]] = lcsByPath(path)
-
-        export baseSources.pathFor as basePathFor
-        export leftSources.pathFor as leftPathFor
-        export rightSources.pathFor as rightPathFor)
+      )
     catch
       // NOTE: don't convert this to use of `Try` with a subsequent `.toEither`
       // conversion. We want most flavours of exception to propagate, as they

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
@@ -4,9 +4,14 @@ import cats.Eq
 import com.google.common.hash.{Funnel, HashFunction}
 import com.sageserpent.kineticmerge
 import com.sageserpent.kineticmerge.core
+import com.sageserpent.kineticmerge.core.LongestCommonSubsequence.{
+  Contribution,
+  Sized
+}
 import com.sageserpent.kineticmerge.core.MatchAnalysis.{
   AbstractConfiguration,
-  AdmissibleFailure
+  AdmissibleFailure,
+  ParallelMatchesGroupIdsByMatch
 }
 import com.typesafe.scalalogging.StrictLogging
 
@@ -20,6 +25,8 @@ trait SectionedCode[Path, Element]:
   def matchesFor(
       section: Section[Element]
   ): collection.Set[Match[Section[Element]]]
+
+  def lcsFor(path: Path): LongestCommonSubsequence[Section[Element]]
 
   def basePathFor(baseSection: Section[Element]): Path
   def leftPathFor(leftSection: Section[Element]): Path
@@ -110,6 +117,146 @@ object SectionedCode extends StrictLogging:
         ): collection.Set[Match[Section[Element]]] =
           sectionsAndTheirMatches.get(section)
 
+        override def lcsFor(
+            path: Path
+        ): LongestCommonSubsequence[Section[Element]] =
+          lcsByPath.getOrElseUpdate(
+            path, {
+              val baseSections =
+                baseFilesByPath
+                  .get(path)
+                  .map(_.sections)
+                  .getOrElse(IndexedSeq.empty)
+              val leftSections =
+                leftFilesByPath
+                  .get(path)
+                  .map(_.sections)
+                  .getOrElse(IndexedSeq.empty)
+              val rightSections =
+                rightFilesByPath
+                  .get(path)
+                  .map(_.sections)
+                  .getOrElse(IndexedSeq.empty)
+
+              val parallelMatchesGroupIdsByMatch =
+                matchesAndTheirSections.parallelMatchesGroupIdsByMatch
+              val tinyParallelMatchesGroupIdsByMatch =
+                tinyMatchesAndTheirSectionsOnly.parallelMatchesGroupIdsByMatch
+
+              val tinyIdOffset =
+                1 + parallelMatchesGroupIdsByMatch.values
+                  .foldLeft(0)(_ max _)
+
+              def groupIdFor(m: Match[Section[Element]]): Option[Int] =
+                parallelMatchesGroupIdsByMatch
+                  .get(m)
+                  .headOption
+                  .orElse(
+                    tinyParallelMatchesGroupIdsByMatch
+                      .get(m)
+                      .headOption
+                      .map(_ + tinyIdOffset)
+                  )
+
+              def groupIdsForSection(s: Section[Element]): Set[Int] =
+                (matchesAndTheirSections.sectionsAndTheirMatches.get(s) ++
+                  tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches.get(s))
+                  .flatMap(groupIdFor)
+                  .toSet
+
+              case class Block(
+                  groupIds: Set[Int],
+                  sections: IndexedSeq[Section[Element]]
+              )
+
+              def compress(
+                  sections: IndexedSeq[Section[Element]]
+              ): IndexedSeq[Block] = {
+                val blocks = mutable.ArrayBuffer.empty[Block]
+                var currentGroupIds = Set.empty[Int]
+                val currentSections = mutable.ArrayBuffer.empty[Section[Element]]
+
+                for (s <- sections) {
+                  val gIds = groupIdsForSection(s)
+                  if (gIds.nonEmpty && gIds == currentGroupIds) {
+                    currentSections += s
+                  } else {
+                    if (currentSections.nonEmpty) {
+                      blocks += Block(currentGroupIds, currentSections.toIndexedSeq)
+                      currentSections.clear()
+                    }
+                    if (gIds.nonEmpty) {
+                      currentSections += s
+                      currentGroupIds = gIds
+                    } else {
+                      blocks += Block(Set.empty, IndexedSeq(s))
+                      currentGroupIds = Set.empty
+                    }
+                  }
+                }
+                if (currentSections.nonEmpty) {
+                  blocks += Block(currentGroupIds, currentSections.toIndexedSeq)
+                }
+                blocks.toIndexedSeq
+              }
+
+              val baseBlocks  = compress(baseSections)
+              val leftBlocks  = compress(leftSections)
+              val rightBlocks = compress(rightSections)
+
+              given blockSized: Sized[Block] = _.sections.map(_.size).sum
+
+              given Eq[Block] with
+                override def eqv(x: Block, y: Block): Boolean =
+                  x.sections.size == y.sections.size && {
+                    val commonGroups = x.groupIds.intersect(y.groupIds)
+                    if (commonGroups.nonEmpty) true
+                    else
+                      x.sections.zip(y.sections).forall { (s1, s2) =>
+                        s1.size == s2.size && Eq[Seq[Element]].eqv(
+                          s1.content,
+                          s2.content
+                        )
+                      }
+                  }
+              end given
+
+              val blockLcs = LongestCommonSubsequence.of(
+                baseBlocks,
+                leftBlocks,
+                rightBlocks
+              )(using
+                Eq[Block],
+                blockSized,
+                com.sageserpent.kineticmerge.NoProgressRecording
+              )
+
+              def expand(
+                  contributions: IndexedSeq[Contribution[Block]]
+              ): IndexedSeq[Contribution[Section[Element]]] =
+                contributions.flatMap {
+                  case Contribution.Common(b) =>
+                    b.sections.map(Contribution.Common.apply)
+                  case Contribution.Difference(b) =>
+                    b.sections.map(Contribution.Difference.apply)
+                  case Contribution.CommonToBaseAndLeftOnly(b) =>
+                    b.sections.map(Contribution.CommonToBaseAndLeftOnly.apply)
+                  case Contribution.CommonToBaseAndRightOnly(b) =>
+                    b.sections.map(Contribution.CommonToBaseAndRightOnly.apply)
+                  case Contribution.CommonToLeftAndRightOnly(b) =>
+                    b.sections.map(Contribution.CommonToLeftAndRightOnly.apply)
+                }
+
+              given sectionSized: Sized[Section[Element]] = _.size
+
+              LongestCommonSubsequence.apply(
+                expand(blockLcs.base),
+                expand(blockLcs.left),
+                expand(blockLcs.right)
+              )(sectionSized.sizeOf)
+            }
+          )
+
         export baseSources.pathFor as basePathFor
         export leftSources.pathFor as leftPathFor
         export rightSources.pathFor as rightPathFor
@@ -162,7 +309,8 @@ object SectionedCode extends StrictLogging:
             rogueMatches.isEmpty,
             s"Found rogue matches whose sections do not belong to the breakdown: ${pprintCustomised(rogueMatches)}."
           )
-        })
+        }
+      )
     catch
       // NOTE: don't convert this to use of `Try` with a subsequent `.toEither`
       // conversion. We want most flavours of exception to propagate, as they

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
@@ -4,6 +4,10 @@ import cats.Eq
 import com.google.common.hash.{Funnel, HashFunction}
 import com.sageserpent.kineticmerge
 import com.sageserpent.kineticmerge.core
+import com.sageserpent.kineticmerge.core.LongestCommonSubsequence.{
+  Contribution,
+  Sized
+}
 import com.sageserpent.kineticmerge.core.MatchAnalysis.{
   AbstractConfiguration,
   AdmissibleFailure
@@ -18,6 +22,8 @@ trait SectionedCode[Path, Element]:
   def matchesFor(
       section: Section[Element]
   ): collection.Set[Match[Section[Element]]]
+
+  def lcsFor(path: Path): LongestCommonSubsequence[Section[Element]]
 
   def basePathFor(baseSection: Section[Element]): Path
   def leftPathFor(leftSection: Section[Element]): Path
@@ -93,6 +99,289 @@ object SectionedCode extends StrictLogging:
         )
 
       Right(new SectionedCode[Path, Element]:
+        private val lcsByPath: Map[Path, LongestCommonSubsequence[Section[
+          Element
+        ]]] =
+          val parallelMatchesGroupIdsByMatch =
+            matchesAndTheirSections.parallelMatchesGroupIdsByMatch
+          val tinyParallelMatchesGroupIdsByMatch =
+            tinyMatchesAndTheirSectionsOnly.parallelMatchesGroupIdsByMatch
+
+          val tinyIdOffset =
+            1 + (parallelMatchesGroupIdsByMatch.values.toSeq.maxOption
+              .getOrElse(0))
+
+          def groupIdFor(m: Match[Section[Element]]): Option[Int] =
+            parallelMatchesGroupIdsByMatch
+              .get(m)
+              .headOption
+              .orElse(
+                tinyParallelMatchesGroupIdsByMatch
+                  .get(m)
+                  .headOption
+                  .map(_ + tinyIdOffset)
+              )
+
+          val allMatches =
+            matchesAndTheirSections.matches ++ tinyMatchesAndTheirSectionsOnly.matches
+
+          val blockSizes: Map[Int, Int] =
+            allMatches.toSeq
+              .flatMap(m =>
+                groupIdFor(m).map(g =>
+                  g -> (m match
+                    case m: Match.AllSides[Section[Element]] =>
+                      m.baseElement.size
+                    case m: Match.BaseAndLeft[Section[Element]] =>
+                      m.baseElement.size
+                    case m: Match.BaseAndRight[Section[Element]] =>
+                      m.baseElement.size
+                    case m: Match.LeftAndRight[Section[Element]] =>
+                      m.leftElement.size
+                  )
+                )
+              )
+              .groupBy(_._1)
+              .map { case (g, pairs) => g -> pairs.map(_._2).sum }
+
+          enum ThreeWaySide {
+            case Base, Left, Right
+          }
+
+          case class Block(groupId: Int)
+          given Sized[Block] with
+            override def sizeOf(block: Block): Int = blockSizes(block.groupId)
+          given Eq[Block] = Eq.fromUniversalEquals
+
+          def sectionLcsFor(
+              path: Path
+          ): LongestCommonSubsequence[Section[Element]] = {
+            val baseSections =
+              baseFilesByPath
+                .get(path)
+                .map(_.sections)
+                .getOrElse(IndexedSeq.empty)
+            val leftSections =
+              leftFilesByPath
+                .get(path)
+                .map(_.sections)
+                .getOrElse(IndexedSeq.empty)
+            val rightSections =
+              rightFilesByPath
+                .get(path)
+                .map(_.sections)
+                .getOrElse(IndexedSeq.empty)
+
+            def blocksFor(
+                sections: IndexedSeq[Section[Element]]
+            ): IndexedSeq[Block] =
+              sections
+                .flatMap(s =>
+                  matchesAndTheirSections.sectionsAndTheirMatches.get(s) ++
+                    tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
+                      .get(s)
+                )
+                .flatMap(groupIdFor)
+                .distinct
+                .map(Block.apply)
+
+            val baseBlocks  = blocksFor(baseSections)
+            val leftBlocks  = blocksFor(leftSections)
+            val rightBlocks = blocksFor(rightSections)
+
+            val blockLcs = LongestCommonSubsequence.of(
+              baseBlocks,
+              leftBlocks,
+              rightBlocks
+            )(using Eq[Block], summon[Sized[Block]], com.sageserpent.kineticmerge.NoProgressRecording)
+
+            def blockContributionsByGroupId(
+                side: ThreeWaySide,
+                contributions: IndexedSeq[Contribution[Block]]
+            ): Map[Int, Contribution[Block]] =
+              contributions.collect {
+                case c @ Contribution.Common(Block(g)) => g -> c
+                case c @ Contribution.CommonToBaseAndLeftOnly(Block(g))
+                    if side != ThreeWaySide.Right =>
+                  g -> c
+                case c @ Contribution.CommonToBaseAndRightOnly(Block(g))
+                    if side != ThreeWaySide.Left =>
+                  g -> c
+                case c @ Contribution.CommonToLeftAndRightOnly(Block(g))
+                    if side != ThreeWaySide.Base =>
+                  g -> c
+                case c @ Contribution.Difference(Block(g)) => g -> c
+              }.toMap
+
+            val blockContributionByGroupIdOnBase =
+              blockContributionsByGroupId(ThreeWaySide.Base, blockLcs.base)
+            val blockContributionByGroupIdOnLeft =
+              blockContributionsByGroupId(ThreeWaySide.Left, blockLcs.left)
+            val blockContributionByGroupIdOnRight =
+              blockContributionsByGroupId(ThreeWaySide.Right, blockLcs.right)
+
+            def contributionFor(
+                section: Section[Element],
+                side: ThreeWaySide
+            ): Contribution[Section[Element]] =
+              val matches =
+                matchesAndTheirSections.sectionsAndTheirMatches.get(section) ++
+                  tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
+                    .get(section)
+
+              val currentPath = path
+
+              val alignedContributions = matches.flatMap { m =>
+                groupIdFor(m).flatMap { g =>
+                  val blockContrib = side match
+                    case ThreeWaySide.Base =>
+                      blockContributionByGroupIdOnBase.get(g)
+                    case ThreeWaySide.Left =>
+                      blockContributionByGroupIdOnLeft.get(g)
+                    case ThreeWaySide.Right =>
+                      blockContributionByGroupIdOnRight.get(g)
+                  blockContrib.map(bc => m -> bc)
+                }
+              }
+
+              def isCompatible(
+                  m: Match[Section[Element]],
+                  bc: Contribution[Block]
+              ): Boolean = bc match
+                case Contribution.Common(_) => true
+                case Contribution.CommonToBaseAndLeftOnly(_) =>
+                  side != ThreeWaySide.Right
+                case Contribution.CommonToBaseAndRightOnly(_) =>
+                  side != ThreeWaySide.Left
+                case Contribution.CommonToLeftAndRightOnly(_) =>
+                  side != ThreeWaySide.Base
+                case Contribution.Difference(_) => true
+
+              val compatibleAligned =
+                alignedContributions.filter { case (m, bc) =>
+                  isCompatible(m, bc)
+                }
+
+              if compatibleAligned.isEmpty then
+                Contribution.Difference(section)
+              else
+                val (m, bc) = compatibleAligned.maxBy { case (m, bc) =>
+                  bc match
+                    case Contribution.Common(_) => 3
+                    case Contribution.CommonToBaseAndLeftOnly(_) |
+                        Contribution.CommonToBaseAndRightOnly(_) |
+                        Contribution.CommonToLeftAndRightOnly(_) =>
+                      2
+                    case _ => 1
+                }
+
+                bc match
+                  case Contribution.Common(_) =>
+                    m match
+                      case Match.AllSides(b, l, r) =>
+                        val baseIsLocal  = basePathFor(b) == currentPath
+                        val leftIsLocal  = leftPathFor(l) == currentPath
+                        val rightIsLocal = rightPathFor(r) == currentPath
+
+                        (baseIsLocal, leftIsLocal, rightIsLocal) match
+                          case (true, true, true) => Contribution.Common(section)
+                          case (true, true, false) if side != ThreeWaySide.Right =>
+                            Contribution.CommonToBaseAndLeftOnly(section)
+                          case (true, false, true) if side != ThreeWaySide.Left =>
+                            Contribution.CommonToBaseAndRightOnly(section)
+                          case (false, true, true) if side != ThreeWaySide.Base =>
+                            Contribution.CommonToLeftAndRightOnly(section)
+                          case _ => Contribution.Difference(section)
+
+                      case Match.BaseAndLeft(b, l) if side != ThreeWaySide.Right =>
+                        if basePathFor(b) == currentPath && leftPathFor(
+                            l
+                          ) == currentPath
+                        then Contribution.CommonToBaseAndLeftOnly(section)
+                        else Contribution.Difference(section)
+                      case Match.BaseAndRight(b, r) if side != ThreeWaySide.Left =>
+                        if basePathFor(b) == currentPath && rightPathFor(
+                            r
+                          ) == currentPath
+                        then Contribution.CommonToBaseAndRightOnly(section)
+                        else Contribution.Difference(section)
+                      case Match.LeftAndRight(l, r) if side != ThreeWaySide.Base =>
+                        if leftPathFor(l) == currentPath && rightPathFor(
+                            r
+                          ) == currentPath
+                        then Contribution.CommonToLeftAndRightOnly(section)
+                        else Contribution.Difference(section)
+                      case _ => Contribution.Difference(section)
+                  case Contribution.CommonToBaseAndLeftOnly(_) =>
+                    m match
+                      case Match.AllSides(b, l, _) if side != ThreeWaySide.Right =>
+                        if basePathFor(b) == currentPath && leftPathFor(
+                            l
+                          ) == currentPath
+                        then Contribution.CommonToBaseAndLeftOnly(section)
+                        else Contribution.Difference(section)
+                      case Match.BaseAndLeft(b, l) if side != ThreeWaySide.Right =>
+                        if basePathFor(b) == currentPath && leftPathFor(
+                            l
+                          ) == currentPath
+                        then Contribution.CommonToBaseAndLeftOnly(section)
+                        else Contribution.Difference(section)
+                      case _ => Contribution.Difference(section)
+                  case Contribution.CommonToBaseAndRightOnly(_) =>
+                    m match
+                      case Match.AllSides(b, _, r) if side != ThreeWaySide.Left =>
+                        if basePathFor(b) == currentPath && rightPathFor(
+                            r
+                          ) == currentPath
+                        then Contribution.CommonToBaseAndRightOnly(section)
+                        else Contribution.Difference(section)
+                      case Match.BaseAndRight(b, r) if side != ThreeWaySide.Left =>
+                        if basePathFor(b) == currentPath && rightPathFor(
+                            r
+                          ) == currentPath
+                        then Contribution.CommonToBaseAndRightOnly(section)
+                        else Contribution.Difference(section)
+                      case _ => Contribution.Difference(section)
+                  case Contribution.CommonToLeftAndRightOnly(_) =>
+                    m match
+                      case Match.AllSides(_, l, r) if side != ThreeWaySide.Base =>
+                        if leftPathFor(l) == currentPath && rightPathFor(
+                            r
+                          ) == currentPath
+                        then Contribution.CommonToLeftAndRightOnly(section)
+                        else Contribution.Difference(section)
+                      case Match.LeftAndRight(l, r) if side != ThreeWaySide.Base =>
+                        if leftPathFor(l) == currentPath && rightPathFor(
+                            r
+                          ) == currentPath
+                        then Contribution.CommonToLeftAndRightOnly(section)
+                        else Contribution.Difference(section)
+                      case _ => Contribution.Difference(section)
+                  case _ => Contribution.Difference(section)
+                end match
+              end if
+            end contributionFor
+
+            def elementSize(section: Section[Element]): Int = section.size
+
+            val baseContributions =
+              baseSections.map(contributionFor(_, ThreeWaySide.Base))
+            val leftContributions =
+              leftSections.map(contributionFor(_, ThreeWaySide.Left))
+            val rightContributions =
+              rightSections.map(contributionFor(_, ThreeWaySide.Right))
+
+            LongestCommonSubsequence(
+              baseContributions,
+              leftContributions,
+              rightContributions
+            )(elementSize)
+          }
+
+          val paths =
+            baseFilesByPath.keySet ++ leftFilesByPath.keySet ++ rightFilesByPath.keySet
+          paths.map(path => path -> sectionLcsFor(path)).toMap
+
         {
           // Invariant: the matches are referenced only by their participating
           // sections.
@@ -153,6 +442,10 @@ object SectionedCode extends StrictLogging:
             section: Section[Element]
         ): collection.Set[Match[Section[Element]]] =
           sectionsAndTheirMatches.get(section)
+
+        override def lcsFor(
+            path: Path
+        ): LongestCommonSubsequence[Section[Element]] = lcsByPath(path)
 
         export baseSources.pathFor as basePathFor
         export leftSources.pathFor as leftPathFor

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
@@ -14,6 +14,8 @@ import com.sageserpent.kineticmerge.core.MatchAnalysis.{
 }
 import com.typesafe.scalalogging.StrictLogging
 
+import scala.collection.mutable
+
 trait SectionedCode[Path, Element]:
   def base: Map[Path, File[Element]]
   def left: Map[Path, File[Element]]
@@ -122,36 +124,9 @@ object SectionedCode extends StrictLogging:
                   .map(_ + tinyIdOffset)
               )
 
-          val allMatches =
-            matchesAndTheirSections.matches ++ tinyMatchesAndTheirSectionsOnly.matches
-
-          val blockSizes: Map[Int, Int] =
-            allMatches.toSeq
-              .flatMap(m =>
-                groupIdFor(m).map(g =>
-                  g -> (m match
-                    case m: Match.AllSides[Section[Element]] =>
-                      m.baseElement.size
-                    case m: Match.BaseAndLeft[Section[Element]] =>
-                      m.baseElement.size
-                    case m: Match.BaseAndRight[Section[Element]] =>
-                      m.baseElement.size
-                    case m: Match.LeftAndRight[Section[Element]] =>
-                      m.leftElement.size
-                  )
-                )
-              )
-              .groupBy(_._1)
-              .map { case (g, pairs) => g -> pairs.map(_._2).sum }
-
-          enum ThreeWaySide {
-            case Base, Left, Right
-          }
-
-          case class Block(groupId: Int)
-          given Sized[Block] with
-            override def sizeOf(block: Block): Int = blockSizes(block.groupId)
-          given Eq[Block] = Eq.fromUniversalEquals
+          case class Block(
+              sections: IndexedSeq[Section[Element]]
+          )
 
           def sectionLcsFor(
               path: Path
@@ -172,216 +147,108 @@ object SectionedCode extends StrictLogging:
                 .map(_.sections)
                 .getOrElse(IndexedSeq.empty)
 
-            def blocksFor(
-                sections: IndexedSeq[Section[Element]]
-            ): IndexedSeq[Block] =
-              sections
-                .flatMap(s =>
-                  matchesAndTheirSections.sectionsAndTheirMatches.get(s) ++
-                    tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
-                      .get(s)
-                )
+            def groupIdsForSection(s: Section[Element]): Set[Int] =
+              (matchesAndTheirSections.sectionsAndTheirMatches.get(s) ++
+                tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches.get(s))
                 .flatMap(groupIdFor)
-                .distinct
-                .map(Block.apply)
+                .toSet
 
-            val baseBlocks  = blocksFor(baseSections)
-            val leftBlocks  = blocksFor(leftSections)
-            val rightBlocks = blocksFor(rightSections)
+            def compress(
+                sections: IndexedSeq[Section[Element]]
+            ): IndexedSeq[Block] = {
+              val blocks = mutable.ArrayBuffer.empty[Block]
+              var currentGroupIds = Set.empty[Int]
+              val currentSections = mutable.ArrayBuffer.empty[Section[Element]]
+
+              for (s <- sections) {
+                val gIds = groupIdsForSection(s)
+                if (gIds.nonEmpty && gIds == currentGroupIds) {
+                  currentSections += s
+                } else {
+                  if (currentSections.nonEmpty) {
+                    blocks += Block(currentSections.toIndexedSeq)
+                    currentSections.clear()
+                  }
+                  if (gIds.nonEmpty) {
+                    currentSections += s
+                    currentGroupIds = gIds
+                  } else {
+                    blocks += Block(IndexedSeq(s))
+                    currentGroupIds = Set.empty
+                  }
+                }
+              }
+              if (currentSections.nonEmpty) {
+                blocks += Block(currentSections.toIndexedSeq)
+              }
+              blocks.toIndexedSeq
+            }
+
+            val baseBlocks = compress(baseSections)
+            val leftBlocks = compress(leftSections)
+            val rightBlocks = compress(rightSections)
+
+            given Sized[Block] = _.sections.map(_.size).sum
+
+            given Eq[Block] with
+              override def eqv(x: Block, y: Block): Boolean =
+                x.sections.size == y.sections.size &&
+                  x.sections.zip(y.sections).forall { (s1, s2) =>
+                    val ms1 =
+                      matchesAndTheirSections.sectionsAndTheirMatches.get(s1) ++
+                        tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
+                          .get(s1)
+                    val ms2 =
+                      matchesAndTheirSections.sectionsAndTheirMatches.get(s2) ++
+                        tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
+                          .get(s2)
+                    ms1.intersect(ms2).nonEmpty || (
+                      s1.size == s2.size && Eq[Seq[Element]].eqv(
+                        s1.content,
+                        s2.content
+                      )
+                    )
+                  }
+            end given
 
             val blockLcs = LongestCommonSubsequence.of(
               baseBlocks,
               leftBlocks,
               rightBlocks
-            )(using Eq[Block], summon[Sized[Block]], com.sageserpent.kineticmerge.NoProgressRecording)
+            )(using
+              Eq[Block],
+              summon[Sized[Block]],
+              com.sageserpent.kineticmerge.NoProgressRecording
+            )
 
-            def blockContributionsByGroupId(
-                side: ThreeWaySide,
+            def expand(
                 contributions: IndexedSeq[Contribution[Block]]
-            ): Map[Int, Contribution[Block]] =
-              contributions.collect {
-                case c @ Contribution.Common(Block(g)) => g -> c
-                case c @ Contribution.CommonToBaseAndLeftOnly(Block(g))
-                    if side != ThreeWaySide.Right =>
-                  g -> c
-                case c @ Contribution.CommonToBaseAndRightOnly(Block(g))
-                    if side != ThreeWaySide.Left =>
-                  g -> c
-                case c @ Contribution.CommonToLeftAndRightOnly(Block(g))
-                    if side != ThreeWaySide.Base =>
-                  g -> c
-                case c @ Contribution.Difference(Block(g)) => g -> c
-              }.toMap
-
-            val blockContributionByGroupIdOnBase =
-              blockContributionsByGroupId(ThreeWaySide.Base, blockLcs.base)
-            val blockContributionByGroupIdOnLeft =
-              blockContributionsByGroupId(ThreeWaySide.Left, blockLcs.left)
-            val blockContributionByGroupIdOnRight =
-              blockContributionsByGroupId(ThreeWaySide.Right, blockLcs.right)
-
-            def contributionFor(
-                section: Section[Element],
-                side: ThreeWaySide
-            ): Contribution[Section[Element]] =
-              val matches =
-                matchesAndTheirSections.sectionsAndTheirMatches.get(section) ++
-                  tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
-                    .get(section)
-
-              val currentPath = path
-
-              val alignedContributions = matches.flatMap { m =>
-                groupIdFor(m).flatMap { g =>
-                  val blockContrib = side match
-                    case ThreeWaySide.Base =>
-                      blockContributionByGroupIdOnBase.get(g)
-                    case ThreeWaySide.Left =>
-                      blockContributionByGroupIdOnLeft.get(g)
-                    case ThreeWaySide.Right =>
-                      blockContributionByGroupIdOnRight.get(g)
-                  blockContrib.map(bc => m -> bc)
-                }
+            ): IndexedSeq[Contribution[Section[Element]]] =
+              contributions.flatMap {
+                case Contribution.Common(b) =>
+                  b.sections.map(Contribution.Common.apply)
+                case Contribution.Difference(b) =>
+                  b.sections.map(Contribution.Difference.apply)
+                case Contribution.CommonToBaseAndLeftOnly(b) =>
+                  b.sections.map(Contribution.CommonToBaseAndLeftOnly.apply)
+                case Contribution.CommonToBaseAndRightOnly(b) =>
+                  b.sections.map(Contribution.CommonToBaseAndRightOnly.apply)
+                case Contribution.CommonToLeftAndRightOnly(b) =>
+                  b.sections.map(Contribution.CommonToLeftAndRightOnly.apply)
               }
 
-              def isCompatible(
-                  m: Match[Section[Element]],
-                  bc: Contribution[Block]
-              ): Boolean = bc match
-                case Contribution.Common(_) => true
-                case Contribution.CommonToBaseAndLeftOnly(_) =>
-                  side != ThreeWaySide.Right
-                case Contribution.CommonToBaseAndRightOnly(_) =>
-                  side != ThreeWaySide.Left
-                case Contribution.CommonToLeftAndRightOnly(_) =>
-                  side != ThreeWaySide.Base
-                case Contribution.Difference(_) => true
-
-              val compatibleAligned =
-                alignedContributions.filter { case (m, bc) =>
-                  isCompatible(m, bc)
-                }
-
-              if compatibleAligned.isEmpty then
-                Contribution.Difference(section)
-              else
-                val (m, bc) = compatibleAligned.maxBy { case (m, bc) =>
-                  bc match
-                    case Contribution.Common(_) => 3
-                    case Contribution.CommonToBaseAndLeftOnly(_) |
-                        Contribution.CommonToBaseAndRightOnly(_) |
-                        Contribution.CommonToLeftAndRightOnly(_) =>
-                      2
-                    case _ => 1
-                }
-
-                bc match
-                  case Contribution.Common(_) =>
-                    m match
-                      case Match.AllSides(b, l, r) =>
-                        val baseIsLocal  = basePathFor(b) == currentPath
-                        val leftIsLocal  = leftPathFor(l) == currentPath
-                        val rightIsLocal = rightPathFor(r) == currentPath
-
-                        (baseIsLocal, leftIsLocal, rightIsLocal) match
-                          case (true, true, true) => Contribution.Common(section)
-                          case (true, true, false) if side != ThreeWaySide.Right =>
-                            Contribution.CommonToBaseAndLeftOnly(section)
-                          case (true, false, true) if side != ThreeWaySide.Left =>
-                            Contribution.CommonToBaseAndRightOnly(section)
-                          case (false, true, true) if side != ThreeWaySide.Base =>
-                            Contribution.CommonToLeftAndRightOnly(section)
-                          case _ => Contribution.Difference(section)
-
-                      case Match.BaseAndLeft(b, l) if side != ThreeWaySide.Right =>
-                        if basePathFor(b) == currentPath && leftPathFor(
-                            l
-                          ) == currentPath
-                        then Contribution.CommonToBaseAndLeftOnly(section)
-                        else Contribution.Difference(section)
-                      case Match.BaseAndRight(b, r) if side != ThreeWaySide.Left =>
-                        if basePathFor(b) == currentPath && rightPathFor(
-                            r
-                          ) == currentPath
-                        then Contribution.CommonToBaseAndRightOnly(section)
-                        else Contribution.Difference(section)
-                      case Match.LeftAndRight(l, r) if side != ThreeWaySide.Base =>
-                        if leftPathFor(l) == currentPath && rightPathFor(
-                            r
-                          ) == currentPath
-                        then Contribution.CommonToLeftAndRightOnly(section)
-                        else Contribution.Difference(section)
-                      case _ => Contribution.Difference(section)
-                  case Contribution.CommonToBaseAndLeftOnly(_) =>
-                    m match
-                      case Match.AllSides(b, l, _) if side != ThreeWaySide.Right =>
-                        if basePathFor(b) == currentPath && leftPathFor(
-                            l
-                          ) == currentPath
-                        then Contribution.CommonToBaseAndLeftOnly(section)
-                        else Contribution.Difference(section)
-                      case Match.BaseAndLeft(b, l) if side != ThreeWaySide.Right =>
-                        if basePathFor(b) == currentPath && leftPathFor(
-                            l
-                          ) == currentPath
-                        then Contribution.CommonToBaseAndLeftOnly(section)
-                        else Contribution.Difference(section)
-                      case _ => Contribution.Difference(section)
-                  case Contribution.CommonToBaseAndRightOnly(_) =>
-                    m match
-                      case Match.AllSides(b, _, r) if side != ThreeWaySide.Left =>
-                        if basePathFor(b) == currentPath && rightPathFor(
-                            r
-                          ) == currentPath
-                        then Contribution.CommonToBaseAndRightOnly(section)
-                        else Contribution.Difference(section)
-                      case Match.BaseAndRight(b, r) if side != ThreeWaySide.Left =>
-                        if basePathFor(b) == currentPath && rightPathFor(
-                            r
-                          ) == currentPath
-                        then Contribution.CommonToBaseAndRightOnly(section)
-                        else Contribution.Difference(section)
-                      case _ => Contribution.Difference(section)
-                  case Contribution.CommonToLeftAndRightOnly(_) =>
-                    m match
-                      case Match.AllSides(_, l, r) if side != ThreeWaySide.Base =>
-                        if leftPathFor(l) == currentPath && rightPathFor(
-                            r
-                          ) == currentPath
-                        then Contribution.CommonToLeftAndRightOnly(section)
-                        else Contribution.Difference(section)
-                      case Match.LeftAndRight(l, r) if side != ThreeWaySide.Base =>
-                        if leftPathFor(l) == currentPath && rightPathFor(
-                            r
-                          ) == currentPath
-                        then Contribution.CommonToLeftAndRightOnly(section)
-                        else Contribution.Difference(section)
-                      case _ => Contribution.Difference(section)
-                  case _ => Contribution.Difference(section)
-                end match
-              end if
-            end contributionFor
-
-            def elementSize(section: Section[Element]): Int = section.size
-
-            val baseContributions =
-              baseSections.map(contributionFor(_, ThreeWaySide.Base))
-            val leftContributions =
-              leftSections.map(contributionFor(_, ThreeWaySide.Left))
-            val rightContributions =
-              rightSections.map(contributionFor(_, ThreeWaySide.Right))
+            given Sized[Section[Element]] = _.size
 
             LongestCommonSubsequence(
-              baseContributions,
-              leftContributions,
-              rightContributions
-            )(elementSize)
+              expand(blockLcs.base),
+              expand(blockLcs.left),
+              expand(blockLcs.right)
+            )(summon[Sized[Section[Element]]].sizeOf)
           }
 
           val paths =
             baseFilesByPath.keySet ++ leftFilesByPath.keySet ++ rightFilesByPath.keySet
           paths.map(path => path -> sectionLcsFor(path)).toMap
-
         {
           // Invariant: the matches are referenced only by their participating
           // sections.

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
@@ -10,7 +10,8 @@ import com.sageserpent.kineticmerge.core.LongestCommonSubsequence.{
 }
 import com.sageserpent.kineticmerge.core.MatchAnalysis.{
   AbstractConfiguration,
-  AdmissibleFailure
+  AdmissibleFailure,
+  ParallelMatchesGroupIdsByMatch
 }
 import com.typesafe.scalalogging.StrictLogging
 
@@ -137,44 +138,129 @@ object SectionedCode extends StrictLogging:
                   .map(_.sections)
                   .getOrElse(IndexedSeq.empty)
 
-              given Sized[Section[Element]] = _.size
+              val parallelMatchesGroupIdsByMatch =
+                matchesAndTheirSections.parallelMatchesGroupIdsByMatch
+              val tinyParallelMatchesGroupIdsByMatch =
+                tinyMatchesAndTheirSectionsOnly.parallelMatchesGroupIdsByMatch
 
-              given Eq[Section[Element]] with
-                override def eqv(
-                    lhs: Section[Element],
-                    rhs: Section[Element]
-                ): Boolean =
-                  val matchesForLhs =
-                    matchesAndTheirSections.sectionsAndTheirMatches.get(lhs) ++
-                      tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
-                        .get(lhs)
-                  val matchesForRhs =
-                    matchesAndTheirSections.sectionsAndTheirMatches.get(rhs) ++
-                      tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
-                        .get(rhs)
-                  val bothBelongToTheSameMatches =
-                    matchesForLhs.intersect(matchesForRhs).nonEmpty
+              val tinyIdOffset =
+                1 + parallelMatchesGroupIdsByMatch.values
+                  .foldLeft(0)(_ max _)
 
-                  bothBelongToTheSameMatches || (lhs.size == rhs.size && Eq[
-                    Seq[Element]
-                  ].eqv(lhs.content, rhs.content))
+              def groupIdFor(m: Match[Section[Element]]): Option[Int] =
+                parallelMatchesGroupIdsByMatch
+                  .get(m)
+                  .headOption
+                  .orElse(
+                    tinyParallelMatchesGroupIdsByMatch
+                      .get(m)
+                      .headOption
+                      .map(_ + tinyIdOffset)
+                  )
+
+              def groupIdsForSection(s: Section[Element]): Set[Int] =
+                (matchesAndTheirSections.sectionsAndTheirMatches.get(s) ++
+                  tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches.get(s))
+                  .flatMap(groupIdFor)
+                  .toSet
+
+              case class Block(
+                  groupIds: Set[Int],
+                  sections: IndexedSeq[Section[Element]]
+              )
+
+              def compress(
+                  sections: IndexedSeq[Section[Element]]
+              ): IndexedSeq[Block] = {
+                val blocks = mutable.ArrayBuffer.empty[Block]
+                var currentGroupIds = Set.empty[Int]
+                val currentSections = mutable.ArrayBuffer.empty[Section[Element]]
+
+                for (s <- sections) {
+                  val gIds = groupIdsForSection(s)
+                  if (gIds.nonEmpty && gIds == currentGroupIds) {
+                    currentSections += s
+                  } else {
+                    if (currentSections.nonEmpty) {
+                      blocks += Block(currentGroupIds, currentSections.toIndexedSeq)
+                      currentSections.clear()
+                    }
+                    if (gIds.nonEmpty) {
+                      currentSections += s
+                      currentGroupIds = gIds
+                    } else {
+                      blocks += Block(Set.empty, IndexedSeq(s))
+                      currentGroupIds = Set.empty
+                    }
+                  }
+                }
+                if (currentSections.nonEmpty) {
+                  blocks += Block(currentGroupIds, currentSections.toIndexedSeq)
+                }
+                blocks.toIndexedSeq
+              }
+
+              val baseBlocks  = compress(baseSections)
+              val leftBlocks  = compress(leftSections)
+              val rightBlocks = compress(rightSections)
+
+              given blockSized: Sized[Block] = _.sections.map(_.size).sum
+
+              given Eq[Block] with
+                override def eqv(x: Block, y: Block): Boolean =
+                  x.sections.size == y.sections.size && {
+                    val commonGroups = x.groupIds.intersect(y.groupIds)
+                    if (commonGroups.nonEmpty) true
+                    else
+                      x.sections.zip(y.sections).forall { (s1, s2) =>
+                        s1.size == s2.size && Eq[Seq[Element]].eqv(
+                          s1.content,
+                          s2.content
+                        )
+                      }
+                  }
               end given
 
-              LongestCommonSubsequence.of(
-                baseSections,
-                leftSections,
-                rightSections
+              val blockLcs = LongestCommonSubsequence.of(
+                baseBlocks,
+                leftBlocks,
+                rightBlocks
               )(using
-                Eq[Section[Element]],
-                summon[Sized[Section[Element]]],
+                Eq[Block],
+                blockSized,
                 com.sageserpent.kineticmerge.NoProgressRecording
               )
+
+              def expand(
+                  contributions: IndexedSeq[Contribution[Block]]
+              ): IndexedSeq[Contribution[Section[Element]]] =
+                contributions.flatMap {
+                  case Contribution.Common(b) =>
+                    b.sections.map(Contribution.Common.apply)
+                  case Contribution.Difference(b) =>
+                    b.sections.map(Contribution.Difference.apply)
+                  case Contribution.CommonToBaseAndLeftOnly(b) =>
+                    b.sections.map(Contribution.CommonToBaseAndLeftOnly.apply)
+                  case Contribution.CommonToBaseAndRightOnly(b) =>
+                    b.sections.map(Contribution.CommonToBaseAndRightOnly.apply)
+                  case Contribution.CommonToLeftAndRightOnly(b) =>
+                    b.sections.map(Contribution.CommonToLeftAndRightOnly.apply)
+                }
+
+              given sectionSized: Sized[Section[Element]] = _.size
+
+              LongestCommonSubsequence.apply(
+                expand(blockLcs.base),
+                expand(blockLcs.left),
+                expand(blockLcs.right)
+              )(sectionSized.sizeOf)
             }
           )
 
         export baseSources.pathFor as basePathFor
         export leftSources.pathFor as leftPathFor
         export rightSources.pathFor as rightPathFor
+
         {
           // Invariant: the matches are referenced only by their participating
           // sections.

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
@@ -4,14 +4,9 @@ import cats.Eq
 import com.google.common.hash.{Funnel, HashFunction}
 import com.sageserpent.kineticmerge
 import com.sageserpent.kineticmerge.core
-import com.sageserpent.kineticmerge.core.LongestCommonSubsequence.{
-  Contribution,
-  Sized
-}
 import com.sageserpent.kineticmerge.core.MatchAnalysis.{
   AbstractConfiguration,
-  AdmissibleFailure,
-  ParallelMatchesGroupIdsByMatch
+  AdmissibleFailure
 }
 import com.typesafe.scalalogging.StrictLogging
 
@@ -25,8 +20,6 @@ trait SectionedCode[Path, Element]:
   def matchesFor(
       section: Section[Element]
   ): collection.Set[Match[Section[Element]]]
-
-  def lcsFor(path: Path): LongestCommonSubsequence[Section[Element]]
 
   def basePathFor(baseSection: Section[Element]): Path
   def leftPathFor(leftSection: Section[Element]): Path
@@ -117,146 +110,6 @@ object SectionedCode extends StrictLogging:
         ): collection.Set[Match[Section[Element]]] =
           sectionsAndTheirMatches.get(section)
 
-        override def lcsFor(
-            path: Path
-        ): LongestCommonSubsequence[Section[Element]] =
-          lcsByPath.getOrElseUpdate(
-            path, {
-              val baseSections =
-                baseFilesByPath
-                  .get(path)
-                  .map(_.sections)
-                  .getOrElse(IndexedSeq.empty)
-              val leftSections =
-                leftFilesByPath
-                  .get(path)
-                  .map(_.sections)
-                  .getOrElse(IndexedSeq.empty)
-              val rightSections =
-                rightFilesByPath
-                  .get(path)
-                  .map(_.sections)
-                  .getOrElse(IndexedSeq.empty)
-
-              val parallelMatchesGroupIdsByMatch =
-                matchesAndTheirSections.parallelMatchesGroupIdsByMatch
-              val tinyParallelMatchesGroupIdsByMatch =
-                tinyMatchesAndTheirSectionsOnly.parallelMatchesGroupIdsByMatch
-
-              val tinyIdOffset =
-                1 + parallelMatchesGroupIdsByMatch.values
-                  .foldLeft(0)(_ max _)
-
-              def groupIdFor(m: Match[Section[Element]]): Option[Int] =
-                parallelMatchesGroupIdsByMatch
-                  .get(m)
-                  .headOption
-                  .orElse(
-                    tinyParallelMatchesGroupIdsByMatch
-                      .get(m)
-                      .headOption
-                      .map(_ + tinyIdOffset)
-                  )
-
-              def groupIdsForSection(s: Section[Element]): Set[Int] =
-                (matchesAndTheirSections.sectionsAndTheirMatches.get(s) ++
-                  tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches.get(s))
-                  .flatMap(groupIdFor)
-                  .toSet
-
-              case class Block(
-                  groupIds: Set[Int],
-                  sections: IndexedSeq[Section[Element]]
-              )
-
-              def compress(
-                  sections: IndexedSeq[Section[Element]]
-              ): IndexedSeq[Block] = {
-                val blocks = mutable.ArrayBuffer.empty[Block]
-                var currentGroupIds = Set.empty[Int]
-                val currentSections = mutable.ArrayBuffer.empty[Section[Element]]
-
-                for (s <- sections) {
-                  val gIds = groupIdsForSection(s)
-                  if (gIds.nonEmpty && gIds == currentGroupIds) {
-                    currentSections += s
-                  } else {
-                    if (currentSections.nonEmpty) {
-                      blocks += Block(currentGroupIds, currentSections.toIndexedSeq)
-                      currentSections.clear()
-                    }
-                    if (gIds.nonEmpty) {
-                      currentSections += s
-                      currentGroupIds = gIds
-                    } else {
-                      blocks += Block(Set.empty, IndexedSeq(s))
-                      currentGroupIds = Set.empty
-                    }
-                  }
-                }
-                if (currentSections.nonEmpty) {
-                  blocks += Block(currentGroupIds, currentSections.toIndexedSeq)
-                }
-                blocks.toIndexedSeq
-              }
-
-              val baseBlocks  = compress(baseSections)
-              val leftBlocks  = compress(leftSections)
-              val rightBlocks = compress(rightSections)
-
-              given blockSized: Sized[Block] = _.sections.map(_.size).sum
-
-              given Eq[Block] with
-                override def eqv(x: Block, y: Block): Boolean =
-                  x.sections.size == y.sections.size && {
-                    val commonGroups = x.groupIds.intersect(y.groupIds)
-                    if (commonGroups.nonEmpty) true
-                    else
-                      x.sections.zip(y.sections).forall { (s1, s2) =>
-                        s1.size == s2.size && Eq[Seq[Element]].eqv(
-                          s1.content,
-                          s2.content
-                        )
-                      }
-                  }
-              end given
-
-              val blockLcs = LongestCommonSubsequence.of(
-                baseBlocks,
-                leftBlocks,
-                rightBlocks
-              )(using
-                Eq[Block],
-                blockSized,
-                com.sageserpent.kineticmerge.NoProgressRecording
-              )
-
-              def expand(
-                  contributions: IndexedSeq[Contribution[Block]]
-              ): IndexedSeq[Contribution[Section[Element]]] =
-                contributions.flatMap {
-                  case Contribution.Common(b) =>
-                    b.sections.map(Contribution.Common.apply)
-                  case Contribution.Difference(b) =>
-                    b.sections.map(Contribution.Difference.apply)
-                  case Contribution.CommonToBaseAndLeftOnly(b) =>
-                    b.sections.map(Contribution.CommonToBaseAndLeftOnly.apply)
-                  case Contribution.CommonToBaseAndRightOnly(b) =>
-                    b.sections.map(Contribution.CommonToBaseAndRightOnly.apply)
-                  case Contribution.CommonToLeftAndRightOnly(b) =>
-                    b.sections.map(Contribution.CommonToLeftAndRightOnly.apply)
-                }
-
-              given sectionSized: Sized[Section[Element]] = _.size
-
-              LongestCommonSubsequence.apply(
-                expand(blockLcs.base),
-                expand(blockLcs.left),
-                expand(blockLcs.right)
-              )(sectionSized.sizeOf)
-            }
-          )
-
         export baseSources.pathFor as basePathFor
         export leftSources.pathFor as leftPathFor
         export rightSources.pathFor as rightPathFor
@@ -309,8 +162,7 @@ object SectionedCode extends StrictLogging:
             rogueMatches.isEmpty,
             s"Found rogue matches whose sections do not belong to the breakdown: ${pprintCustomised(rogueMatches)}."
           )
-        }
-      )
+        })
     catch
       // NOTE: don't convert this to use of `Try` with a subsequent `.toEither`
       // conversion. We want most flavours of exception to propagate, as they

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -1,7 +1,6 @@
 package com.sageserpent.kineticmerge.core
 
 import cats.{Eq, Order}
-import com.sageserpent.kineticmerge.core.merge.mergeUsing
 import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 import com.sageserpent.kineticmerge.core.CoreMergeAlgebra.MultiSidedMergeResult
 import com.sageserpent.kineticmerge.core.FirstPassMergeResult.{
@@ -15,7 +14,7 @@ import com.sageserpent.kineticmerge.core.MoveDestinationsReport.{
   MoveEvaluation,
   OppositeSideAnchor
 }
-import com.sageserpent.kineticmerge.core.merge.of as mergeOf
+import com.sageserpent.kineticmerge.core.merge.{mergeUsing, of as mergeOf}
 import com.sageserpent.kineticmerge.{
   NoProgressRecording,
   ProgressRecording,
@@ -32,16 +31,23 @@ import scala.math.Ordering.Implicits.seqOrdering
 
 object SectionedCodeExtension extends StrictLogging:
 
-  /** Add merging capability to a [[SectionedCode]].
-    *
-    * Not sure exactly where this capability should be implemented - is it
-    * really a core part of the API for [[SectionedCode]]? Hence the extension
-    * as a temporary measure.
-    */
-
+  /** Add merging capability to a [[SectionedCode]]. */
   extension [Path, Element: Eq: Order](
       sectionedCode: SectionedCode[Path, Element]
   )
+    // TODO: need to add the phase one computation from
+    // https://github.com/sageserpent-open/kineticMerge/issues/321#issuecomment-4319818815.
+
+    private def longestCommonSubsequenceOf(
+        base: IndexedSeq[Section[Element]],
+        left: IndexedSeq[Section[Element]],
+        right: IndexedSeq[Section[Element]]
+    ): LongestCommonSubsequence[Section[Element]] =
+      // TODO: see
+      // https://github.com/sageserpent-open/kineticMerge/issues/321#issuecomment-4319818815,
+      // phase two.
+      ???
+
     def merge(using
         progressRecording: ProgressRecording
     ): (
@@ -270,14 +276,14 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  mergeOf(mergeAlgebra =
-                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                      FileDeletionContext.Left
-                    )
-                  )(
+                  longestCommonSubsequenceOf(
                     base = baseSections,
                     left = IndexedSeq.empty,
                     right = rightSections
+                  ).mergeUsing(mergeAlgebra =
+                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                      FileDeletionContext.Left
+                    )
                   )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
@@ -290,14 +296,14 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  mergeOf(mergeAlgebra =
-                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                      FileDeletionContext.Right
-                    )
-                  )(
+                  longestCommonSubsequenceOf(
                     base = baseSections,
                     left = leftSections,
                     right = IndexedSeq.empty
+                  ).mergeUsing(mergeAlgebra =
+                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                      FileDeletionContext.Right
+                    )
                   )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
@@ -315,14 +321,14 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  mergeOf(mergeAlgebra =
-                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                      FileDeletionContext.None
-                    )
-                  )(
+                  longestCommonSubsequenceOf(
                     base = optionalBaseSections.getOrElse(IndexedSeq.empty),
                     left = leftSections,
                     right = rightSections
+                  ).mergeUsing(mergeAlgebra =
+                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                      FileDeletionContext.None
+                    )
                   )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -1,6 +1,7 @@
 package com.sageserpent.kineticmerge.core
 
 import cats.{Eq, Order}
+import com.sageserpent.kineticmerge.core.merge.mergeUsing
 import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 import com.sageserpent.kineticmerge.core.CoreMergeAlgebra.MultiSidedMergeResult
 import com.sageserpent.kineticmerge.core.FirstPassMergeResult.{
@@ -14,7 +15,7 @@ import com.sageserpent.kineticmerge.core.MoveDestinationsReport.{
   MoveEvaluation,
   OppositeSideAnchor
 }
-import com.sageserpent.kineticmerge.core.merge.{mergeUsing, of as mergeOf}
+import com.sageserpent.kineticmerge.core.merge.of as mergeOf
 import com.sageserpent.kineticmerge.{
   NoProgressRecording,
   ProgressRecording,
@@ -31,59 +32,16 @@ import scala.math.Ordering.Implicits.seqOrdering
 
 object SectionedCodeExtension extends StrictLogging:
 
-  /** Add merging capability to a [[SectionedCode]]. */
+  /** Add merging capability to a [[SectionedCode]].
+    *
+    * Not sure exactly where this capability should be implemented - is it
+    * really a core part of the API for [[SectionedCode]]? Hence the extension
+    * as a temporary measure.
+    */
+
   extension [Path, Element: Eq: Order](
       sectionedCode: SectionedCode[Path, Element]
   )
-    private def longestCommonSubsequenceOf(
-        base: IndexedSeq[Section[Element]],
-        left: IndexedSeq[Section[Element]],
-        right: IndexedSeq[Section[Element]]
-    ): LongestCommonSubsequence[Section[Element]] =
-      // PLAN:
-      // 1. Form blocks composed of runs of contiguous sections that form one
-      // side of a group of parallel matches, including any filler sections
-      // between the matched sections. A block is associated with at most one
-      // group is, so if there are several moves that diverge from or converge
-      // from the same run of sections, then this is represented by multiple
-      // blocks that happen to have the same run of sections but differing group
-      // ids. If filler sections are not covered by one side of a group, they
-      // are placed in their own block that has no group id. Blocks on the same
-      // side are sized by the content they cover and can be compared for
-      // equality using the group id, and are ordered by a triple of (start
-      // offset, the negative of the block size, group id).
-      // 2. The dynamic programming LCS algorithm is used to form an LCS at the
-      // block level, starting with sequences of blocks from each side that are
-      // arranged according to their intrinsic ordering.
-      // 3. Because sections can be shared between multiple blocks on the same
-      // side due to diverging / converging moves, overlapping of blocks and
-      // nesting of blocks (these are all feasible and indeed desirable
-      // situations in terms of capturing code motion accurately), it is
-      // necessary to clean up the block-level LCS. Looking at each side of the
-      // block-level LCS, if a run of adjacent blocks is found that a) have some
-      // or all sections in common and b) consider the blocks to be part of a
-      // common or partially common contribution to the LCS, then the group ids
-      // of the blocks are added to an exclusion set. This is intended to stop a
-      // single section from being repeated on one side of the section-level LCS
-      // expansion later on. <<<---- TODO: this is too draconian, as it excludes
-      // *everything* covered by the group: if two blocks have a partial
-      // overlap, it should only be the shared sections and their corresponding
-      // matched sections on the other side(s) that are excluded. Nevertheless
-      // it will do as a start...
-      // 4. The blocks from each side of the block-level LCS are expanded into a
-      // section-level LCS. Each block's group id is examined - if missing, the
-      // block's sections are assigned difference contributions, if present but
-      // the group id is excluded, then again the block's sections are assigned
-      // difference contributions. Otherwise, the block uses its own
-      // contribution
-      // to guide the assignation of the sections, so a common contributed block
-      // assigns its sections participating on all-sides matches common
-      // contributions, but assigns sections participating in pairwise matches
-      // partially common contributions, filler sections being assigned
-      // difference contributions.
-
-      ???
-
     def merge(using
         progressRecording: ProgressRecording
     ): (
@@ -312,14 +270,14 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  longestCommonSubsequenceOf(
-                    base = baseSections,
-                    left = IndexedSeq.empty,
-                    right = rightSections
-                  ).mergeUsing(mergeAlgebra =
+                  mergeOf(mergeAlgebra =
                     FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
                       FileDeletionContext.Left
                     )
+                  )(
+                    base = baseSections,
+                    left = IndexedSeq.empty,
+                    right = rightSections
                   )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
@@ -332,14 +290,14 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  longestCommonSubsequenceOf(
-                    base = baseSections,
-                    left = leftSections,
-                    right = IndexedSeq.empty
-                  ).mergeUsing(mergeAlgebra =
+                  mergeOf(mergeAlgebra =
                     FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
                       FileDeletionContext.Right
                     )
+                  )(
+                    base = baseSections,
+                    left = leftSections,
+                    right = IndexedSeq.empty
                   )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
@@ -357,14 +315,14 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  longestCommonSubsequenceOf(
-                    base = optionalBaseSections.getOrElse(IndexedSeq.empty),
-                    left = leftSections,
-                    right = rightSections
-                  ).mergeUsing(mergeAlgebra =
+                  mergeOf(mergeAlgebra =
                     FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
                       FileDeletionContext.None
                     )
+                  )(
+                    base = optionalBaseSections.getOrElse(IndexedSeq.empty),
+                    left = leftSections,
+                    right = rightSections
                   )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -2,6 +2,7 @@ package com.sageserpent.kineticmerge.core
 
 import cats.{Eq, Order}
 import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
+import com.sageserpent.kineticmerge.core.merge.mergeUsing
 import com.sageserpent.kineticmerge.core.CoreMergeAlgebra.MultiSidedMergeResult
 import com.sageserpent.kineticmerge.core.FirstPassMergeResult.{
   FileDeletionContext,
@@ -269,15 +270,13 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  mergeOf(mergeAlgebra =
-                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                      FileDeletionContext.Left
+                  sectionedCode
+                    .lcsFor(path)
+                    .mergeUsing(
+                      FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                        FileDeletionContext.Left
+                      )
                     )
-                  )(
-                    base = baseSections,
-                    left = IndexedSeq.empty,
-                    right = rightSections
-                  )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
               case (Some(baseSections), Some(leftSections), None) =>
@@ -289,15 +288,13 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  mergeOf(mergeAlgebra =
-                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                      FileDeletionContext.Right
+                  sectionedCode
+                    .lcsFor(path)
+                    .mergeUsing(
+                      FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                        FileDeletionContext.Right
+                      )
                     )
-                  )(
-                    base = baseSections,
-                    left = leftSections,
-                    right = IndexedSeq.empty
-                  )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
               case (
@@ -314,15 +311,13 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  mergeOf(mergeAlgebra =
-                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                      FileDeletionContext.None
+                  sectionedCode
+                    .lcsFor(path)
+                    .mergeUsing(
+                      FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                        FileDeletionContext.None
+                      )
                     )
-                  )(
-                    base = optionalBaseSections.getOrElse(IndexedSeq.empty),
-                    left = leftSections,
-                    right = rightSections
-                  )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -35,17 +35,53 @@ object SectionedCodeExtension extends StrictLogging:
   extension [Path, Element: Eq: Order](
       sectionedCode: SectionedCode[Path, Element]
   )
-    // TODO: need to add the phase one computation from
-    // https://github.com/sageserpent-open/kineticMerge/issues/321#issuecomment-4319818815.
-
     private def longestCommonSubsequenceOf(
         base: IndexedSeq[Section[Element]],
         left: IndexedSeq[Section[Element]],
         right: IndexedSeq[Section[Element]]
     ): LongestCommonSubsequence[Section[Element]] =
-      // TODO: see
-      // https://github.com/sageserpent-open/kineticMerge/issues/321#issuecomment-4319818815,
-      // phase two.
+      // PLAN:
+      // 1. Form blocks composed of runs of contiguous sections that form one
+      // side of a group of parallel matches, including any filler sections
+      // between the matched sections. A block is associated with at most one
+      // group is, so if there are several moves that diverge from or converge
+      // from the same run of sections, then this is represented by multiple
+      // blocks that happen to have the same run of sections but differing group
+      // ids. If filler sections are not covered by one side of a group, they
+      // are placed in their own block that has no group id. Blocks on the same
+      // side are sized by the content they cover and can be compared for
+      // equality using the group id, and are ordered by a triple of (start
+      // offset, the negative of the block size, group id).
+      // 2. The dynamic programming LCS algorithm is used to form an LCS at the
+      // block level, starting with sequences of blocks from each side that are
+      // arranged according to their intrinsic ordering.
+      // 3. Because sections can be shared between multiple blocks on the same
+      // side due to diverging / converging moves, overlapping of blocks and
+      // nesting of blocks (these are all feasible and indeed desirable
+      // situations in terms of capturing code motion accurately), it is
+      // necessary to clean up the block-level LCS. Looking at each side of the
+      // block-level LCS, if a run of adjacent blocks is found that a) have some
+      // or all sections in common and b) consider the blocks to be part of a
+      // common or partially common contribution to the LCS, then the group ids
+      // of the blocks are added to an exclusion set. This is intended to stop a
+      // single section from being repeated on one side of the section-level LCS
+      // expansion later on. <<<---- TODO: this is too draconian, as it excludes
+      // *everything* covered by the group: if two blocks have a partial
+      // overlap, it should only be the shared sections and their corresponding
+      // matched sections on the other side(s) that are excluded. Nevertheless
+      // it will do as a start...
+      // 4. The blocks from each side of the block-level LCS are expanded into a
+      // section-level LCS. Each block's group id is examined - if missing, the
+      // block's sections are assigned difference contributions, if present but
+      // the group id is excluded, then again the block's sections are assigned
+      // difference contributions. Otherwise, the block uses its own
+      // contribution
+      // to guide the assignation of the sections, so a common contributed block
+      // assigns its sections participating on all-sides matches common
+      // contributions, but assigns sections participating in pairwise matches
+      // partially common contributions, filler sections being assigned
+      // difference contributions.
+
       ???
 
     def merge(using

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -1,8 +1,8 @@
 package com.sageserpent.kineticmerge.core
 
 import cats.{Eq, Order}
-import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 import com.sageserpent.kineticmerge.core.merge.mergeUsing
+import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 import com.sageserpent.kineticmerge.core.CoreMergeAlgebra.MultiSidedMergeResult
 import com.sageserpent.kineticmerge.core.FirstPassMergeResult.{
   FileDeletionContext,
@@ -270,13 +270,15 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  sectionedCode
-                    .lcsFor(path)
-                    .mergeUsing(
-                      FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                        FileDeletionContext.Left
-                      )
+                  mergeOf(mergeAlgebra =
+                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                      FileDeletionContext.Left
                     )
+                  )(
+                    base = baseSections,
+                    left = IndexedSeq.empty,
+                    right = rightSections
+                  )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
               case (Some(baseSections), Some(leftSections), None) =>
@@ -288,13 +290,15 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  sectionedCode
-                    .lcsFor(path)
-                    .mergeUsing(
-                      FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                        FileDeletionContext.Right
-                      )
+                  mergeOf(mergeAlgebra =
+                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                      FileDeletionContext.Right
                     )
+                  )(
+                    base = baseSections,
+                    left = leftSections,
+                    right = IndexedSeq.empty
+                  )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
               case (
@@ -311,13 +315,15 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  sectionedCode
-                    .lcsFor(path)
-                    .mergeUsing(
-                      FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                        FileDeletionContext.None
-                      )
+                  mergeOf(mergeAlgebra =
+                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                      FileDeletionContext.None
                     )
+                  )(
+                    base = optionalBaseSections.getOrElse(IndexedSeq.empty),
+                    left = leftSections,
+                    right = rightSections
+                  )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
 


### PR DESCRIPTION
Implements issue #321: Use parallel matches groups to generate per-file longest common subsequences. This optimization avoids full DP on sections by aligning at the block (match group) level first.

---
*PR created automatically by Jules for task [11265001918498214285](https://jules.google.com/task/11265001918498214285) started by @sageserpent-open*