### PR TITLE
Use parallel matches groups to generate per-file longest common subsequences

### DIFF
--- a/src/main/scala/com/sageserpent/kineticmerge/core/File.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/File.scala
@@ -10,8 +10,8 @@ case class File[Element](
 ):
   // Invariant - sections are contiguous.
   if sections.nonEmpty then
-    sections.zip(sections.tail).foreach { case (first, second) =>
-      require(first.onePastEndOffset == second.startOffset)
+    sections.zip(sections.tail).foreach { case (predecessor, successor) =>
+      require(predecessor.onePastEndOffset == successor.startOffset)
     }
   end if
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
@@ -151,6 +151,58 @@ end LongestCommonSubsequence
 
 object LongestCommonSubsequence:
 
+  def apply[Element](
+      base: IndexedSeq[Contribution[Element]],
+      left: IndexedSeq[Contribution[Element]],
+      right: IndexedSeq[Contribution[Element]]
+  )(elementSize: Element => Int): LongestCommonSubsequence[Element] =
+    def commonSubsequenceSize(
+        contributions: IndexedSeq[Contribution[Element]]
+    ): CommonSubsequenceSize =
+      contributions.foldLeft(CommonSubsequenceSize.zero) {
+        case (partialSize, Contribution.Common(element)) =>
+          partialSize.addCostOfASingleContribution(elementSize(element))
+        case (partialSize, _) => partialSize
+      }
+
+    def commonToLeftAndRightOnlySize(
+        contributions: IndexedSeq[Contribution[Element]]
+    ): CommonSubsequenceSize =
+      contributions.foldLeft(CommonSubsequenceSize.zero) {
+        case (partialSize, Contribution.CommonToLeftAndRightOnly(element)) =>
+          partialSize.addCostOfASingleContribution(elementSize(element))
+        case (partialSize, _) => partialSize
+      }
+
+    def commonToBaseAndLeftOnlySize(
+        contributions: IndexedSeq[Contribution[Element]]
+    ): CommonSubsequenceSize =
+      contributions.foldLeft(CommonSubsequenceSize.zero) {
+        case (partialSize, Contribution.CommonToBaseAndLeftOnly(element)) =>
+          partialSize.addCostOfASingleContribution(elementSize(element))
+        case (partialSize, _) => partialSize
+      }
+
+    def commonToBaseAndRightOnlySize(
+        contributions: IndexedSeq[Contribution[Element]]
+    ): CommonSubsequenceSize =
+      contributions.foldLeft(CommonSubsequenceSize.zero) {
+        case (partialSize, Contribution.CommonToBaseAndRightOnly(element)) =>
+          partialSize.addCostOfASingleContribution(elementSize(element))
+        case (partialSize, _) => partialSize
+      }
+
+    new LongestCommonSubsequence(
+      base = base,
+      left = left,
+      right = right,
+      commonSubsequenceSize = commonSubsequenceSize(base),
+      commonToLeftAndRightOnlySize = commonToLeftAndRightOnlySize(left),
+      commonToBaseAndLeftOnlySize = commonToBaseAndLeftOnlySize(base),
+      commonToBaseAndRightOnlySize = commonToBaseAndRightOnlySize(base)
+    )
+  end apply
+
   def defaultElementSize[Element](irrelevant: Element): Int = 1
 
   def of[Element: Eq: Sized](

--- a/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
@@ -151,17 +151,19 @@ end LongestCommonSubsequence
 
 object LongestCommonSubsequence:
 
-  def apply[Element](
+  def apply[Element: Sized](
       base: IndexedSeq[Contribution[Element]],
       left: IndexedSeq[Contribution[Element]],
       right: IndexedSeq[Contribution[Element]]
-  )(elementSize: Element => Int): LongestCommonSubsequence[Element] =
+  ): LongestCommonSubsequence[Element] =
+    val sizeOf = summon[Sized[Element]].sizeOf
+    
     def commonSubsequenceSize(
         contributions: IndexedSeq[Contribution[Element]]
     ): CommonSubsequenceSize =
       contributions.foldLeft(CommonSubsequenceSize.zero) {
         case (partialSize, Contribution.Common(element)) =>
-          partialSize.addCostOfASingleContribution(elementSize(element))
+          partialSize.addCostOfASingleContribution(sizeOf(element))
         case (partialSize, _) => partialSize
       }
 
@@ -170,7 +172,7 @@ object LongestCommonSubsequence:
     ): CommonSubsequenceSize =
       contributions.foldLeft(CommonSubsequenceSize.zero) {
         case (partialSize, Contribution.CommonToLeftAndRightOnly(element)) =>
-          partialSize.addCostOfASingleContribution(elementSize(element))
+          partialSize.addCostOfASingleContribution(sizeOf(element))
         case (partialSize, _) => partialSize
       }
 
@@ -179,7 +181,7 @@ object LongestCommonSubsequence:
     ): CommonSubsequenceSize =
       contributions.foldLeft(CommonSubsequenceSize.zero) {
         case (partialSize, Contribution.CommonToBaseAndLeftOnly(element)) =>
-          partialSize.addCostOfASingleContribution(elementSize(element))
+          partialSize.addCostOfASingleContribution(sizeOf(element))
         case (partialSize, _) => partialSize
       }
 
@@ -188,7 +190,7 @@ object LongestCommonSubsequence:
     ): CommonSubsequenceSize =
       contributions.foldLeft(CommonSubsequenceSize.zero) {
         case (partialSize, Contribution.CommonToBaseAndRightOnly(element)) =>
-          partialSize.addCostOfASingleContribution(elementSize(element))
+          partialSize.addCostOfASingleContribution(sizeOf(element))
         case (partialSize, _) => partialSize
       }
 
@@ -999,6 +1001,7 @@ object LongestCommonSubsequence:
       )
   end CommonSubsequenceSize
 
+  // TODO: this definition seems a bit strange - why not hoist `element` up into the core enum constructor?
   enum Contribution[Element]:
     case Common(
         element: Element
@@ -1017,6 +1020,19 @@ object LongestCommonSubsequence:
     )
 
     def element: Element
+    
+    def constructLikeness[AnotherElement](
+        anotherElement: AnotherElement
+    ): Contribution[AnotherElement] =
+      this match
+        case Common(_)                  => Common(anotherElement)
+        case Difference(_)              => Difference(anotherElement)
+        case CommonToBaseAndLeftOnly(_) =>
+          CommonToBaseAndLeftOnly(anotherElement)
+        case CommonToBaseAndRightOnly(_) =>
+          CommonToBaseAndRightOnly(anotherElement)
+        case CommonToLeftAndRightOnly(_) =>
+          CommonToLeftAndRightOnly(anotherElement)
   end Contribution
 
   object CommonSubsequenceSize:

--- a/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
@@ -214,6 +214,42 @@ object LongestCommonSubsequence:
           }
 
         case (
+              Seq(Contribution.Difference(baseElement), baseTail*),
+              _,
+              _
+            ) =>
+          synchronise(
+            baseTail,
+            left,
+            right,
+            partialResult.addBaseDifference(baseElement)
+          )
+
+        case (
+              _,
+              Seq(Contribution.Difference(leftElement), leftTail*),
+              _
+            ) =>
+          synchronise(
+            base,
+            leftTail,
+            right,
+            partialResult.addLeftDifference(leftElement)
+          )
+
+        case (
+              _,
+              _,
+              Seq(Contribution.Difference(rightElement), rightTail*)
+            ) =>
+          synchronise(
+            base,
+            left,
+            rightTail,
+            partialResult.addRightDifference(rightElement)
+          )
+
+        case (
               Seq(Contribution.Common(baseElement), baseTail*),
               Seq(Contribution.Common(leftElement), leftTail*),
               Seq(Contribution.Common(rightElement), rightTail*)
@@ -229,111 +265,6 @@ object LongestCommonSubsequence:
             partialResult.addCommon(baseElement, leftElement, rightElement)(
               sized.sizeOf
             )
-          )
-
-        case (
-              Seq(Contribution.Difference(baseElement), baseTail*),
-              Seq(Contribution.Common(leftElement), _*),
-              Seq(Contribution.Common(rightElement), _*)
-            )
-            if equality.eqv(
-              leftElement,
-              rightElement
-            ) =>
-          synchronise(
-            baseTail,
-            left,
-            right,
-            partialResult.addBaseDifference(baseElement)
-          )
-
-        case (
-              Seq(Contribution.Common(baseElement), _*),
-              Seq(Contribution.Difference(leftElement), leftTail*),
-              Seq(Contribution.Common(rightElement), _*)
-            )
-            if equality.eqv(
-              baseElement,
-              rightElement
-            ) =>
-          synchronise(
-            base,
-            leftTail,
-            right,
-            partialResult.addLeftDifference(leftElement)
-          )
-
-        case (
-              Seq(Contribution.Common(baseElement), _*),
-              Seq(Contribution.Common(leftElement), _*),
-              Seq(Contribution.Difference(rightElement), rightTail*)
-            )
-            if equality.eqv(
-              baseElement,
-              leftElement
-            ) =>
-          synchronise(
-            base,
-            left,
-            rightTail,
-            partialResult.addRightDifference(rightElement)
-          )
-
-        case (
-              Seq(
-                Contribution.Common(_) |
-                Contribution.CommonToBaseAndLeftOnly(_) |
-                Contribution.CommonToBaseAndRightOnly(_),
-                _*
-              ) | Seq(),
-              Seq(Contribution.Difference(leftElement), leftTail*),
-              Seq(Contribution.Difference(rightElement), rightTail*)
-            ) =>
-          synchronise(
-            base,
-            leftTail,
-            rightTail,
-            partialResult
-              .addLeftDifference(leftElement)
-              .addRightDifference(rightElement)
-          )
-
-        case (
-              Seq(Contribution.Difference(baseElement), baseTail*),
-              Seq(
-                Contribution.Common(_) |
-                Contribution.CommonToBaseAndLeftOnly(_) |
-                Contribution.CommonToLeftAndRightOnly(_),
-                _*
-              ) | Seq(),
-              Seq(Contribution.Difference(rightElement), rightTail*)
-            ) =>
-          synchronise(
-            baseTail,
-            left,
-            rightTail,
-            partialResult
-              .addBaseDifference(baseElement)
-              .addRightDifference(rightElement)
-          )
-
-        case (
-              Seq(Contribution.Difference(baseElement), baseTail*),
-              Seq(Contribution.Difference(leftElement), leftTail*),
-              Seq(
-                Contribution.Common(_) |
-                Contribution.CommonToBaseAndRightOnly(_) |
-                Contribution.CommonToLeftAndRightOnly(_),
-                _*
-              ) | Seq()
-            ) =>
-          synchronise(
-            baseTail,
-            leftTail,
-            right,
-            partialResult
-              .addBaseDifference(baseElement)
-              .addLeftDifference(leftElement)
           )
 
         case (
@@ -400,59 +331,6 @@ object LongestCommonSubsequence:
             partialResult.addCommonBaseAndLeft(baseElement, leftElement)(
               sized.sizeOf
             )
-          )
-
-        case (
-              Seq(Contribution.Difference(baseElement), baseTail*),
-              Seq(Contribution.Difference(leftElement), leftTail*),
-              Seq(Contribution.Difference(rightElement), rightTail*)
-            ) =>
-          synchronise(
-            baseTail,
-            leftTail,
-            rightTail,
-            partialResult
-              .addBaseDifference(baseElement)
-              .addLeftDifference(leftElement)
-              .addRightDifference(rightElement)
-          )
-
-          // NOTE: these are fall-through cases, with some overlap with the
-          // previous cases, so leave them down here...
-        case (
-              Seq(Contribution.Difference(baseElement), baseTail*),
-              _,
-              _
-            ) =>
-          synchronise(
-            baseTail,
-            left,
-            right,
-            partialResult.addBaseDifference(baseElement)
-          )
-
-        case (
-              _,
-              Seq(Contribution.Difference(leftElement), leftTail*),
-              _
-            ) =>
-          synchronise(
-            base,
-            leftTail,
-            right,
-            partialResult.addLeftDifference(leftElement)
-          )
-
-        case (
-              _,
-              _,
-              Seq(Contribution.Difference(rightElement), rightTail*)
-            ) =>
-          synchronise(
-            base,
-            left,
-            rightTail,
-            partialResult.addRightDifference(rightElement)
           )
 
         case _ => failure
@@ -543,6 +421,9 @@ object LongestCommonSubsequence:
             resultSnapshotPriorToMutation
           end advanceToNextLeadingSwathe
 
+          private def notYetReachedFinalSwathe =
+            maximumSwatheIndex > _indexOfLeadingSwathe
+
           def topLevelSolution: LongestCommonSubsequence[Element] =
             require(!notYetReachedFinalSwathe)
 
@@ -553,13 +434,6 @@ object LongestCommonSubsequence:
               right.size
             )
           end topLevelSolution
-
-          private def notYetReachedFinalSwathe =
-            maximumSwatheIndex > _indexOfLeadingSwathe
-
-          inline private def storageLotForLeadingSwathe =
-            _indexOfLeadingSwathe % 2
-          end storageLotForLeadingSwathe
 
           def consultRelevantSwatheForSolution(
               onePastBaseIndex: Int,
@@ -609,6 +483,10 @@ object LongestCommonSubsequence:
               onePastRightIndex
             ) = longestCommonSubsequence
           end storeSolutionInLeadingSwathe
+
+          inline private def storageLotForLeadingSwathe =
+            _indexOfLeadingSwathe % 2
+          end storageLotForLeadingSwathe
 
           inline private def newStorage = Storage(
             baseEqualToSwatheIndex =

--- a/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
@@ -151,13 +151,16 @@ end LongestCommonSubsequence
 
 object LongestCommonSubsequence:
 
-  def apply[Element: Sized](
+  def apply[Element: Eq: Sized](
       base: IndexedSeq[Contribution[Element]],
       left: IndexedSeq[Contribution[Element]],
       right: IndexedSeq[Contribution[Element]]
   ): LongestCommonSubsequence[Element] =
+    // TODO: add contract checking - we expect the subsequences of fully or
+    // partially common contributions to align on each pair of sides.
+
     val sizeOf = summon[Sized[Element]].sizeOf
-    
+
     def commonSubsequenceSize(
         contributions: IndexedSeq[Contribution[Element]]
     ): CommonSubsequenceSize =
@@ -1001,7 +1004,8 @@ object LongestCommonSubsequence:
       )
   end CommonSubsequenceSize
 
-  // TODO: this definition seems a bit strange - why not hoist `element` up into the core enum constructor?
+  // TODO: this definition seems a bit strange - why not hoist `element` up into
+  // the core enum constructor?
   enum Contribution[Element]:
     case Common(
         element: Element
@@ -1020,7 +1024,7 @@ object LongestCommonSubsequence:
     )
 
     def element: Element
-    
+
     def constructLikeness[AnotherElement](
         anotherElement: AnotherElement
     ): Contribution[AnotherElement] =

--- a/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
@@ -285,7 +285,7 @@ object LongestCommonSubsequence:
                 Contribution.CommonToBaseAndLeftOnly(_) |
                 Contribution.CommonToBaseAndRightOnly(_),
                 _*
-              ),
+              ) | Seq(),
               Seq(Contribution.Difference(leftElement), leftTail*),
               Seq(Contribution.Difference(rightElement), rightTail*)
             ) =>
@@ -305,7 +305,7 @@ object LongestCommonSubsequence:
                 Contribution.CommonToBaseAndLeftOnly(_) |
                 Contribution.CommonToLeftAndRightOnly(_),
                 _*
-              ),
+              ) | Seq(),
               Seq(Contribution.Difference(rightElement), rightTail*)
             ) =>
           synchronise(
@@ -325,7 +325,7 @@ object LongestCommonSubsequence:
                 Contribution.CommonToBaseAndRightOnly(_) |
                 Contribution.CommonToLeftAndRightOnly(_),
                 _*
-              )
+              ) | Seq()
             ) =>
           synchronise(
             baseTail,
@@ -415,6 +415,44 @@ object LongestCommonSubsequence:
               .addBaseDifference(baseElement)
               .addLeftDifference(leftElement)
               .addRightDifference(rightElement)
+          )
+
+          // NOTE: these are fall-through cases, with some overlap with the
+          // previous cases, so leave them down here...
+        case (
+              Seq(Contribution.Difference(baseElement), baseTail*),
+              _,
+              _
+            ) =>
+          synchronise(
+            baseTail,
+            left,
+            right,
+            partialResult.addBaseDifference(baseElement)
+          )
+
+        case (
+              _,
+              Seq(Contribution.Difference(leftElement), leftTail*),
+              _
+            ) =>
+          synchronise(
+            base,
+            leftTail,
+            right,
+            partialResult.addLeftDifference(leftElement)
+          )
+
+        case (
+              _,
+              _,
+              Seq(Contribution.Difference(rightElement), rightTail*)
+            ) =>
+          synchronise(
+            base,
+            left,
+            rightTail,
+            partialResult.addRightDifference(rightElement)
           )
 
         case _ => failure
@@ -519,6 +557,10 @@ object LongestCommonSubsequence:
           private def notYetReachedFinalSwathe =
             maximumSwatheIndex > _indexOfLeadingSwathe
 
+          inline private def storageLotForLeadingSwathe =
+            _indexOfLeadingSwathe % 2
+          end storageLotForLeadingSwathe
+
           def consultRelevantSwatheForSolution(
               onePastBaseIndex: Int,
               onePastLeftIndex: Int,
@@ -567,10 +609,6 @@ object LongestCommonSubsequence:
               onePastRightIndex
             ) = longestCommonSubsequence
           end storeSolutionInLeadingSwathe
-
-          inline private def storageLotForLeadingSwathe =
-            _indexOfLeadingSwathe % 2
-          end storageLotForLeadingSwathe
 
           inline private def newStorage = Storage(
             baseEqualToSwatheIndex =

--- a/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
@@ -11,6 +11,7 @@ import com.sageserpent.kineticmerge.core.LongestCommonSubsequence.{
 }
 import monocle.syntax.all.*
 
+import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.Using
@@ -159,52 +160,281 @@ object LongestCommonSubsequence:
     // TODO: add contract checking - we expect the subsequences of fully or
     // partially common contributions to align on each pair of sides.
 
-    val sizeOf = summon[Sized[Element]].sizeOf
+    // PLAN: go through the three sequences, looking for a side or sides that
+    // have either a partially or fully common contribution (if more than one,
+    // they should agree on the contribution kind and elements). Advance through
+    // the other side or sides until the contributions are synchronised across
+    // the relevant sides (this should take place and should not involve
+    // skipping through other contributions). Use the helper methods on
+    // `LongestCommonSubsequence` to build up the sizes.
 
-    def commonSubsequenceSize(
-        contributions: IndexedSeq[Contribution[Element]]
-    ): CommonSubsequenceSize =
-      contributions.foldLeft(CommonSubsequenceSize.zero) {
-        case (partialSize, Contribution.Common(element)) =>
-          partialSize.addCostOfASingleContribution(sizeOf(element))
-        case (partialSize, _) => partialSize
-      }
+    val equality = summon[Eq[Element]]
+    val sized    = summon[Sized[Element]]
 
-    def commonToLeftAndRightOnlySize(
-        contributions: IndexedSeq[Contribution[Element]]
-    ): CommonSubsequenceSize =
-      contributions.foldLeft(CommonSubsequenceSize.zero) {
-        case (partialSize, Contribution.CommonToLeftAndRightOnly(element)) =>
-          partialSize.addCostOfASingleContribution(sizeOf(element))
-        case (partialSize, _) => partialSize
-      }
+    @tailrec
+    def synchronise(
+        base: Seq[Contribution[Element]],
+        left: Seq[Contribution[Element]],
+        right: Seq[Contribution[Element]],
+        partialResult: LongestCommonSubsequence[Element]
+    ): LongestCommonSubsequence[Element] =
+      def failure: Nothing =
+        throw new IllegalArgumentException(
+          s"""Failed to synchronise the three inputs while assembling the longest common subsequence.
+             |Base head:
+             |${pprintCustomised(base.headOption)}
+             |Left head:
+             |${pprintCustomised(left.headOption)}
+             |Right head:
+             |${pprintCustomised(right.headOption)}
+             |""".stripMargin
+        )
 
-    def commonToBaseAndLeftOnlySize(
-        contributions: IndexedSeq[Contribution[Element]]
-    ): CommonSubsequenceSize =
-      contributions.foldLeft(CommonSubsequenceSize.zero) {
-        case (partialSize, Contribution.CommonToBaseAndLeftOnly(element)) =>
-          partialSize.addCostOfASingleContribution(sizeOf(element))
-        case (partialSize, _) => partialSize
-      }
+      (base, left, right) match
+        case (Seq(), Seq(), Seq()) => partialResult
+        case (_, Seq(), Seq())     =>
+          base.foldLeft(partialResult) {
+            case (result, Contribution.Difference(baseElement)) =>
+              result.addBaseDifference(baseElement)
+            case _ => failure
+          }
 
-    def commonToBaseAndRightOnlySize(
-        contributions: IndexedSeq[Contribution[Element]]
-    ): CommonSubsequenceSize =
-      contributions.foldLeft(CommonSubsequenceSize.zero) {
-        case (partialSize, Contribution.CommonToBaseAndRightOnly(element)) =>
-          partialSize.addCostOfASingleContribution(sizeOf(element))
-        case (partialSize, _) => partialSize
-      }
+        case (Seq(), _, Seq()) =>
+          left.foldLeft(partialResult) {
+            case (result, Contribution.Difference(leftElement)) =>
+              result.addLeftDifference(leftElement)
+            case _ => failure
+          }
 
-    new LongestCommonSubsequence(
-      base = base,
-      left = left,
-      right = right,
-      commonSubsequenceSize = commonSubsequenceSize(base),
-      commonToLeftAndRightOnlySize = commonToLeftAndRightOnlySize(left),
-      commonToBaseAndLeftOnlySize = commonToBaseAndLeftOnlySize(base),
-      commonToBaseAndRightOnlySize = commonToBaseAndRightOnlySize(base)
+        case (Seq(), Seq(), _) =>
+          right.foldLeft(partialResult) {
+            case (result, Contribution.Difference(rightElement)) =>
+              result.addRightDifference(rightElement)
+            case _ => failure
+          }
+
+        case (
+              Seq(Contribution.Common(baseElement), baseTail*),
+              Seq(Contribution.Common(leftElement), leftTail*),
+              Seq(Contribution.Common(rightElement), rightTail*)
+            )
+            if equality.eqv(baseElement, leftElement) && equality.eqv(
+              baseElement,
+              rightElement
+            ) =>
+          synchronise(
+            baseTail,
+            leftTail,
+            rightTail,
+            partialResult.addCommon(baseElement, leftElement, rightElement)(
+              sized.sizeOf
+            )
+          )
+
+        case (
+              Seq(Contribution.Difference(baseElement), baseTail*),
+              Seq(Contribution.Common(leftElement), _*),
+              Seq(Contribution.Common(rightElement), _*)
+            )
+            if equality.eqv(
+              leftElement,
+              rightElement
+            ) =>
+          synchronise(
+            baseTail,
+            left,
+            right,
+            partialResult.addBaseDifference(baseElement)
+          )
+
+        case (
+              Seq(Contribution.Common(baseElement), _*),
+              Seq(Contribution.Difference(leftElement), leftTail*),
+              Seq(Contribution.Common(rightElement), _*)
+            )
+            if equality.eqv(
+              baseElement,
+              rightElement
+            ) =>
+          synchronise(
+            base,
+            leftTail,
+            right,
+            partialResult.addLeftDifference(leftElement)
+          )
+
+        case (
+              Seq(Contribution.Common(baseElement), _*),
+              Seq(Contribution.Common(leftElement), _*),
+              Seq(Contribution.Difference(rightElement), rightTail*)
+            )
+            if equality.eqv(
+              baseElement,
+              leftElement
+            ) =>
+          synchronise(
+            base,
+            left,
+            rightTail,
+            partialResult.addRightDifference(rightElement)
+          )
+
+        case (
+              Seq(
+                Contribution.Common(_) |
+                Contribution.CommonToBaseAndLeftOnly(_) |
+                Contribution.CommonToBaseAndRightOnly(_),
+                _*
+              ),
+              Seq(Contribution.Difference(leftElement), leftTail*),
+              Seq(Contribution.Difference(rightElement), rightTail*)
+            ) =>
+          synchronise(
+            base,
+            leftTail,
+            rightTail,
+            partialResult
+              .addLeftDifference(leftElement)
+              .addRightDifference(rightElement)
+          )
+
+        case (
+              Seq(Contribution.Difference(baseElement), baseTail*),
+              Seq(
+                Contribution.Common(_) |
+                Contribution.CommonToBaseAndLeftOnly(_) |
+                Contribution.CommonToLeftAndRightOnly(_),
+                _*
+              ),
+              Seq(Contribution.Difference(rightElement), rightTail*)
+            ) =>
+          synchronise(
+            baseTail,
+            left,
+            rightTail,
+            partialResult
+              .addBaseDifference(baseElement)
+              .addRightDifference(rightElement)
+          )
+
+        case (
+              Seq(Contribution.Difference(baseElement), baseTail*),
+              Seq(Contribution.Difference(leftElement), leftTail*),
+              Seq(
+                Contribution.Common(_) |
+                Contribution.CommonToBaseAndRightOnly(_) |
+                Contribution.CommonToLeftAndRightOnly(_),
+                _*
+              )
+            ) =>
+          synchronise(
+            baseTail,
+            leftTail,
+            right,
+            partialResult
+              .addBaseDifference(baseElement)
+              .addLeftDifference(leftElement)
+          )
+
+        case (
+              _,
+              Seq(
+                Contribution.CommonToLeftAndRightOnly(leftElement),
+                leftTail*
+              ),
+              Seq(
+                Contribution.CommonToLeftAndRightOnly(rightElement),
+                rightTail*
+              )
+            )
+            if equality.eqv(
+              leftElement,
+              rightElement
+            ) =>
+          synchronise(
+            base,
+            leftTail,
+            rightTail,
+            partialResult.addCommonLeftAndRight(leftElement, rightElement)(
+              sized.sizeOf
+            )
+          )
+
+        case (
+              Seq(
+                Contribution.CommonToBaseAndRightOnly(baseElement),
+                baseTail*
+              ),
+              _,
+              Seq(
+                Contribution.CommonToBaseAndRightOnly(rightElement),
+                rightTail*
+              )
+            )
+            if equality.eqv(
+              baseElement,
+              rightElement
+            ) =>
+          synchronise(
+            baseTail,
+            left,
+            rightTail,
+            partialResult.addCommonBaseAndRight(baseElement, rightElement)(
+              sized.sizeOf
+            )
+          )
+
+        case (
+              Seq(Contribution.CommonToBaseAndLeftOnly(baseElement), baseTail*),
+              Seq(Contribution.CommonToBaseAndLeftOnly(leftElement), leftTail*),
+              _
+            )
+            if equality.eqv(
+              baseElement,
+              leftElement
+            ) =>
+          synchronise(
+            baseTail,
+            leftTail,
+            right,
+            partialResult.addCommonBaseAndLeft(baseElement, leftElement)(
+              sized.sizeOf
+            )
+          )
+
+        case (
+              Seq(Contribution.Difference(baseElement), baseTail*),
+              Seq(Contribution.Difference(leftElement), leftTail*),
+              Seq(Contribution.Difference(rightElement), rightTail*)
+            ) =>
+          synchronise(
+            baseTail,
+            leftTail,
+            rightTail,
+            partialResult
+              .addBaseDifference(baseElement)
+              .addLeftDifference(leftElement)
+              .addRightDifference(rightElement)
+          )
+
+        case _ => failure
+
+      end match
+    end synchronise
+
+    synchronise(
+      base,
+      left,
+      right,
+      LongestCommonSubsequence(
+        base = IndexedSeq.empty,
+        left = IndexedSeq.empty,
+        right = IndexedSeq.empty,
+        commonSubsequenceSize = CommonSubsequenceSize.zero,
+        commonToLeftAndRightOnlySize = CommonSubsequenceSize.zero,
+        commonToBaseAndLeftOnlySize = CommonSubsequenceSize.zero,
+        commonToBaseAndRightOnlySize = CommonSubsequenceSize.zero
+      )
     )
   end apply
 
@@ -275,9 +505,6 @@ object LongestCommonSubsequence:
             resultSnapshotPriorToMutation
           end advanceToNextLeadingSwathe
 
-          private def notYetReachedFinalSwathe =
-            maximumSwatheIndex > _indexOfLeadingSwathe
-
           def topLevelSolution: LongestCommonSubsequence[Element] =
             require(!notYetReachedFinalSwathe)
 
@@ -288,6 +515,9 @@ object LongestCommonSubsequence:
               right.size
             )
           end topLevelSolution
+
+          private def notYetReachedFinalSwathe =
+            maximumSwatheIndex > _indexOfLeadingSwathe
 
           def consultRelevantSwatheForSolution(
               onePastBaseIndex: Int,

--- a/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
@@ -148,6 +148,25 @@ case class LongestCommonSubsequence[Element] private (
       commonToBaseAndRightOnlySize = commonToBaseAndLeftOnlySize
     )
   end mirror
+
+  // TODO: do we need this after all?
+  def append(
+      another: LongestCommonSubsequence[Element]
+  ): LongestCommonSubsequence[Element] =
+    LongestCommonSubsequence(
+      base = base concat another.base,
+      left = left concat another.left,
+      right = right concat another.right,
+      commonSubsequenceSize =
+        commonSubsequenceSize plus another.commonSubsequenceSize,
+      commonToLeftAndRightOnlySize =
+        commonToLeftAndRightOnlySize plus another.commonToLeftAndRightOnlySize,
+      commonToBaseAndLeftOnlySize =
+        commonToBaseAndLeftOnlySize plus another.commonToBaseAndLeftOnlySize,
+      commonToBaseAndRightOnlySize =
+        commonToBaseAndRightOnlySize plus another.commonToBaseAndRightOnlySize
+    )
+
 end LongestCommonSubsequence
 
 object LongestCommonSubsequence:
@@ -435,6 +454,10 @@ object LongestCommonSubsequence:
             )
           end topLevelSolution
 
+          inline private def storageLotForLeadingSwathe =
+            _indexOfLeadingSwathe % 2
+          end storageLotForLeadingSwathe
+
           def consultRelevantSwatheForSolution(
               onePastBaseIndex: Int,
               onePastLeftIndex: Int,
@@ -483,10 +506,6 @@ object LongestCommonSubsequence:
               onePastRightIndex
             ) = longestCommonSubsequence
           end storeSolutionInLeadingSwathe
-
-          inline private def storageLotForLeadingSwathe =
-            _indexOfLeadingSwathe % 2
-          end storageLotForLeadingSwathe
 
           inline private def newStorage = Storage(
             baseEqualToSwatheIndex =

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -813,7 +813,7 @@ object MatchAnalysis extends StrictLogging:
           assume(sectionSize == secondSection.size)
 
           case class RecursionState(
-              groupIdFromPreviousBite: Option[ParallelMatchesGroupId],
+              deferredGroupIdFromPrecedingBite: Option[ParallelMatchesGroupId],
               mealStartOffsetRelativeToMeal: Int,
               biteDepth: Int,
               remainingBiteEdges: Seq[BiteEdge],
@@ -828,7 +828,7 @@ object MatchAnalysis extends StrictLogging:
                     val size = sectionSize - mealStartOffsetRelativeToMeal
 
                     for
-                      assignedGroupId <- groupIdFromPreviousBite
+                      assignedGroupId <- deferredGroupIdFromPrecedingBite
                         .fold(ifEmpty = freshGroupId)(State.pure)
 
                       fragment = factory(
@@ -861,14 +861,14 @@ object MatchAnalysis extends StrictLogging:
                       then
                         val size =
                           startOffsetRelativeToMeal - mealStartOffsetRelativeToMeal
-                        val assignedGroupId = (
-                          groupIdFromPreviousBite,
-                          groupIdsBySortedBiteEdge.get(biteEdge)
-                        ) match
-                          case (
-                                Some(groupIdFromPrecedingBite),
-                                Some(groupIdFromSucceedingBite)
-                              ) =>
+
+                        val groupIdFromSucceedingBite =
+                          groupIdsBySortedBiteEdge(biteEdge)
+
+                        val assignedGroupId =
+                          deferredGroupIdFromPrecedingBite.fold(ifEmpty =
+                            State.pure(groupIdFromSucceedingBite)
+                          )(groupIdFromPrecedingBite =>
                             if groupIdFromPrecedingBite != groupIdFromSucceedingBite
                             then
                               // If the preceding and succeeding bite belong to
@@ -881,16 +881,7 @@ object MatchAnalysis extends StrictLogging:
                               // belonging to other groups.
                               freshGroupId
                             else State.pure(groupIdFromSucceedingBite)
-
-                          case (Some(groupIdFromPrecedingBite), None) =>
-                            State.pure(groupIdFromPrecedingBite)
-
-                          case (None, Some(groupIdFromSucceedingBite)) =>
-                            State.pure(groupIdFromSucceedingBite)
-
-                          case (None, None) =>
-                            // TODO: can this case ever occur?
-                            freshGroupId
+                          )
 
                         val fragment = factory(
                           firstSide.section(firstPath)(
@@ -910,7 +901,7 @@ object MatchAnalysis extends StrictLogging:
                   yield Left(
                     this
                       .copy(
-                        groupIdFromPreviousBite = None,
+                        deferredGroupIdFromPrecedingBite = None,
                         mealStartOffsetRelativeToMeal =
                           startOffsetRelativeToMeal,
                         biteDepth = 1 + biteDepth,
@@ -937,8 +928,8 @@ object MatchAnalysis extends StrictLogging:
                           // NOTE: nested or overlapping bites to the right
                           // overwrite any prior contribution of a group id to
                           // the *succeeding* context.
-                          groupIdFromPreviousBite =
-                            groupIdsBySortedBiteEdge.get(biteEdge),
+                          deferredGroupIdFromPrecedingBite =
+                            Some(groupIdsBySortedBiteEdge(biteEdge)),
                           mealStartOffsetRelativeToMeal =
                             onePastEndOffsetRelativeToMeal,
                           biteDepth = biteDepth - 1,
@@ -953,7 +944,7 @@ object MatchAnalysis extends StrictLogging:
 
           FlatMap[ParallelMatchesGroupIdTracking].tailRecM(
             RecursionState(
-              groupIdFromPreviousBite = None,
+              deferredGroupIdFromPrecedingBite = None,
               mealStartOffsetRelativeToMeal = 0,
               biteDepth = 0,
               remainingBiteEdges = biteEdges.toSeq,
@@ -1462,6 +1453,610 @@ object MatchAnalysis extends StrictLogging:
         result
 
       end reconcileMatches
+
+      def parallelMatchesOnly: MatchesAndTheirSections =
+        // PLAN:
+
+        // 1. Build up sources composed of matched sections concatenated
+        // together by path preserving their original order.
+
+        val baseMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(baseSection, _, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndLeft(baseSection, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndRight(baseSection, _))
+                  if section == baseSection =>
+                section
+            }
+
+        val leftMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, leftSection, _))
+                  if section == leftSection =>
+                section
+              case (section, Match.BaseAndLeft(_, leftSection))
+                  if section == leftSection =>
+                section
+              case (section, Match.LeftAndRight(leftSection, _))
+                  if section == leftSection =>
+                section
+            }
+
+        val rightMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, _, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.BaseAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.LeftAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+            }
+
+        case class MetaMatchContentSources(
+            override val contentsByPath: Map[Path, IndexedSeq[
+              Section[Element]
+            ]],
+            override val label: String
+        ) extends MappedContentSources[Path, Section[Element]]
+
+        def sourcesForMetaMatching(label: String)(
+            sources: Sources[Path, Element],
+            matchedSections: Iterable[Section[Element]]
+        ) = MetaMatchContentSources(
+          contentsByPath = matchedSections
+            .groupBy(sources.pathFor)
+            .map((path, sections) =>
+              path -> sections.toIndexedSeq
+                .sortBy(section =>
+                  // NOTE: use the negative of the section size as a tiebreaker
+                  // if more than one section has the same start offset. This
+                  // makes sure that a subsuming section comes *before* any
+                  // sections that it might subsume, so it can't interpose
+                  // itself within what would have been a run of parallel
+                  // subsumed sections; that way we don't accidentally split
+                  // what should be larger meta-matches. That can occur when the
+                  // subsuming section is contributed by a larger pairwise match
+                  // that subsumes several all-sides matches, and the first
+                  // all-sides match aligns with the start of the pairwise
+                  // match. The test
+                  // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation`
+                  // has an example of this.
+                  section.startOffset -> -section.size
+                )
+            ),
+          label = label
+        )
+
+        val baseSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-base")(
+            baseSources,
+            baseMatchedSections
+          )
+        val leftSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-left")(
+            leftSources,
+            leftMatchedSections
+          )
+        val rightSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-right")(
+            rightSources,
+            rightMatchedSections
+          )
+
+        // 2. Apply `MatchAnalysis.of` to these sections, using the
+        // potential match key of the section to underpin equality and
+        // hashing.
+
+        object metaMatchConfiguration extends AbstractConfiguration:
+          override val minimumMatchSize: Int                    = 1
+          override val thresholdSizeFractionForMatching: Double = 0
+          override val minimumAmbiguousMatchSize: Int           = 1
+          override val ambiguousMatchesThreshold: Int           = Int.MaxValue
+          override val progressRecording: ProgressRecording     =
+            configuration.progressRecording
+        end metaMatchConfiguration
+
+        given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
+
+        given Funnel[Section[Element]] with
+          override def funnel(
+              from: Section[Element],
+              into: PrimitiveSink
+          ): Unit =
+            from.content.foreach(summon[Funnel[Element]].funnel(_, into))
+
+        end given
+
+        val metaMatchAnalysis = of(
+          baseSourcesForMetaMatching,
+          leftSourcesForMetaMatching,
+          rightSourcesForMetaMatching
+        )(metaMatchConfiguration)
+
+        // 3. The resulting meta-matches provide parallel sequences of sections
+        // that are unzipped to yield corresponding all-sides and pairwise
+        // matches.
+
+        val metaMatches = metaMatchAnalysis.matches
+
+        // NOTE: because meta-matching starts with matched *sections* and
+        // ignores gaps, we have to guard against sections that would have
+        // formed the sides of a suppressed outer match making a second attempt
+        // at building a match.
+        val groupsOfBackTranslatedParallelMatches = metaMatches
+          .map {
+            case Match.AllSides(
+                  baseMetaSection,
+                  leftMetaSection,
+                  rightMetaSection
+                ) =>
+              (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (baseSection, leftSection, rightSection)
+                      if !isSubsumedNonTriviallyByAnAllSidesMatch(
+                        baseSection,
+                        leftSection,
+                        rightSection
+                      ) =>
+                    Match.AllSides(baseSection, leftSection, rightSection)
+                }
+            case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
+              (baseMetaSection.content lazyZip leftMetaSection.content)
+                .collect {
+                  case (baseSection, leftSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+                        baseSection,
+                        leftSection
+                      ) =>
+                    Match.BaseAndLeft(baseSection, leftSection)
+                }
+            case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
+              (baseMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (baseSection, rightSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+                        baseSection,
+                        rightSection
+                      ) =>
+                    Match.BaseAndRight(baseSection, rightSection)
+                }
+            case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
+              (leftMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (leftSection, rightSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+                        leftSection,
+                        rightSection
+                      ) =>
+                    Match.LeftAndRight(leftSection, rightSection)
+                }
+          }
+          .filter(_.nonEmpty)
+          .toSeq
+
+        // 4. Build putative groups from the back-translated matches. These
+        // won't be perfectly accurate, but are refined later by
+        // `reconcileMatches`.
+
+        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
+        // the back-translated matches, because the thinning out of ambiguous
+        // matches performed by the meta-matching and back translation above
+        // means there are new opportunities for matches to be generated - while
+        // the vast majority of these are redundant pairwise matches, there are
+        // some that are vital to capture things such as moves with migrated
+        // edits / deletions - the test
+        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
+        // an example of this.
+        val backTranslatedMatchesAndTheirSections =
+          MatchesAndTheirSections.empty
+            .withMatches(
+              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
+              haveTrimmedMatches = false
+            )
+            .matchesAndTheirSections
+            .withoutRedundantPairwiseMatches
+
+        val backTranslatedMatches =
+          backTranslatedMatchesAndTheirSections.matches
+
+        val parallelMatchesGroupIdsByMatch =
+          Map.from(
+            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
+              (parallelMatches, groupId) =>
+                parallelMatches
+                  .filter(backTranslatedMatches.contains)
+                  .map(_ -> groupId)
+            )
+          )
+
+        backTranslatedMatchesAndTheirSections
+          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
+      end parallelMatchesOnly
+
+      // Cleans up the state when a putative all-sides match that would have
+      // been ambiguous on one side with another all-sides match was partially
+      // suppressed by a larger pairwise match. This situation results in a
+      // pairwise match that shares its sections on both sides with the other
+      // all-sides match; remove any such redundant pairwise matches.
+      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
+        val redundantMatches =
+          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
+
+        if redundantMatches.nonEmpty then
+          logger.debug(
+            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
+          )
+        end if
+
+        withoutTheseMatches(redundantMatches)
+      end withoutRedundantPairwiseMatches
+
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(allSides)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
+            )
+        }
+      end withoutTheseMatches
+
+      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
+        aMatch match
+          case Match.BaseAndLeft(baseSection, leftSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(leftSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.BaseAndRight(baseSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.LeftAndRight(leftSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(leftSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case _: Match.AllSides[Section[Element]] => false
+
+      private def isSubsumedNonTriviallyByAnAllSidesMatch(
+          baseSection: Section[Element],
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAnAllSidesMatch
+
+      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+          baseSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+          baseSection: Section[Element],
+          leftSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
+
+      private def withMatches(
+          matches: Set[GenericMatch[Element]],
+          haveTrimmedMatches: Boolean
+      ): MatchingResult =
+        val updatedMatchesAndTheirSections =
+          matches.foldLeft(this)(_ withMatch _)
+
+        val pathInclusions =
+          if !haveTrimmedMatches then
+            case class PathInclusionsImplementation(
+                basePaths: Set[Path],
+                leftPaths: Set[Path],
+                rightPaths: Set[Path]
+            ) extends PathInclusions:
+              override def isIncludedOnBase(basePath: Path): Boolean =
+                basePaths.contains(basePath)
+
+              override def isIncludedOnLeft(leftPath: Path): Boolean =
+                leftPaths.contains(leftPath)
+
+              override def isIncludedOnRight(rightPath: Path): Boolean =
+                rightPaths.contains(rightPath)
+
+              def addPathOnBaseFor(
+                  baseSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
+              def addPathOnLeftFor(
+                  leftSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
+              def addPathOnRightFor(
+                  rightSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(rightPaths =
+                  rightPaths + rightSources.pathFor(rightSection)
+                )
+            end PathInclusionsImplementation
+
+            matches.foldLeft(
+              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
+            )((partialPathInclusions, aMatch) =>
+              aMatch match
+                case Match.AllSides(baseSection, leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.BaseAndLeft(baseSection, leftSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                case Match.BaseAndRight(baseSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.LeftAndRight(leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+            )
+          else PathInclusions.all
+
+        MatchingResult(
+          matchesAndTheirSections = updatedMatchesAndTheirSections,
+          numberOfMatchesForTheGivenWindowSize = matches.size,
+          estimatedWindowSizeForOptimalMatch =
+            estimateOptimalMatchSize(matches),
+          pathInclusions = pathInclusions
+        )
+      end withMatches
+
+      private def withMatch(
+          aMatch: GenericMatch[Element]
+      ): MatchesAndTheirSections =
+        aMatch match
+          case Match.AllSides(baseSection, leftSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
+              baseFingerprintedInclusionsByPath =
+                knockOutFromBaseFingerprintedInclusions(baseSection),
+              leftFingerprintedInclusionsByPath =
+                knockOutFromLeftFingerprintedInclusions(leftSection),
+              rightFingerprintedInclusionsByPath =
+                knockOutFromRightFingerprintedInclusions(rightSection)
+            )
+          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
+            )
+          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
+            )
+          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
+            copy(
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
+            )
+        end match
+      end withMatch
 
       private def checkInvariant(): Unit =
         // We expect to tally either two lots of a given pairwise match or three
@@ -2141,610 +2736,6 @@ object MatchAnalysis extends StrictLogging:
             )
         }
       end pairwiseMatchesSubsumingOnBothSidesWithBiteEdges
-
-      def parallelMatchesOnly: MatchesAndTheirSections =
-        // PLAN:
-
-        // 1. Build up sources composed of matched sections concatenated
-        // together by path preserving their original order.
-
-        val baseMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(baseSection, _, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndLeft(baseSection, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndRight(baseSection, _))
-                  if section == baseSection =>
-                section
-            }
-
-        val leftMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, leftSection, _))
-                  if section == leftSection =>
-                section
-              case (section, Match.BaseAndLeft(_, leftSection))
-                  if section == leftSection =>
-                section
-              case (section, Match.LeftAndRight(leftSection, _))
-                  if section == leftSection =>
-                section
-            }
-
-        val rightMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, _, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.BaseAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.LeftAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-            }
-
-        case class MetaMatchContentSources(
-            override val contentsByPath: Map[Path, IndexedSeq[
-              Section[Element]
-            ]],
-            override val label: String
-        ) extends MappedContentSources[Path, Section[Element]]
-
-        def sourcesForMetaMatching(label: String)(
-            sources: Sources[Path, Element],
-            matchedSections: Iterable[Section[Element]]
-        ) = MetaMatchContentSources(
-          contentsByPath = matchedSections
-            .groupBy(sources.pathFor)
-            .map((path, sections) =>
-              path -> sections.toIndexedSeq
-                .sortBy(section =>
-                  // NOTE: use the negative of the section size as a tiebreaker
-                  // if more than one section has the same start offset. This
-                  // makes sure that a subsuming section comes *before* any
-                  // sections that it might subsume, so it can't interpose
-                  // itself within what would have been a run of parallel
-                  // subsumed sections; that way we don't accidentally split
-                  // what should be larger meta-matches. That can occur when the
-                  // subsuming section is contributed by a larger pairwise match
-                  // that subsumes several all-sides matches, and the first
-                  // all-sides match aligns with the start of the pairwise
-                  // match. The test
-                  // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation`
-                  // has an example of this.
-                  section.startOffset -> -section.size
-                )
-            ),
-          label = label
-        )
-
-        val baseSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-base")(
-            baseSources,
-            baseMatchedSections
-          )
-        val leftSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-left")(
-            leftSources,
-            leftMatchedSections
-          )
-        val rightSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-right")(
-            rightSources,
-            rightMatchedSections
-          )
-
-        // 2. Apply `MatchAnalysis.of` to these sections, using the
-        // potential match key of the section to underpin equality and
-        // hashing.
-
-        object metaMatchConfiguration extends AbstractConfiguration:
-          override val minimumMatchSize: Int                    = 1
-          override val thresholdSizeFractionForMatching: Double = 0
-          override val minimumAmbiguousMatchSize: Int           = 1
-          override val ambiguousMatchesThreshold: Int           = Int.MaxValue
-          override val progressRecording: ProgressRecording     =
-            configuration.progressRecording
-        end metaMatchConfiguration
-
-        given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
-
-        given Funnel[Section[Element]] with
-          override def funnel(
-              from: Section[Element],
-              into: PrimitiveSink
-          ): Unit =
-            from.content.foreach(summon[Funnel[Element]].funnel(_, into))
-
-        end given
-
-        val metaMatchAnalysis = of(
-          baseSourcesForMetaMatching,
-          leftSourcesForMetaMatching,
-          rightSourcesForMetaMatching
-        )(metaMatchConfiguration)
-
-        // 3. The resulting meta-matches provide parallel sequences of sections
-        // that are unzipped to yield corresponding all-sides and pairwise
-        // matches.
-
-        val metaMatches = metaMatchAnalysis.matches
-
-        // NOTE: because meta-matching starts with matched *sections* and
-        // ignores gaps, we have to guard against sections that would have
-        // formed the sides of a suppressed outer match making a second attempt
-        // at building a match.
-        val groupsOfBackTranslatedParallelMatches = metaMatches
-          .map {
-            case Match.AllSides(
-                  baseMetaSection,
-                  leftMetaSection,
-                  rightMetaSection
-                ) =>
-              (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAnAllSidesMatch(
-                        baseSection,
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.AllSides(baseSection, leftSection, rightSection)
-                }
-            case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
-              (baseMetaSection.content lazyZip leftMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-                        baseSection,
-                        leftSection
-                      ) =>
-                    Match.BaseAndLeft(baseSection, leftSection)
-                }
-            case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
-              (baseMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-                        baseSection,
-                        rightSection
-                      ) =>
-                    Match.BaseAndRight(baseSection, rightSection)
-                }
-            case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
-              (leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.LeftAndRight(leftSection, rightSection)
-                }
-          }
-          .filter(_.nonEmpty)
-          .toSeq
-
-        // 4. Build putative groups from the back-translated matches. These
-        // won't be perfectly accurate, but are refined later by
-        // `reconcileMatches`.
-
-        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
-        // the back-translated matches, because the thinning out of ambiguous
-        // matches performed by the meta-matching and back translation above
-        // means there are new opportunities for matches to be generated - while
-        // the vast majority of these are redundant pairwise matches, there are
-        // some that are vital to capture things such as moves with migrated
-        // edits / deletions - the test
-        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
-        // an example of this.
-        val backTranslatedMatchesAndTheirSections =
-          MatchesAndTheirSections.empty
-            .withMatches(
-              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
-              haveTrimmedMatches = false
-            )
-            .matchesAndTheirSections
-            .withoutRedundantPairwiseMatches
-
-        val backTranslatedMatches =
-          backTranslatedMatchesAndTheirSections.matches
-
-        val parallelMatchesGroupIdsByMatch =
-          Map.from(
-            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
-              (parallelMatches, groupId) =>
-                parallelMatches
-                  .filter(backTranslatedMatches.contains)
-                  .map(_ -> groupId)
-            )
-          )
-
-        backTranslatedMatchesAndTheirSections
-          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
-      end parallelMatchesOnly
-
-      // Cleans up the state when a putative all-sides match that would have
-      // been ambiguous on one side with another all-sides match was partially
-      // suppressed by a larger pairwise match. This situation results in a
-      // pairwise match that shares its sections on both sides with the other
-      // all-sides match; remove any such redundant pairwise matches.
-      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
-        val redundantMatches =
-          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
-
-        if redundantMatches.nonEmpty then
-          logger.debug(
-            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
-          )
-        end if
-
-        withoutTheseMatches(redundantMatches)
-      end withoutRedundantPairwiseMatches
-
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(allSides)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
-            )
-        }
-      end withoutTheseMatches
-
-      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
-        aMatch match
-          case Match.BaseAndLeft(baseSection, leftSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(leftSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.BaseAndRight(baseSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.LeftAndRight(leftSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(leftSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case _: Match.AllSides[Section[Element]] => false
-
-      private def isSubsumedNonTriviallyByAnAllSidesMatch(
-          baseSection: Section[Element],
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAnAllSidesMatch
-
-      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-          baseSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-          baseSection: Section[Element],
-          leftSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
-
-      private def withMatches(
-          matches: Set[GenericMatch[Element]],
-          haveTrimmedMatches: Boolean
-      ): MatchingResult =
-        val updatedMatchesAndTheirSections =
-          matches.foldLeft(this)(_ withMatch _)
-
-        val pathInclusions =
-          if !haveTrimmedMatches then
-            case class PathInclusionsImplementation(
-                basePaths: Set[Path],
-                leftPaths: Set[Path],
-                rightPaths: Set[Path]
-            ) extends PathInclusions:
-              override def isIncludedOnBase(basePath: Path): Boolean =
-                basePaths.contains(basePath)
-
-              override def isIncludedOnLeft(leftPath: Path): Boolean =
-                leftPaths.contains(leftPath)
-
-              override def isIncludedOnRight(rightPath: Path): Boolean =
-                rightPaths.contains(rightPath)
-
-              def addPathOnBaseFor(
-                  baseSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
-              def addPathOnLeftFor(
-                  leftSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
-              def addPathOnRightFor(
-                  rightSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(rightPaths =
-                  rightPaths + rightSources.pathFor(rightSection)
-                )
-            end PathInclusionsImplementation
-
-            matches.foldLeft(
-              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
-            )((partialPathInclusions, aMatch) =>
-              aMatch match
-                case Match.AllSides(baseSection, leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.BaseAndLeft(baseSection, leftSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                case Match.BaseAndRight(baseSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.LeftAndRight(leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-            )
-          else PathInclusions.all
-
-        MatchingResult(
-          matchesAndTheirSections = updatedMatchesAndTheirSections,
-          numberOfMatchesForTheGivenWindowSize = matches.size,
-          estimatedWindowSizeForOptimalMatch =
-            estimateOptimalMatchSize(matches),
-          pathInclusions = pathInclusions
-        )
-      end withMatches
-
-      private def withMatch(
-          aMatch: GenericMatch[Element]
-      ): MatchesAndTheirSections =
-        aMatch match
-          case Match.AllSides(baseSection, leftSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
-              baseFingerprintedInclusionsByPath =
-                knockOutFromBaseFingerprintedInclusions(baseSection),
-              leftFingerprintedInclusionsByPath =
-                knockOutFromLeftFingerprintedInclusions(leftSection),
-              rightFingerprintedInclusionsByPath =
-                knockOutFromRightFingerprintedInclusions(rightSection)
-            )
-          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
-            )
-          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
-            )
-          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
-            copy(
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
-            )
-        end match
-      end withMatch
 
       private def pairwiseMatchesSubsumingOnBothSides(
           allSides: Match.AllSides[Section[Element]]

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1376,15 +1376,17 @@ object MatchAnalysis extends StrictLogging:
                         updatedParallelMatchesGroupIdsByMatch
                           .filter((key, _) => matches.contains(key))
 
-                      val groupIdsWithPossibleGaps: Map[
+                      val compactGroupIdsKeyedByGroupsIdsWithPossibleGaps: Map[
                         ParallelMatchesGroupId,
                         ParallelMatchesGroupId
                       ] =
-                        parallelMatchesGroupIdsByMatch.values.zipWithIndex.toMap
+                        parallelMatchesGroupIdsByMatch.values.toSeq.distinct.zipWithIndex.toMap
 
                       val parallelMatchesWithReorganisedGroupIdsByMatch =
                         parallelMatchesGroupIdsByMatch.map((aMatch, groupId) =>
-                          aMatch -> groupIdsWithPossibleGaps(groupId)
+                          aMatch -> compactGroupIdsKeyedByGroupsIdsWithPossibleGaps(
+                            groupId
+                          )
                         )
 
                       Right(
@@ -1439,7 +1441,7 @@ object MatchAnalysis extends StrictLogging:
 
           SortedMap.from(
             result.parallelMatchesGroupIdsByMatch.groupBy(_._2).map {
-              (groupId, group) => groupId -> SortedSet.from(group.map(_._1))
+              (groupId, group) => groupId -> SortedSet.from(group.keys)
             }
           )
         end groupsOfParallelMatches

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -758,8 +758,8 @@ object MatchAnalysis extends StrictLogging:
           }
           .map(_.toSet)
 
-      // There are preconditions buried in the implementations that require the
-      // bite edges to be sorted in terms of their offsets and not exceed the
+      // There are contracts buried in the implementation that require the bite
+      // edges to be sorted in terms of their offsets and not exceed the
       // section's boundaries.
       extension (biteEdges: SortedSet[BiteEdge])
         private def eatIntoPairwiseMatch(
@@ -827,24 +827,21 @@ object MatchAnalysis extends StrictLogging:
                   if sectionSize > mealStartOffsetRelativeToMeal then
                     val size = sectionSize - mealStartOffsetRelativeToMeal
 
-                    for
-                      assignedGroupId <- deferredGroupIdFromPrecedingBite
-                        .fold(ifEmpty = freshGroupId)(State.pure)
-
-                      fragment = factory(
-                        firstSide.section(firstPath)(
-                          firstSection.startOffset + mealStartOffsetRelativeToMeal,
-                          size
-                        ),
-                        secondSide.section(secondPath)(
-                          secondSection.startOffset + mealStartOffsetRelativeToMeal,
-                          size
-                        )
+                    val fragment = factory(
+                      firstSide.section(firstPath)(
+                        firstSection.startOffset + mealStartOffsetRelativeToMeal,
+                        size
+                      ),
+                      secondSide.section(secondPath)(
+                        secondSection.startOffset + mealStartOffsetRelativeToMeal,
+                        size
                       )
+                    )
 
-                      _ <- assignGroupId(fragment, assignedGroupId)
-                    yield Right(fragments.appended(fragment))
-                    end for
+                    assignGroupId(
+                      fragment,
+                      deferredGroupIdFromPrecedingBite
+                    ) as Right(fragments.appended(fragment))
                   else State.pure(Right(fragments))
 
                 case Seq(
@@ -865,9 +862,9 @@ object MatchAnalysis extends StrictLogging:
                         val groupIdFromSucceedingBite =
                           groupIdsBySortedBiteEdge(biteEdge)
 
-                        val assignedGroupId =
+                        val groupId =
                           deferredGroupIdFromPrecedingBite.fold(ifEmpty =
-                            State.pure(groupIdFromSucceedingBite)
+                            Some(groupIdFromSucceedingBite)
                           )(groupIdFromPrecedingBite =>
                             if groupIdFromPrecedingBite != groupIdFromSucceedingBite
                             then
@@ -879,8 +876,8 @@ object MatchAnalysis extends StrictLogging:
                               // might result in multiple fragments sharing the
                               // same group id but with intervening bites
                               // belonging to other groups.
-                              freshGroupId
-                            else State.pure(groupIdFromSucceedingBite)
+                              None
+                            else Some(groupIdFromSucceedingBite)
                           )
 
                         val fragment = factory(
@@ -894,9 +891,9 @@ object MatchAnalysis extends StrictLogging:
                           )
                         )
 
-                        assignedGroupId
-                          .flatMap(assignGroupId(fragment, _))
-                          .as(fragments.appended(fragment))
+                        assignGroupId(fragment, groupId).as(
+                          fragments.appended(fragment)
+                        )
                       else State.pure(fragments)
                   yield Left(
                     this
@@ -957,17 +954,18 @@ object MatchAnalysis extends StrictLogging:
 
       private def assignGroupId(
           fragment: PairwiseMatch,
-          groupId: ParallelMatchesGroupId
+          groupId: Option[ParallelMatchesGroupId]
       ): ParallelMatchesGroupIdTracking[Unit] =
-        State.modify[ParallelMatchesGroupIdsByMatch](_ + (fragment -> groupId))
+        State.modify[ParallelMatchesGroupIdsByMatch] { groupIdsByMatch =>
+          val assignedGroupId = groupId.getOrElse(
+            // TODO: trawling linearly through the group ids to find the maximum
+            // isn't a great idea. Perhaps there should be a maximum group id
+            // too?
+            groupIdsByMatch.values.maxOption.fold(ifEmpty = 0)(1 + _)
+          )
 
-      private def freshGroupId
-          : ParallelMatchesGroupIdTracking[ParallelMatchesGroupId] =
-        // TODO: trawling linearly through the group ids to find the maximum
-        // isn't a great idea. Perhaps there should be a maximum group id too?
-        State.inspect[ParallelMatchesGroupIdsByMatch, ParallelMatchesGroupId](
-          _.values.maxOption.fold(ifEmpty = 0)(1 + _)
-        )
+          groupIdsByMatch + (fragment -> assignedGroupId)
+        }
 
       private def propagateGroupIds(
           original: GenericMatch[Element],
@@ -1453,610 +1451,6 @@ object MatchAnalysis extends StrictLogging:
         result
 
       end reconcileMatches
-
-      def parallelMatchesOnly: MatchesAndTheirSections =
-        // PLAN:
-
-        // 1. Build up sources composed of matched sections concatenated
-        // together by path preserving their original order.
-
-        val baseMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(baseSection, _, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndLeft(baseSection, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndRight(baseSection, _))
-                  if section == baseSection =>
-                section
-            }
-
-        val leftMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, leftSection, _))
-                  if section == leftSection =>
-                section
-              case (section, Match.BaseAndLeft(_, leftSection))
-                  if section == leftSection =>
-                section
-              case (section, Match.LeftAndRight(leftSection, _))
-                  if section == leftSection =>
-                section
-            }
-
-        val rightMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, _, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.BaseAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.LeftAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-            }
-
-        case class MetaMatchContentSources(
-            override val contentsByPath: Map[Path, IndexedSeq[
-              Section[Element]
-            ]],
-            override val label: String
-        ) extends MappedContentSources[Path, Section[Element]]
-
-        def sourcesForMetaMatching(label: String)(
-            sources: Sources[Path, Element],
-            matchedSections: Iterable[Section[Element]]
-        ) = MetaMatchContentSources(
-          contentsByPath = matchedSections
-            .groupBy(sources.pathFor)
-            .map((path, sections) =>
-              path -> sections.toIndexedSeq
-                .sortBy(section =>
-                  // NOTE: use the negative of the section size as a tiebreaker
-                  // if more than one section has the same start offset. This
-                  // makes sure that a subsuming section comes *before* any
-                  // sections that it might subsume, so it can't interpose
-                  // itself within what would have been a run of parallel
-                  // subsumed sections; that way we don't accidentally split
-                  // what should be larger meta-matches. That can occur when the
-                  // subsuming section is contributed by a larger pairwise match
-                  // that subsumes several all-sides matches, and the first
-                  // all-sides match aligns with the start of the pairwise
-                  // match. The test
-                  // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation`
-                  // has an example of this.
-                  section.startOffset -> -section.size
-                )
-            ),
-          label = label
-        )
-
-        val baseSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-base")(
-            baseSources,
-            baseMatchedSections
-          )
-        val leftSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-left")(
-            leftSources,
-            leftMatchedSections
-          )
-        val rightSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-right")(
-            rightSources,
-            rightMatchedSections
-          )
-
-        // 2. Apply `MatchAnalysis.of` to these sections, using the
-        // potential match key of the section to underpin equality and
-        // hashing.
-
-        object metaMatchConfiguration extends AbstractConfiguration:
-          override val minimumMatchSize: Int                    = 1
-          override val thresholdSizeFractionForMatching: Double = 0
-          override val minimumAmbiguousMatchSize: Int           = 1
-          override val ambiguousMatchesThreshold: Int           = Int.MaxValue
-          override val progressRecording: ProgressRecording     =
-            configuration.progressRecording
-        end metaMatchConfiguration
-
-        given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
-
-        given Funnel[Section[Element]] with
-          override def funnel(
-              from: Section[Element],
-              into: PrimitiveSink
-          ): Unit =
-            from.content.foreach(summon[Funnel[Element]].funnel(_, into))
-
-        end given
-
-        val metaMatchAnalysis = of(
-          baseSourcesForMetaMatching,
-          leftSourcesForMetaMatching,
-          rightSourcesForMetaMatching
-        )(metaMatchConfiguration)
-
-        // 3. The resulting meta-matches provide parallel sequences of sections
-        // that are unzipped to yield corresponding all-sides and pairwise
-        // matches.
-
-        val metaMatches = metaMatchAnalysis.matches
-
-        // NOTE: because meta-matching starts with matched *sections* and
-        // ignores gaps, we have to guard against sections that would have
-        // formed the sides of a suppressed outer match making a second attempt
-        // at building a match.
-        val groupsOfBackTranslatedParallelMatches = metaMatches
-          .map {
-            case Match.AllSides(
-                  baseMetaSection,
-                  leftMetaSection,
-                  rightMetaSection
-                ) =>
-              (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAnAllSidesMatch(
-                        baseSection,
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.AllSides(baseSection, leftSection, rightSection)
-                }
-            case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
-              (baseMetaSection.content lazyZip leftMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-                        baseSection,
-                        leftSection
-                      ) =>
-                    Match.BaseAndLeft(baseSection, leftSection)
-                }
-            case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
-              (baseMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-                        baseSection,
-                        rightSection
-                      ) =>
-                    Match.BaseAndRight(baseSection, rightSection)
-                }
-            case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
-              (leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.LeftAndRight(leftSection, rightSection)
-                }
-          }
-          .filter(_.nonEmpty)
-          .toSeq
-
-        // 4. Build putative groups from the back-translated matches. These
-        // won't be perfectly accurate, but are refined later by
-        // `reconcileMatches`.
-
-        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
-        // the back-translated matches, because the thinning out of ambiguous
-        // matches performed by the meta-matching and back translation above
-        // means there are new opportunities for matches to be generated - while
-        // the vast majority of these are redundant pairwise matches, there are
-        // some that are vital to capture things such as moves with migrated
-        // edits / deletions - the test
-        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
-        // an example of this.
-        val backTranslatedMatchesAndTheirSections =
-          MatchesAndTheirSections.empty
-            .withMatches(
-              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
-              haveTrimmedMatches = false
-            )
-            .matchesAndTheirSections
-            .withoutRedundantPairwiseMatches
-
-        val backTranslatedMatches =
-          backTranslatedMatchesAndTheirSections.matches
-
-        val parallelMatchesGroupIdsByMatch =
-          Map.from(
-            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
-              (parallelMatches, groupId) =>
-                parallelMatches
-                  .filter(backTranslatedMatches.contains)
-                  .map(_ -> groupId)
-            )
-          )
-
-        backTranslatedMatchesAndTheirSections
-          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
-      end parallelMatchesOnly
-
-      // Cleans up the state when a putative all-sides match that would have
-      // been ambiguous on one side with another all-sides match was partially
-      // suppressed by a larger pairwise match. This situation results in a
-      // pairwise match that shares its sections on both sides with the other
-      // all-sides match; remove any such redundant pairwise matches.
-      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
-        val redundantMatches =
-          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
-
-        if redundantMatches.nonEmpty then
-          logger.debug(
-            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
-          )
-        end if
-
-        withoutTheseMatches(redundantMatches)
-      end withoutRedundantPairwiseMatches
-
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(allSides)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
-            )
-        }
-      end withoutTheseMatches
-
-      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
-        aMatch match
-          case Match.BaseAndLeft(baseSection, leftSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(leftSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.BaseAndRight(baseSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.LeftAndRight(leftSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(leftSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case _: Match.AllSides[Section[Element]] => false
-
-      private def isSubsumedNonTriviallyByAnAllSidesMatch(
-          baseSection: Section[Element],
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAnAllSidesMatch
-
-      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-          baseSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-          baseSection: Section[Element],
-          leftSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
-
-      private def withMatches(
-          matches: Set[GenericMatch[Element]],
-          haveTrimmedMatches: Boolean
-      ): MatchingResult =
-        val updatedMatchesAndTheirSections =
-          matches.foldLeft(this)(_ withMatch _)
-
-        val pathInclusions =
-          if !haveTrimmedMatches then
-            case class PathInclusionsImplementation(
-                basePaths: Set[Path],
-                leftPaths: Set[Path],
-                rightPaths: Set[Path]
-            ) extends PathInclusions:
-              override def isIncludedOnBase(basePath: Path): Boolean =
-                basePaths.contains(basePath)
-
-              override def isIncludedOnLeft(leftPath: Path): Boolean =
-                leftPaths.contains(leftPath)
-
-              override def isIncludedOnRight(rightPath: Path): Boolean =
-                rightPaths.contains(rightPath)
-
-              def addPathOnBaseFor(
-                  baseSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
-              def addPathOnLeftFor(
-                  leftSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
-              def addPathOnRightFor(
-                  rightSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(rightPaths =
-                  rightPaths + rightSources.pathFor(rightSection)
-                )
-            end PathInclusionsImplementation
-
-            matches.foldLeft(
-              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
-            )((partialPathInclusions, aMatch) =>
-              aMatch match
-                case Match.AllSides(baseSection, leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.BaseAndLeft(baseSection, leftSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                case Match.BaseAndRight(baseSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.LeftAndRight(leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-            )
-          else PathInclusions.all
-
-        MatchingResult(
-          matchesAndTheirSections = updatedMatchesAndTheirSections,
-          numberOfMatchesForTheGivenWindowSize = matches.size,
-          estimatedWindowSizeForOptimalMatch =
-            estimateOptimalMatchSize(matches),
-          pathInclusions = pathInclusions
-        )
-      end withMatches
-
-      private def withMatch(
-          aMatch: GenericMatch[Element]
-      ): MatchesAndTheirSections =
-        aMatch match
-          case Match.AllSides(baseSection, leftSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
-              baseFingerprintedInclusionsByPath =
-                knockOutFromBaseFingerprintedInclusions(baseSection),
-              leftFingerprintedInclusionsByPath =
-                knockOutFromLeftFingerprintedInclusions(leftSection),
-              rightFingerprintedInclusionsByPath =
-                knockOutFromRightFingerprintedInclusions(rightSection)
-            )
-          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
-            )
-          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
-            )
-          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
-            copy(
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
-            )
-        end match
-      end withMatch
 
       private def checkInvariant(): Unit =
         // We expect to tally either two lots of a given pairwise match or three
@@ -2736,6 +2130,610 @@ object MatchAnalysis extends StrictLogging:
             )
         }
       end pairwiseMatchesSubsumingOnBothSidesWithBiteEdges
+
+      def parallelMatchesOnly: MatchesAndTheirSections =
+        // PLAN:
+
+        // 1. Build up sources composed of matched sections concatenated
+        // together by path preserving their original order.
+
+        val baseMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(baseSection, _, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndLeft(baseSection, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndRight(baseSection, _))
+                  if section == baseSection =>
+                section
+            }
+
+        val leftMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, leftSection, _))
+                  if section == leftSection =>
+                section
+              case (section, Match.BaseAndLeft(_, leftSection))
+                  if section == leftSection =>
+                section
+              case (section, Match.LeftAndRight(leftSection, _))
+                  if section == leftSection =>
+                section
+            }
+
+        val rightMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, _, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.BaseAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.LeftAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+            }
+
+        case class MetaMatchContentSources(
+            override val contentsByPath: Map[Path, IndexedSeq[
+              Section[Element]
+            ]],
+            override val label: String
+        ) extends MappedContentSources[Path, Section[Element]]
+
+        def sourcesForMetaMatching(label: String)(
+            sources: Sources[Path, Element],
+            matchedSections: Iterable[Section[Element]]
+        ) = MetaMatchContentSources(
+          contentsByPath = matchedSections
+            .groupBy(sources.pathFor)
+            .map((path, sections) =>
+              path -> sections.toIndexedSeq
+                .sortBy(section =>
+                  // NOTE: use the negative of the section size as a tiebreaker
+                  // if more than one section has the same start offset. This
+                  // makes sure that a subsuming section comes *before* any
+                  // sections that it might subsume, so it can't interpose
+                  // itself within what would have been a run of parallel
+                  // subsumed sections; that way we don't accidentally split
+                  // what should be larger meta-matches. That can occur when the
+                  // subsuming section is contributed by a larger pairwise match
+                  // that subsumes several all-sides matches, and the first
+                  // all-sides match aligns with the start of the pairwise
+                  // match. The test
+                  // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation`
+                  // has an example of this.
+                  section.startOffset -> -section.size
+                )
+            ),
+          label = label
+        )
+
+        val baseSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-base")(
+            baseSources,
+            baseMatchedSections
+          )
+        val leftSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-left")(
+            leftSources,
+            leftMatchedSections
+          )
+        val rightSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-right")(
+            rightSources,
+            rightMatchedSections
+          )
+
+        // 2. Apply `MatchAnalysis.of` to these sections, using the
+        // potential match key of the section to underpin equality and
+        // hashing.
+
+        object metaMatchConfiguration extends AbstractConfiguration:
+          override val minimumMatchSize: Int                    = 1
+          override val thresholdSizeFractionForMatching: Double = 0
+          override val minimumAmbiguousMatchSize: Int           = 1
+          override val ambiguousMatchesThreshold: Int           = Int.MaxValue
+          override val progressRecording: ProgressRecording     =
+            configuration.progressRecording
+        end metaMatchConfiguration
+
+        given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
+
+        given Funnel[Section[Element]] with
+          override def funnel(
+              from: Section[Element],
+              into: PrimitiveSink
+          ): Unit =
+            from.content.foreach(summon[Funnel[Element]].funnel(_, into))
+
+        end given
+
+        val metaMatchAnalysis = of(
+          baseSourcesForMetaMatching,
+          leftSourcesForMetaMatching,
+          rightSourcesForMetaMatching
+        )(metaMatchConfiguration)
+
+        // 3. The resulting meta-matches provide parallel sequences of sections
+        // that are unzipped to yield corresponding all-sides and pairwise
+        // matches.
+
+        val metaMatches = metaMatchAnalysis.matches
+
+        // NOTE: because meta-matching starts with matched *sections* and
+        // ignores gaps, we have to guard against sections that would have
+        // formed the sides of a suppressed outer match making a second attempt
+        // at building a match.
+        val groupsOfBackTranslatedParallelMatches = metaMatches
+          .map {
+            case Match.AllSides(
+                  baseMetaSection,
+                  leftMetaSection,
+                  rightMetaSection
+                ) =>
+              (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (baseSection, leftSection, rightSection)
+                      if !isSubsumedNonTriviallyByAnAllSidesMatch(
+                        baseSection,
+                        leftSection,
+                        rightSection
+                      ) =>
+                    Match.AllSides(baseSection, leftSection, rightSection)
+                }
+            case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
+              (baseMetaSection.content lazyZip leftMetaSection.content)
+                .collect {
+                  case (baseSection, leftSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+                        baseSection,
+                        leftSection
+                      ) =>
+                    Match.BaseAndLeft(baseSection, leftSection)
+                }
+            case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
+              (baseMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (baseSection, rightSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+                        baseSection,
+                        rightSection
+                      ) =>
+                    Match.BaseAndRight(baseSection, rightSection)
+                }
+            case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
+              (leftMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (leftSection, rightSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+                        leftSection,
+                        rightSection
+                      ) =>
+                    Match.LeftAndRight(leftSection, rightSection)
+                }
+          }
+          .filter(_.nonEmpty)
+          .toSeq
+
+        // 4. Build putative groups from the back-translated matches. These
+        // won't be perfectly accurate, but are refined later by
+        // `reconcileMatches`.
+
+        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
+        // the back-translated matches, because the thinning out of ambiguous
+        // matches performed by the meta-matching and back translation above
+        // means there are new opportunities for matches to be generated - while
+        // the vast majority of these are redundant pairwise matches, there are
+        // some that are vital to capture things such as moves with migrated
+        // edits / deletions - the test
+        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
+        // an example of this.
+        val backTranslatedMatchesAndTheirSections =
+          MatchesAndTheirSections.empty
+            .withMatches(
+              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
+              haveTrimmedMatches = false
+            )
+            .matchesAndTheirSections
+            .withoutRedundantPairwiseMatches
+
+        val backTranslatedMatches =
+          backTranslatedMatchesAndTheirSections.matches
+
+        val parallelMatchesGroupIdsByMatch =
+          Map.from(
+            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
+              (parallelMatches, groupId) =>
+                parallelMatches
+                  .filter(backTranslatedMatches.contains)
+                  .map(_ -> groupId)
+            )
+          )
+
+        backTranslatedMatchesAndTheirSections
+          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
+      end parallelMatchesOnly
+
+      // Cleans up the state when a putative all-sides match that would have
+      // been ambiguous on one side with another all-sides match was partially
+      // suppressed by a larger pairwise match. This situation results in a
+      // pairwise match that shares its sections on both sides with the other
+      // all-sides match; remove any such redundant pairwise matches.
+      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
+        val redundantMatches =
+          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
+
+        if redundantMatches.nonEmpty then
+          logger.debug(
+            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
+          )
+        end if
+
+        withoutTheseMatches(redundantMatches)
+      end withoutRedundantPairwiseMatches
+
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(allSides)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
+            )
+        }
+      end withoutTheseMatches
+
+      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
+        aMatch match
+          case Match.BaseAndLeft(baseSection, leftSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(leftSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.BaseAndRight(baseSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.LeftAndRight(leftSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(leftSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case _: Match.AllSides[Section[Element]] => false
+
+      private def isSubsumedNonTriviallyByAnAllSidesMatch(
+          baseSection: Section[Element],
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAnAllSidesMatch
+
+      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+          baseSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+          baseSection: Section[Element],
+          leftSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
+
+      private def withMatches(
+          matches: Set[GenericMatch[Element]],
+          haveTrimmedMatches: Boolean
+      ): MatchingResult =
+        val updatedMatchesAndTheirSections =
+          matches.foldLeft(this)(_ withMatch _)
+
+        val pathInclusions =
+          if !haveTrimmedMatches then
+            case class PathInclusionsImplementation(
+                basePaths: Set[Path],
+                leftPaths: Set[Path],
+                rightPaths: Set[Path]
+            ) extends PathInclusions:
+              override def isIncludedOnBase(basePath: Path): Boolean =
+                basePaths.contains(basePath)
+
+              override def isIncludedOnLeft(leftPath: Path): Boolean =
+                leftPaths.contains(leftPath)
+
+              override def isIncludedOnRight(rightPath: Path): Boolean =
+                rightPaths.contains(rightPath)
+
+              def addPathOnBaseFor(
+                  baseSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
+              def addPathOnLeftFor(
+                  leftSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
+              def addPathOnRightFor(
+                  rightSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(rightPaths =
+                  rightPaths + rightSources.pathFor(rightSection)
+                )
+            end PathInclusionsImplementation
+
+            matches.foldLeft(
+              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
+            )((partialPathInclusions, aMatch) =>
+              aMatch match
+                case Match.AllSides(baseSection, leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.BaseAndLeft(baseSection, leftSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                case Match.BaseAndRight(baseSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.LeftAndRight(leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+            )
+          else PathInclusions.all
+
+        MatchingResult(
+          matchesAndTheirSections = updatedMatchesAndTheirSections,
+          numberOfMatchesForTheGivenWindowSize = matches.size,
+          estimatedWindowSizeForOptimalMatch =
+            estimateOptimalMatchSize(matches),
+          pathInclusions = pathInclusions
+        )
+      end withMatches
+
+      private def withMatch(
+          aMatch: GenericMatch[Element]
+      ): MatchesAndTheirSections =
+        aMatch match
+          case Match.AllSides(baseSection, leftSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
+              baseFingerprintedInclusionsByPath =
+                knockOutFromBaseFingerprintedInclusions(baseSection),
+              leftFingerprintedInclusionsByPath =
+                knockOutFromLeftFingerprintedInclusions(leftSection),
+              rightFingerprintedInclusionsByPath =
+                knockOutFromRightFingerprintedInclusions(rightSection)
+            )
+          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
+            )
+          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
+            )
+          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
+            copy(
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
+            )
+        end match
+      end withMatch
 
       private def pairwiseMatchesSubsumingOnBothSides(
           allSides: Match.AllSides[Section[Element]]

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -32,7 +32,7 @@ import scala.collection.immutable.{
   SortedSet
 }
 import scala.collection.parallel.CollectionConverters.*
-import scala.collection.{immutable, mutable}
+import scala.collection.{View, immutable, mutable}
 import scala.util.{Success, Using}
 
 trait MatchAnalysis[Path, Element]:
@@ -1278,6 +1278,99 @@ object MatchAnalysis extends StrictLogging:
         end if
       end purgedOfMatchesWithOverlappingSections
 
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(allSides)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
+            )
+        }
+      end withoutTheseMatches
+
       def reconcileMatches: MatchesAndTheirSections =
         val matches = sectionsAndTheirMatches.values.toSet
 
@@ -1451,6 +1544,530 @@ object MatchAnalysis extends StrictLogging:
         result
 
       end reconcileMatches
+
+      def parallelMatchesOnly: MatchesAndTheirSections =
+        // PLAN:
+
+        // 1. Build up sources composed of matched sections concatenated
+        // together by path preserving their original order.
+
+        val baseMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(baseSection, _, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndLeft(baseSection, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndRight(baseSection, _))
+                  if section == baseSection =>
+                section
+            }
+
+        val leftMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, leftSection, _))
+                  if section == leftSection =>
+                section
+              case (section, Match.BaseAndLeft(_, leftSection))
+                  if section == leftSection =>
+                section
+              case (section, Match.LeftAndRight(leftSection, _))
+                  if section == leftSection =>
+                section
+            }
+
+        val rightMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, _, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.BaseAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.LeftAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+            }
+
+        // 2. Apply `MatchAnalysis.of` to these sections, using the
+        // potential match key of the section to underpin equality and
+        // hashing.
+
+        def groupsOfBackTranslatedParallelMatchesFrom(
+            baseMatchedSections: Iterable[Section[Element]],
+            leftMatchedSections: Iterable[Section[Element]],
+            rightMatchedSections: Iterable[Section[Element]]
+        ): Seq[View[Match[Section[Element]]]] =
+          case class MetaMatchContentSources(
+              override val contentsByPath: Map[Path, IndexedSeq[
+                Section[Element]
+              ]],
+              override val label: String
+          ) extends MappedContentSources[Path, Section[Element]]
+
+          def sourcesForMetaMatching(label: String)(
+              sources: Sources[Path, Element],
+              matchedSections: Iterable[Section[Element]]
+          ) = MetaMatchContentSources(
+            contentsByPath = matchedSections
+              .groupBy(sources.pathFor)
+              .map((path, sections) =>
+                path -> sections.toIndexedSeq
+                  .sortBy(section =>
+                    // NOTE: use the negative of the section size as a
+                    // tiebreaker if more than one section has the same start
+                    // offset. This makes sure that a subsuming section comes
+                    // *before* any sections that it might subsume, so it can't
+                    // interpose itself within what would have been a run of
+                    // parallel subsumed sections; that way we don't
+                    // accidentally split what should be larger meta-matches.
+                    // That can occur when the subsuming section is contributed
+                    // by a larger pairwise match that subsumes several
+                    // all-sides matches, and the first all-sides match aligns
+                    // with the start of the pairwise match. The test
+                    // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation`
+                    // has an example of this.
+                    section.startOffset -> -section.size
+                  )
+              ),
+            label = label
+          )
+
+          val baseSourcesForMetaMatching =
+            sourcesForMetaMatching("meta-base")(
+              baseSources,
+              baseMatchedSections
+            )
+          val leftSourcesForMetaMatching =
+            sourcesForMetaMatching("meta-left")(
+              leftSources,
+              leftMatchedSections
+            )
+          val rightSourcesForMetaMatching =
+            sourcesForMetaMatching("meta-right")(
+              rightSources,
+              rightMatchedSections
+            )
+
+          object metaMatchConfiguration extends AbstractConfiguration:
+            override val minimumMatchSize: Int                    = 1
+            override val thresholdSizeFractionForMatching: Double = 0
+            override val minimumAmbiguousMatchSize: Int           = 1
+            override val ambiguousMatchesThreshold: Int           = Int.MaxValue
+            override val progressRecording: ProgressRecording     =
+              configuration.progressRecording
+          end metaMatchConfiguration
+
+          given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
+
+          given Funnel[Section[Element]] with
+            override def funnel(
+                from: Section[Element],
+                into: PrimitiveSink
+            ): Unit =
+              from.content.foreach(summon[Funnel[Element]].funnel(_, into))
+
+          end given
+
+          val metaMatchAnalysis = of(
+            baseSourcesForMetaMatching,
+            leftSourcesForMetaMatching,
+            rightSourcesForMetaMatching
+          )(metaMatchConfiguration)
+
+          // 3. The resulting meta-matches provide parallel sequences of
+          // sections that are unzipped to yield corresponding all-sides and
+          // pairwise matches.
+
+          val metaMatches = metaMatchAnalysis.matches
+
+          // NOTE: because meta-matching starts with matched *sections* and
+          // ignores gaps, we have to guard against sections that would have
+          // formed the sides of a suppressed outer match making a second
+          // attempt at building a match.
+          metaMatches
+            .map {
+              case Match.AllSides(
+                    baseMetaSection,
+                    leftMetaSection,
+                    rightMetaSection
+                  ) =>
+                (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
+                  .collect {
+                    case (baseSection, leftSection, rightSection)
+                        if !isSubsumedNonTriviallyByAnAllSidesMatch(
+                          baseSection,
+                          leftSection,
+                          rightSection
+                        ) =>
+                      Match.AllSides(baseSection, leftSection, rightSection)
+                  }
+              case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
+                (baseMetaSection.content lazyZip leftMetaSection.content)
+                  .collect {
+                    case (baseSection, leftSection)
+                        if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+                          baseSection,
+                          leftSection
+                        ) =>
+                      Match.BaseAndLeft(baseSection, leftSection)
+                  }
+              case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
+                (baseMetaSection.content lazyZip rightMetaSection.content)
+                  .collect {
+                    case (baseSection, rightSection)
+                        if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+                          baseSection,
+                          rightSection
+                        ) =>
+                      Match.BaseAndRight(baseSection, rightSection)
+                  }
+              case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
+                (leftMetaSection.content lazyZip rightMetaSection.content)
+                  .collect {
+                    case (leftSection, rightSection)
+                        if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+                          leftSection,
+                          rightSection
+                        ) =>
+                      Match.LeftAndRight(leftSection, rightSection)
+                  }
+            }
+            .filter(_.nonEmpty)
+            .toSeq
+        end groupsOfBackTranslatedParallelMatchesFrom
+
+        val groupsOfBackTranslatedParallelMatches =
+          groupsOfBackTranslatedParallelMatchesFrom(
+            baseMatchedSections,
+            leftMatchedSections,
+            rightMatchedSections
+          )
+
+        // 4. Build putative groups from the back-translated matches. These
+        // won't be perfectly accurate, but are refined later by
+        // `reconcileMatches`.
+
+        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
+        // the back-translated matches, because the thinning out of ambiguous
+        // matches performed by the meta-matching and back translation above
+        // means there are new opportunities for matches to be generated - while
+        // the vast majority of these are redundant pairwise matches, there are
+        // some that are vital to capture things such as moves with migrated
+        // edits / deletions - the test
+        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
+        // an example of this.
+        val backTranslatedMatchesAndTheirSections =
+          MatchesAndTheirSections.empty
+            .withMatches(
+              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
+              haveTrimmedMatches = false
+            )
+            .matchesAndTheirSections
+            .withoutRedundantPairwiseMatches
+
+        val backTranslatedMatches =
+          backTranslatedMatchesAndTheirSections.matches
+
+        val parallelMatchesGroupIdsByMatch =
+          Map.from(
+            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
+              (parallelMatches, groupId) =>
+                parallelMatches
+                  .filter(backTranslatedMatches.contains)
+                  .map(_ -> groupId)
+            )
+          )
+
+        backTranslatedMatchesAndTheirSections
+          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
+      end parallelMatchesOnly
+
+      // Cleans up the state when a putative all-sides match that would have
+      // been ambiguous on one side with another all-sides match was partially
+      // suppressed by a larger pairwise match. This situation results in a
+      // pairwise match that shares its sections on both sides with the other
+      // all-sides match; remove any such redundant pairwise matches.
+      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
+        val redundantMatches =
+          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
+
+        if redundantMatches.nonEmpty then
+          logger.debug(
+            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
+          )
+        end if
+
+        withoutTheseMatches(redundantMatches)
+      end withoutRedundantPairwiseMatches
+
+      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
+        aMatch match
+          case Match.BaseAndLeft(baseSection, leftSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(leftSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.BaseAndRight(baseSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.LeftAndRight(leftSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(leftSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case _: Match.AllSides[Section[Element]] => false
+
+      private def isSubsumedNonTriviallyByAnAllSidesMatch(
+          baseSection: Section[Element],
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAnAllSidesMatch
+
+      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+          baseSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+          baseSection: Section[Element],
+          leftSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
+
+      private def withMatches(
+          matches: Set[GenericMatch[Element]],
+          haveTrimmedMatches: Boolean
+      ): MatchingResult =
+        val updatedMatchesAndTheirSections =
+          matches.foldLeft(this)(_ withMatch _)
+
+        val pathInclusions =
+          if !haveTrimmedMatches then
+            case class PathInclusionsImplementation(
+                basePaths: Set[Path],
+                leftPaths: Set[Path],
+                rightPaths: Set[Path]
+            ) extends PathInclusions:
+              override def isIncludedOnBase(basePath: Path): Boolean =
+                basePaths.contains(basePath)
+
+              override def isIncludedOnLeft(leftPath: Path): Boolean =
+                leftPaths.contains(leftPath)
+
+              override def isIncludedOnRight(rightPath: Path): Boolean =
+                rightPaths.contains(rightPath)
+
+              def addPathOnBaseFor(
+                  baseSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
+              def addPathOnLeftFor(
+                  leftSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
+              def addPathOnRightFor(
+                  rightSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(rightPaths =
+                  rightPaths + rightSources.pathFor(rightSection)
+                )
+            end PathInclusionsImplementation
+
+            matches.foldLeft(
+              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
+            )((partialPathInclusions, aMatch) =>
+              aMatch match
+                case Match.AllSides(baseSection, leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.BaseAndLeft(baseSection, leftSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                case Match.BaseAndRight(baseSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.LeftAndRight(leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+            )
+          else PathInclusions.all
+
+        MatchingResult(
+          matchesAndTheirSections = updatedMatchesAndTheirSections,
+          numberOfMatchesForTheGivenWindowSize = matches.size,
+          estimatedWindowSizeForOptimalMatch =
+            estimateOptimalMatchSize(matches),
+          pathInclusions = pathInclusions
+        )
+      end withMatches
+
+      private def withMatch(
+          aMatch: GenericMatch[Element]
+      ): MatchesAndTheirSections =
+        aMatch match
+          case Match.AllSides(baseSection, leftSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
+              baseFingerprintedInclusionsByPath =
+                knockOutFromBaseFingerprintedInclusions(baseSection),
+              leftFingerprintedInclusionsByPath =
+                knockOutFromLeftFingerprintedInclusions(leftSection),
+              rightFingerprintedInclusionsByPath =
+                knockOutFromRightFingerprintedInclusions(rightSection)
+            )
+          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
+            )
+          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
+            )
+          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
+            copy(
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
+            )
+        end match
+      end withMatch
 
       private def checkInvariant(): Unit =
         // We expect to tally either two lots of a given pairwise match or three
@@ -2130,610 +2747,6 @@ object MatchAnalysis extends StrictLogging:
             )
         }
       end pairwiseMatchesSubsumingOnBothSidesWithBiteEdges
-
-      def parallelMatchesOnly: MatchesAndTheirSections =
-        // PLAN:
-
-        // 1. Build up sources composed of matched sections concatenated
-        // together by path preserving their original order.
-
-        val baseMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(baseSection, _, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndLeft(baseSection, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndRight(baseSection, _))
-                  if section == baseSection =>
-                section
-            }
-
-        val leftMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, leftSection, _))
-                  if section == leftSection =>
-                section
-              case (section, Match.BaseAndLeft(_, leftSection))
-                  if section == leftSection =>
-                section
-              case (section, Match.LeftAndRight(leftSection, _))
-                  if section == leftSection =>
-                section
-            }
-
-        val rightMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, _, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.BaseAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.LeftAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-            }
-
-        case class MetaMatchContentSources(
-            override val contentsByPath: Map[Path, IndexedSeq[
-              Section[Element]
-            ]],
-            override val label: String
-        ) extends MappedContentSources[Path, Section[Element]]
-
-        def sourcesForMetaMatching(label: String)(
-            sources: Sources[Path, Element],
-            matchedSections: Iterable[Section[Element]]
-        ) = MetaMatchContentSources(
-          contentsByPath = matchedSections
-            .groupBy(sources.pathFor)
-            .map((path, sections) =>
-              path -> sections.toIndexedSeq
-                .sortBy(section =>
-                  // NOTE: use the negative of the section size as a tiebreaker
-                  // if more than one section has the same start offset. This
-                  // makes sure that a subsuming section comes *before* any
-                  // sections that it might subsume, so it can't interpose
-                  // itself within what would have been a run of parallel
-                  // subsumed sections; that way we don't accidentally split
-                  // what should be larger meta-matches. That can occur when the
-                  // subsuming section is contributed by a larger pairwise match
-                  // that subsumes several all-sides matches, and the first
-                  // all-sides match aligns with the start of the pairwise
-                  // match. The test
-                  // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation`
-                  // has an example of this.
-                  section.startOffset -> -section.size
-                )
-            ),
-          label = label
-        )
-
-        val baseSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-base")(
-            baseSources,
-            baseMatchedSections
-          )
-        val leftSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-left")(
-            leftSources,
-            leftMatchedSections
-          )
-        val rightSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-right")(
-            rightSources,
-            rightMatchedSections
-          )
-
-        // 2. Apply `MatchAnalysis.of` to these sections, using the
-        // potential match key of the section to underpin equality and
-        // hashing.
-
-        object metaMatchConfiguration extends AbstractConfiguration:
-          override val minimumMatchSize: Int                    = 1
-          override val thresholdSizeFractionForMatching: Double = 0
-          override val minimumAmbiguousMatchSize: Int           = 1
-          override val ambiguousMatchesThreshold: Int           = Int.MaxValue
-          override val progressRecording: ProgressRecording     =
-            configuration.progressRecording
-        end metaMatchConfiguration
-
-        given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
-
-        given Funnel[Section[Element]] with
-          override def funnel(
-              from: Section[Element],
-              into: PrimitiveSink
-          ): Unit =
-            from.content.foreach(summon[Funnel[Element]].funnel(_, into))
-
-        end given
-
-        val metaMatchAnalysis = of(
-          baseSourcesForMetaMatching,
-          leftSourcesForMetaMatching,
-          rightSourcesForMetaMatching
-        )(metaMatchConfiguration)
-
-        // 3. The resulting meta-matches provide parallel sequences of sections
-        // that are unzipped to yield corresponding all-sides and pairwise
-        // matches.
-
-        val metaMatches = metaMatchAnalysis.matches
-
-        // NOTE: because meta-matching starts with matched *sections* and
-        // ignores gaps, we have to guard against sections that would have
-        // formed the sides of a suppressed outer match making a second attempt
-        // at building a match.
-        val groupsOfBackTranslatedParallelMatches = metaMatches
-          .map {
-            case Match.AllSides(
-                  baseMetaSection,
-                  leftMetaSection,
-                  rightMetaSection
-                ) =>
-              (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAnAllSidesMatch(
-                        baseSection,
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.AllSides(baseSection, leftSection, rightSection)
-                }
-            case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
-              (baseMetaSection.content lazyZip leftMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-                        baseSection,
-                        leftSection
-                      ) =>
-                    Match.BaseAndLeft(baseSection, leftSection)
-                }
-            case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
-              (baseMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-                        baseSection,
-                        rightSection
-                      ) =>
-                    Match.BaseAndRight(baseSection, rightSection)
-                }
-            case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
-              (leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.LeftAndRight(leftSection, rightSection)
-                }
-          }
-          .filter(_.nonEmpty)
-          .toSeq
-
-        // 4. Build putative groups from the back-translated matches. These
-        // won't be perfectly accurate, but are refined later by
-        // `reconcileMatches`.
-
-        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
-        // the back-translated matches, because the thinning out of ambiguous
-        // matches performed by the meta-matching and back translation above
-        // means there are new opportunities for matches to be generated - while
-        // the vast majority of these are redundant pairwise matches, there are
-        // some that are vital to capture things such as moves with migrated
-        // edits / deletions - the test
-        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
-        // an example of this.
-        val backTranslatedMatchesAndTheirSections =
-          MatchesAndTheirSections.empty
-            .withMatches(
-              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
-              haveTrimmedMatches = false
-            )
-            .matchesAndTheirSections
-            .withoutRedundantPairwiseMatches
-
-        val backTranslatedMatches =
-          backTranslatedMatchesAndTheirSections.matches
-
-        val parallelMatchesGroupIdsByMatch =
-          Map.from(
-            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
-              (parallelMatches, groupId) =>
-                parallelMatches
-                  .filter(backTranslatedMatches.contains)
-                  .map(_ -> groupId)
-            )
-          )
-
-        backTranslatedMatchesAndTheirSections
-          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
-      end parallelMatchesOnly
-
-      // Cleans up the state when a putative all-sides match that would have
-      // been ambiguous on one side with another all-sides match was partially
-      // suppressed by a larger pairwise match. This situation results in a
-      // pairwise match that shares its sections on both sides with the other
-      // all-sides match; remove any such redundant pairwise matches.
-      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
-        val redundantMatches =
-          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
-
-        if redundantMatches.nonEmpty then
-          logger.debug(
-            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
-          )
-        end if
-
-        withoutTheseMatches(redundantMatches)
-      end withoutRedundantPairwiseMatches
-
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(allSides)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
-            )
-        }
-      end withoutTheseMatches
-
-      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
-        aMatch match
-          case Match.BaseAndLeft(baseSection, leftSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(leftSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.BaseAndRight(baseSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.LeftAndRight(leftSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(leftSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case _: Match.AllSides[Section[Element]] => false
-
-      private def isSubsumedNonTriviallyByAnAllSidesMatch(
-          baseSection: Section[Element],
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAnAllSidesMatch
-
-      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-          baseSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-          baseSection: Section[Element],
-          leftSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
-
-      private def withMatches(
-          matches: Set[GenericMatch[Element]],
-          haveTrimmedMatches: Boolean
-      ): MatchingResult =
-        val updatedMatchesAndTheirSections =
-          matches.foldLeft(this)(_ withMatch _)
-
-        val pathInclusions =
-          if !haveTrimmedMatches then
-            case class PathInclusionsImplementation(
-                basePaths: Set[Path],
-                leftPaths: Set[Path],
-                rightPaths: Set[Path]
-            ) extends PathInclusions:
-              override def isIncludedOnBase(basePath: Path): Boolean =
-                basePaths.contains(basePath)
-
-              override def isIncludedOnLeft(leftPath: Path): Boolean =
-                leftPaths.contains(leftPath)
-
-              override def isIncludedOnRight(rightPath: Path): Boolean =
-                rightPaths.contains(rightPath)
-
-              def addPathOnBaseFor(
-                  baseSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
-              def addPathOnLeftFor(
-                  leftSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
-              def addPathOnRightFor(
-                  rightSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(rightPaths =
-                  rightPaths + rightSources.pathFor(rightSection)
-                )
-            end PathInclusionsImplementation
-
-            matches.foldLeft(
-              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
-            )((partialPathInclusions, aMatch) =>
-              aMatch match
-                case Match.AllSides(baseSection, leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.BaseAndLeft(baseSection, leftSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                case Match.BaseAndRight(baseSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.LeftAndRight(leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-            )
-          else PathInclusions.all
-
-        MatchingResult(
-          matchesAndTheirSections = updatedMatchesAndTheirSections,
-          numberOfMatchesForTheGivenWindowSize = matches.size,
-          estimatedWindowSizeForOptimalMatch =
-            estimateOptimalMatchSize(matches),
-          pathInclusions = pathInclusions
-        )
-      end withMatches
-
-      private def withMatch(
-          aMatch: GenericMatch[Element]
-      ): MatchesAndTheirSections =
-        aMatch match
-          case Match.AllSides(baseSection, leftSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
-              baseFingerprintedInclusionsByPath =
-                knockOutFromBaseFingerprintedInclusions(baseSection),
-              leftFingerprintedInclusionsByPath =
-                knockOutFromLeftFingerprintedInclusions(leftSection),
-              rightFingerprintedInclusionsByPath =
-                knockOutFromRightFingerprintedInclusions(rightSection)
-            )
-          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
-            )
-          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
-            )
-          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
-            copy(
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
-            )
-        end match
-      end withMatch
 
       private def pairwiseMatchesSubsumingOnBothSides(
           allSides: Match.AllSides[Section[Element]]

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -58,6 +58,8 @@ trait MatchAnalysis[Path, Element]:
 
   def sectionsAndTheirMatches: MatchedSections[Element]
 
+  def parallelMatchesGroupIdsByMatch: MultiDict[GenericMatch[Element], Int]
+
   def matches: Set[GenericMatch[Element]] =
     sectionsAndTheirMatches.values.toSet
 end MatchAnalysis

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1278,99 +1278,6 @@ object MatchAnalysis extends StrictLogging:
         end if
       end purgedOfMatchesWithOverlappingSections
 
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(allSides)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
-            )
-        }
-      end withoutTheseMatches
-
       def reconcileMatches: MatchesAndTheirSections =
         val matches = sectionsAndTheirMatches.values.toSet
 
@@ -1551,13 +1458,37 @@ object MatchAnalysis extends StrictLogging:
         // 1. Build up sources composed of matched sections concatenated
         // together by path preserving their original order.
 
-        val baseMatchedSections =
+        val baseAllSidesMatchedSections =
           sectionsAndTheirMatches.sets
             .map((key, values) => key -> values.head)
             .collect {
               case (section, Match.AllSides(baseSection, _, _))
                   if section == baseSection =>
                 section
+            }
+
+        val leftAllSidesMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, leftSection, _))
+                  if section == leftSection =>
+                section
+            }
+
+        val rightAllSidesMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, _, rightSection))
+                  if section == rightSection =>
+                section
+            }
+
+        val basePairwiseMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
               case (section, Match.BaseAndLeft(baseSection, _))
                   if section == baseSection =>
                 section
@@ -1566,13 +1497,10 @@ object MatchAnalysis extends StrictLogging:
                 section
             }
 
-        val leftMatchedSections =
+        val leftPairwiseMatchedSections =
           sectionsAndTheirMatches.sets
             .map((key, values) => key -> values.head)
             .collect {
-              case (section, Match.AllSides(_, leftSection, _))
-                  if section == leftSection =>
-                section
               case (section, Match.BaseAndLeft(_, leftSection))
                   if section == leftSection =>
                 section
@@ -1581,13 +1509,10 @@ object MatchAnalysis extends StrictLogging:
                 section
             }
 
-        val rightMatchedSections =
+        val rightPairwiseMatchedSections =
           sectionsAndTheirMatches.sets
             .map((key, values) => key -> values.head)
             .collect {
-              case (section, Match.AllSides(_, _, rightSection))
-                  if section == rightSection =>
-                section
               case (section, Match.BaseAndRight(_, rightSection))
                   if section == rightSection =>
                 section
@@ -1745,11 +1670,27 @@ object MatchAnalysis extends StrictLogging:
         end groupsOfBackTranslatedParallelMatchesFrom
 
         val groupsOfBackTranslatedParallelMatches =
-          groupsOfBackTranslatedParallelMatchesFrom(
-            baseMatchedSections,
-            leftMatchedSections,
-            rightMatchedSections
-          )
+          val groupsOfBackTranslatedParallelAllSidesMatches =
+            // NOTE: resist the temptation to filter out any pairwise
+            // meta-matches here. Yes, most of them expand out to redundant
+            // pairwise matches, but some of them are required. See the
+            // following comment that mentions
+            // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation`.
+            groupsOfBackTranslatedParallelMatchesFrom(
+              baseAllSidesMatchedSections,
+              leftAllSidesMatchedSections,
+              rightAllSidesMatchedSections
+            )
+
+          val groupsOfBackTranslatedParallelPairwiseMatches =
+            groupsOfBackTranslatedParallelMatchesFrom(
+              basePairwiseMatchedSections,
+              leftPairwiseMatchedSections,
+              rightPairwiseMatchedSections
+            )
+
+          groupsOfBackTranslatedParallelAllSidesMatches ++ groupsOfBackTranslatedParallelPairwiseMatches
+        end groupsOfBackTranslatedParallelMatches
 
         // 4. Build putative groups from the back-translated matches. These
         // won't be perfectly accurate, but are refined later by
@@ -1807,6 +1748,99 @@ object MatchAnalysis extends StrictLogging:
 
         withoutTheseMatches(redundantMatches)
       end withoutRedundantPairwiseMatches
+
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(allSides)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
+            )
+        }
+      end withoutTheseMatches
 
       private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
         aMatch match
@@ -2489,18 +2523,6 @@ object MatchAnalysis extends StrictLogging:
             Some(baseSection.startOffset)
           case _ => None
 
-      private def startOffsetOnLeft(
-          aMatch: GenericMatch[Element]
-      ): Option[Int] =
-        aMatch match
-          case Match.AllSides(_, leftSection, _) =>
-            Some(leftSection.startOffset)
-          case Match.BaseAndLeft(_, leftSection) =>
-            Some(leftSection.startOffset)
-          case Match.LeftAndRight(leftSection, _) =>
-            Some(leftSection.startOffset)
-          case _ => None
-
       private def startOffsetOnRight(
           aMatch: GenericMatch[Element]
       ): Option[Int] =
@@ -2511,6 +2533,18 @@ object MatchAnalysis extends StrictLogging:
             Some(rightSection.startOffset)
           case Match.LeftAndRight(_, rightSection) =>
             Some(rightSection.startOffset)
+          case _ => None
+
+      private def startOffsetOnLeft(
+          aMatch: GenericMatch[Element]
+      ): Option[Int] =
+        aMatch match
+          case Match.AllSides(_, leftSection, _) =>
+            Some(leftSection.startOffset)
+          case Match.BaseAndLeft(_, leftSection) =>
+            Some(leftSection.startOffset)
+          case Match.LeftAndRight(leftSection, _) =>
+            Some(leftSection.startOffset)
           case _ => None
 
       private def pareDownOrSuppressCompletely[MatchType <: GenericMatch[

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -733,8 +733,6 @@ object MatchAnalysis extends StrictLogging:
         pairwiseMatchesToBeEaten.sets.toSeq
           .flatTraverse { case (pairwiseMatch, bites) =>
             for
-              groupIdOfFragmentedPairwiseMatch <- groupIdOf(pairwiseMatch)
-
               parallelMatchesGroupIdsByMatch <- State
                 .get[ParallelMatchesGroupIdsByMatch]
 
@@ -746,19 +744,11 @@ object MatchAnalysis extends StrictLogging:
 
               sortedBiteEdges = groupIdsBySortedBiteEdge.keySet
 
-              fragmentsAndGroupIds =
+              fragmentsFromPairwiseMatch <-
                 sortedBiteEdges.eatIntoPairwiseMatch(
                   pairwiseMatch,
-                  groupIdOfFragmentedPairwiseMatch,
                   groupIdsBySortedBiteEdge
                 )
-
-              fragmentsFromPairwiseMatch = fragmentsAndGroupIds.map(_._1)
-              groupIdsForFragments       = fragmentsAndGroupIds.map(_._2)
-
-              _ <- fragmentsFromPairwiseMatch
-                .zip(groupIdsForFragments)
-                .traverse_(assignGroupIds)
             yield
               logger.debug(
                 s"Eating into pairwise match:\n${pprintCustomised(pairwiseMatch)} on behalf of all-sides matches:\n${pprintCustomised(bites)}, resulting in fragments:\n${pprintCustomised(fragmentsFromPairwiseMatch)}"
@@ -774,9 +764,10 @@ object MatchAnalysis extends StrictLogging:
       extension (biteEdges: SortedSet[BiteEdge])
         private def eatIntoPairwiseMatch(
             pairwiseMatch: PairwiseMatch,
-            groupIdOfPairwiseMatch: ParallelMatchesGroupId,
             groupIdsBySortedBiteEdge: Map[BiteEdge, ParallelMatchesGroupId]
-        ): Vector[(PairwiseMatch, ParallelMatchesGroupId)] =
+        ): ParallelMatchesGroupIdTracking[
+          Vector[PairwiseMatch]
+        ] =
           // NOTE: here we work with zero-relative offsets from the start of the
           // meal, thus we can work directly with the offsets from the bite
           // edges.
@@ -821,24 +812,26 @@ object MatchAnalysis extends StrictLogging:
           val sectionSize = firstSection.size
           assume(sectionSize == secondSection.size)
 
-          case class State(
+          case class RecursionState(
               groupIdFromPreviousBite: Option[ParallelMatchesGroupId],
               mealStartOffsetRelativeToMeal: Int,
-              biteDepth: Int
+              biteDepth: Int,
+              remainingBiteEdges: Seq[BiteEdge],
+              fragments: Vector[PairwiseMatch]
           ):
-            @tailrec
-            final def apply(
-                remainingBiteEdges: Seq[BiteEdge],
-                fragments: Vector[
-                  (PairwiseMatch, ParallelMatchesGroupId)
-                ]
-            ): Vector[(PairwiseMatch, ParallelMatchesGroupId)] =
+            final def biteEdgeStep: ParallelMatchesGroupIdTracking[
+              Either[RecursionState, Vector[PairwiseMatch]]
+            ] =
               remainingBiteEdges match
                 case Seq() =>
                   if sectionSize > mealStartOffsetRelativeToMeal then
                     val size = sectionSize - mealStartOffsetRelativeToMeal
-                    fragments.appended(
-                      factory(
+
+                    for
+                      assignedGroupId <- groupIdFromPreviousBite
+                        .fold(ifEmpty = freshGroupId)(State.pure)
+
+                      fragment = factory(
                         firstSide.section(firstPath)(
                           firstSection.startOffset + mealStartOffsetRelativeToMeal,
                           size
@@ -847,11 +840,12 @@ object MatchAnalysis extends StrictLogging:
                           secondSection.startOffset + mealStartOffsetRelativeToMeal,
                           size
                         )
-                      ) -> groupIdFromPreviousBite.getOrElse(
-                        groupIdOfPairwiseMatch
                       )
-                    )
-                  else fragments
+
+                      _ <- assignGroupId(fragment, assignedGroupId)
+                    yield Right(fragments.appended(fragment))
+                    end for
+                  else State.pure(Right(fragments))
 
                 case Seq(
                       biteEdge @ BiteEdge.Start(startOffsetRelativeToMeal),
@@ -862,40 +856,43 @@ object MatchAnalysis extends StrictLogging:
                   )
                   require(sectionSize > startOffsetRelativeToMeal)
 
-                  val updatedFragments =
-                    if 0 == biteDepth && startOffsetRelativeToMeal > mealStartOffsetRelativeToMeal
-                    then
-                      val size =
-                        startOffsetRelativeToMeal - mealStartOffsetRelativeToMeal
-                      val chosenGroupIdForFragment = (
-                        groupIdFromPreviousBite,
-                        groupIdsBySortedBiteEdge.get(biteEdge)
-                      ) match
-                        case (
-                              Some(groupIdFromPrecedingBite),
-                              Some(groupIdFromSucceedingBite)
-                            ) =>
-                          if groupIdFromPrecedingBite != groupIdFromSucceedingBite
-                          then
-                            // If the preceding and succeeding bite belong to
-                            // different groups, we regard the fragment as
-                            // 'staying put' and assign it the group id of the
-                            // pairwise match being eaten into.
-                            groupIdOfPairwiseMatch
-                          else groupIdFromSucceedingBite
+                  for updatedFragments <-
+                      if 0 == biteDepth && startOffsetRelativeToMeal > mealStartOffsetRelativeToMeal
+                      then
+                        val size =
+                          startOffsetRelativeToMeal - mealStartOffsetRelativeToMeal
+                        val assignedGroupId = (
+                          groupIdFromPreviousBite,
+                          groupIdsBySortedBiteEdge.get(biteEdge)
+                        ) match
+                          case (
+                                Some(groupIdFromPrecedingBite),
+                                Some(groupIdFromSucceedingBite)
+                              ) =>
+                            if groupIdFromPrecedingBite != groupIdFromSucceedingBite
+                            then
+                              // If the preceding and succeeding bite belong to
+                              // different groups, we regard the fragment as
+                              // 'staying put' and assign it a fresh group id.
+                              // We don't reuse the group id of the original
+                              // pairwise match being bitten into because that
+                              // might result in multiple fragments sharing the
+                              // saem group id but with intervening bites
+                              // belonging to other groups.
+                              freshGroupId
+                            else State.pure(groupIdFromSucceedingBite)
 
-                        case (Some(groupIdFromPrecedingBite), None) =>
-                          groupIdFromPrecedingBite
+                          case (Some(groupIdFromPrecedingBite), None) =>
+                            State.pure(groupIdFromPrecedingBite)
 
-                        case (None, Some(groupIdFromSucceedingBite)) =>
-                          groupIdFromSucceedingBite
+                          case (None, Some(groupIdFromSucceedingBite)) =>
+                            State.pure(groupIdFromSucceedingBite)
 
-                        case (None, None) =>
-                          // TODO: can this case ever occur?
-                          groupIdOfPairwiseMatch
+                          case (None, None) =>
+                            // TODO: can this case ever occur?
+                            freshGroupId
 
-                      fragments.appended(
-                        factory(
+                        val fragment = factory(
                           firstSide.section(firstPath)(
                             firstSection.startOffset + mealStartOffsetRelativeToMeal,
                             size
@@ -904,17 +901,23 @@ object MatchAnalysis extends StrictLogging:
                             secondSection.startOffset + mealStartOffsetRelativeToMeal,
                             size
                           )
-                        ) -> chosenGroupIdForFragment
-                      )
-                    else fragments
+                        )
 
-                  this
-                    .copy(
-                      groupIdFromPreviousBite = None,
-                      mealStartOffsetRelativeToMeal = startOffsetRelativeToMeal,
-                      biteDepth = 1 + biteDepth
-                    )
-                    .apply(tail, updatedFragments)
+                        assignedGroupId
+                          .flatMap(assignGroupId(fragment, _))
+                          .as(fragments.appended(fragment))
+                      else State.pure(fragments)
+                  yield Left(
+                    this
+                      .copy(
+                        groupIdFromPreviousBite = None,
+                        mealStartOffsetRelativeToMeal =
+                          startOffsetRelativeToMeal,
+                        biteDepth = 1 + biteDepth,
+                        remainingBiteEdges = tail,
+                        fragments = updatedFragments
+                      )
+                  )
 
                 case Seq(
                       biteEdge @ BiteEdge.End(onePastEndOffsetRelativeToMeal),
@@ -927,43 +930,53 @@ object MatchAnalysis extends StrictLogging:
                   )
                   require(onePastEndOffsetRelativeToMeal <= sectionSize)
 
-                  this
-                    .copy(
-                      // NOTE: nested or overlapping bites to the right
-                      // overwrite any prior contribution of group ids to the
-                      // *succeeding* context.
-                      groupIdFromPreviousBite =
-                        groupIdsBySortedBiteEdge.get(biteEdge),
-                      mealStartOffsetRelativeToMeal =
-                        onePastEndOffsetRelativeToMeal,
-                      biteDepth = biteDepth - 1
+                  State.pure(
+                    Left(
+                      this
+                        .copy(
+                          // NOTE: nested or overlapping bites to the right
+                          // overwrite any prior contribution of a group id to
+                          // the *succeeding* context.
+                          groupIdFromPreviousBite =
+                            groupIdsBySortedBiteEdge.get(biteEdge),
+                          mealStartOffsetRelativeToMeal =
+                            onePastEndOffsetRelativeToMeal,
+                          biteDepth = biteDepth - 1,
+                          remainingBiteEdges = tail,
+                          fragments = fragments
+                        )
                     )
-                    .apply(tail, fragments)
+                  )
               end match
-            end apply
-          end State
+            end biteEdgeStep
+          end RecursionState
 
-          State(
-            groupIdFromPreviousBite = None,
-            mealStartOffsetRelativeToMeal = 0,
-            biteDepth = 0
-          )(biteEdges.toSeq, fragments = Vector.empty)
+          FlatMap[ParallelMatchesGroupIdTracking].tailRecM(
+            RecursionState(
+              groupIdFromPreviousBite = None,
+              mealStartOffsetRelativeToMeal = 0,
+              biteDepth = 0,
+              remainingBiteEdges = biteEdges.toSeq,
+              fragments = Vector.empty
+            )
+          )(_.biteEdgeStep)
         end eatIntoPairwiseMatch
 
       end extension
 
-      private def groupIdOf(
-          pairwiseMatch: PairwiseMatch
-      ): ParallelMatchesGroupIdTracking[ParallelMatchesGroupId] =
-        State.inspect[ParallelMatchesGroupIdsByMatch, ParallelMatchesGroupId](
-          groupIdsByMatch => groupIdsByMatch(pairwiseMatch)
-        )
-
-      private def assignGroupIds(
+      private def assignGroupId(
           fragment: PairwiseMatch,
           groupId: ParallelMatchesGroupId
       ): ParallelMatchesGroupIdTracking[Unit] =
         State.modify[ParallelMatchesGroupIdsByMatch](_ + (fragment -> groupId))
+
+      private def freshGroupId
+          : ParallelMatchesGroupIdTracking[ParallelMatchesGroupId] =
+        // TODO: trawling linearly through the group ids to find the maximum
+        // isn't a great idea. Perhaps there should be a maximum group id too?
+        State.inspect[ParallelMatchesGroupIdsByMatch, ParallelMatchesGroupId](
+          _.values.maxOption.fold(ifEmpty = 0)(1 + _)
+        )
 
       private def propagateGroupIds(
           original: GenericMatch[Element],

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -12,7 +12,8 @@ import com.google.common.hash.{Funnel, HashFunction, PrimitiveSink}
 import com.sageserpent.kineticmerge
 import com.sageserpent.kineticmerge.core.MatchAnalysis.{
   GenericMatch,
-  MatchedSections
+  MatchedSections,
+  ParallelMatchesGroupIdsByMatch
 }
 import com.sageserpent.kineticmerge.{
   NoProgressRecording,
@@ -58,7 +59,7 @@ trait MatchAnalysis[Path, Element]:
 
   def sectionsAndTheirMatches: MatchedSections[Element]
 
-  def parallelMatchesGroupIdsByMatch: MultiDict[GenericMatch[Element], Int]
+  def parallelMatchesGroupIdsByMatch: ParallelMatchesGroupIdsByMatch[Element]
 
   def matches: Set[GenericMatch[Element]] =
     sectionsAndTheirMatches.values.toSet
@@ -68,6 +69,11 @@ object MatchAnalysis extends StrictLogging:
   type GenericMatch[Element]    = Match[Section[Element]]
   type MatchedSections[Element] =
     MultiDict[Section[Element], GenericMatch[Element]]
+
+  type ParallelMatchesGroupId = Int
+
+  type ParallelMatchesGroupIdsByMatch[Element] =
+    MultiDict[GenericMatch[Element], ParallelMatchesGroupId]
 
   /** Analyse matches between the sources of {@code base}, {@code left} and
     * {@code right}.
@@ -188,10 +194,8 @@ object MatchAnalysis extends StrictLogging:
 
     type FingerprintedInclusions = Diet[Int]
 
-    type ParallelMatchesGroupId = Int
-
     type ParallelMatchesGroupIdsByMatch =
-      MultiDict[GenericMatch[Element], ParallelMatchesGroupId]
+      MatchAnalysis.ParallelMatchesGroupIdsByMatch[Element]
 
     val tiebreakContentSamplingLimit = 5
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -189,7 +189,7 @@ object MatchAnalysis extends StrictLogging:
     type ParallelMatchesGroupId = Int
 
     type ParallelMatchesGroupIdsByMatch =
-      MultiDict[GenericMatch[Element], ParallelMatchesGroupId]
+      Map[GenericMatch[Element], ParallelMatchesGroupId]
 
     val tiebreakContentSamplingLimit = 5
 
@@ -208,7 +208,7 @@ object MatchAnalysis extends StrictLogging:
           fingerprintedInclusionsByPath(leftSources),
         rightFingerprintedInclusionsByPath =
           fingerprintedInclusionsByPath(rightSources),
-        parallelMatchesGroupIdsByMatch = MultiDict.empty
+        parallelMatchesGroupIdsByMatch = Map.empty
       )
       private val rollingHashFactoryCache: Cache[Int, RollingHash.Factory] =
         Caffeine.newBuilder().build()
@@ -733,13 +733,15 @@ object MatchAnalysis extends StrictLogging:
         pairwiseMatchesToBeEaten.sets.toSeq
           .flatTraverse { case (pairwiseMatch, bites) =>
             for
+              groupIdOfFragmentedPairwiseMatch <- groupIdOf(pairwiseMatch)
+
               parallelMatchesGroupIdsByMatch <- State
                 .get[ParallelMatchesGroupIdsByMatch]
 
               groupIdsBySortedBiteEdge = SortedMap.from(bites.flatMap {
                 case (allSides, biteStart, biteEnd) =>
                   Seq(biteStart, biteEnd)
-                    .map(_ -> parallelMatchesGroupIdsByMatch.get(allSides))
+                    .map(_ -> parallelMatchesGroupIdsByMatch(allSides))
               })
 
               sortedBiteEdges = groupIdsBySortedBiteEdge.keySet
@@ -747,6 +749,7 @@ object MatchAnalysis extends StrictLogging:
               fragmentsAndGroupIds =
                 sortedBiteEdges.eatIntoPairwiseMatch(
                   pairwiseMatch,
+                  groupIdOfFragmentedPairwiseMatch,
                   groupIdsBySortedBiteEdge
                 )
 
@@ -771,10 +774,9 @@ object MatchAnalysis extends StrictLogging:
       extension (biteEdges: SortedSet[BiteEdge])
         private def eatIntoPairwiseMatch(
             pairwiseMatch: PairwiseMatch,
-            groupIdsBySortedBiteEdge: Map[BiteEdge, collection.Set[
-              ParallelMatchesGroupId
-            ]]
-        ): Vector[(PairwiseMatch, Set[ParallelMatchesGroupId])] =
+            groupIdOfPairwiseMatch: ParallelMatchesGroupId,
+            groupIdsBySortedBiteEdge: Map[BiteEdge, ParallelMatchesGroupId]
+        ): Vector[(PairwiseMatch, ParallelMatchesGroupId)] =
           // NOTE: here we work with zero-relative offsets from the start of the
           // meal, thus we can work directly with the offsets from the bite
           // edges.
@@ -820,15 +822,17 @@ object MatchAnalysis extends StrictLogging:
           assume(sectionSize == secondSection.size)
 
           case class State(
-              groupIdsFromPreviousBite: Set[ParallelMatchesGroupId],
+              groupIdFromPreviousBite: Option[ParallelMatchesGroupId],
               mealStartOffsetRelativeToMeal: Int,
               biteDepth: Int
           ):
             @tailrec
             final def apply(
                 remainingBiteEdges: Seq[BiteEdge],
-                fragments: Vector[(PairwiseMatch, Set[ParallelMatchesGroupId])]
-            ): Vector[(PairwiseMatch, Set[ParallelMatchesGroupId])] =
+                fragments: Vector[
+                  (PairwiseMatch, ParallelMatchesGroupId)
+                ]
+            ): Vector[(PairwiseMatch, ParallelMatchesGroupId)] =
               remainingBiteEdges match
                 case Seq() =>
                   if sectionSize > mealStartOffsetRelativeToMeal then
@@ -843,7 +847,9 @@ object MatchAnalysis extends StrictLogging:
                           secondSection.startOffset + mealStartOffsetRelativeToMeal,
                           size
                         )
-                      ) -> groupIdsFromPreviousBite
+                      ) -> groupIdFromPreviousBite.getOrElse(
+                        groupIdOfPairwiseMatch
+                      )
                     )
                   else fragments
 
@@ -861,6 +867,33 @@ object MatchAnalysis extends StrictLogging:
                     then
                       val size =
                         startOffsetRelativeToMeal - mealStartOffsetRelativeToMeal
+                      val chosenGroupIdForFragment = (
+                        groupIdFromPreviousBite,
+                        groupIdsBySortedBiteEdge.get(biteEdge)
+                      ) match
+                        case (
+                              Some(groupIdFromPrecedingBite),
+                              Some(groupIdFromSucceedingBite)
+                            ) =>
+                          if groupIdFromPrecedingBite != groupIdFromSucceedingBite
+                          then
+                            // If the preceding and succeeding bite belong to
+                            // different groups, we regard the fragment as
+                            // 'staying put' and assign it the group id of the
+                            // pairwise match being eaten into.
+                            groupIdOfPairwiseMatch
+                          else groupIdFromSucceedingBite
+
+                        case (Some(groupIdFromPrecedingBite), None) =>
+                          groupIdFromPrecedingBite
+
+                        case (None, Some(groupIdFromSucceedingBite)) =>
+                          groupIdFromSucceedingBite
+
+                        case (None, None) =>
+                          // TODO: can this case ever occur?
+                          groupIdOfPairwiseMatch
+
                       fragments.appended(
                         factory(
                           firstSide.section(firstPath)(
@@ -871,15 +904,13 @@ object MatchAnalysis extends StrictLogging:
                             secondSection.startOffset + mealStartOffsetRelativeToMeal,
                             size
                           )
-                        ) -> (groupIdsFromPreviousBite union groupIdsBySortedBiteEdge(
-                          biteEdge
-                        ).toSet)
+                        ) -> chosenGroupIdForFragment
                       )
                     else fragments
 
                   this
                     .copy(
-                      groupIdsFromPreviousBite = Set.empty,
+                      groupIdFromPreviousBite = None,
                       mealStartOffsetRelativeToMeal = startOffsetRelativeToMeal,
                       biteDepth = 1 + biteDepth
                     )
@@ -901,8 +932,8 @@ object MatchAnalysis extends StrictLogging:
                       // NOTE: nested or overlapping bites to the right
                       // overwrite any prior contribution of group ids to the
                       // *succeeding* context.
-                      groupIdsFromPreviousBite =
-                        groupIdsBySortedBiteEdge(biteEdge).toSet,
+                      groupIdFromPreviousBite =
+                        groupIdsBySortedBiteEdge.get(biteEdge),
                       mealStartOffsetRelativeToMeal =
                         onePastEndOffsetRelativeToMeal,
                       biteDepth = biteDepth - 1
@@ -913,7 +944,7 @@ object MatchAnalysis extends StrictLogging:
           end State
 
           State(
-            groupIdsFromPreviousBite = Set.empty,
+            groupIdFromPreviousBite = None,
             mealStartOffsetRelativeToMeal = 0,
             biteDepth = 0
           )(biteEdges.toSeq, fragments = Vector.empty)
@@ -921,15 +952,18 @@ object MatchAnalysis extends StrictLogging:
 
       end extension
 
+      private def groupIdOf(
+          pairwiseMatch: PairwiseMatch
+      ): ParallelMatchesGroupIdTracking[ParallelMatchesGroupId] =
+        State.inspect[ParallelMatchesGroupIdsByMatch, ParallelMatchesGroupId](
+          groupIdsByMatch => groupIdsByMatch(pairwiseMatch)
+        )
+
       private def assignGroupIds(
           fragment: PairwiseMatch,
-          groupIds: Set[ParallelMatchesGroupId]
+          groupId: ParallelMatchesGroupId
       ): ParallelMatchesGroupIdTracking[Unit] =
-        State.modify[ParallelMatchesGroupIdsByMatch] { groupIdsByMatch =>
-          groupIds.foldLeft(groupIdsByMatch)((partialResult, groupId) =>
-            partialResult.add(fragment, groupId)
-          )
-        }
+        State.modify[ParallelMatchesGroupIdsByMatch](_ + (fragment -> groupId))
 
       private def propagateGroupIds(
           original: GenericMatch[Element],
@@ -938,8 +972,8 @@ object MatchAnalysis extends StrictLogging:
         State.modify { groupIdsByMatch =>
           val groupIds = groupIdsByMatch.get(original)
 
-          groupIds.foldLeft(groupIdsByMatch)((partialResult, groupId) =>
-            partialResult.add(replacement, groupId)
+          groupIds.fold(ifEmpty = groupIdsByMatch)(groupId =>
+            groupIdsByMatch + (replacement -> groupId)
           )
         }
 
@@ -1242,99 +1276,6 @@ object MatchAnalysis extends StrictLogging:
         end if
       end purgedOfMatchesWithOverlappingSections
 
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(allSides)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(baseAndLeft)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(baseAndRight)
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removeKey(leftAndRight)
-            )
-        }
-      end withoutTheseMatches
-
       def reconcileMatches: MatchesAndTheirSections =
         val matches = sectionsAndTheirMatches.values.toSet
 
@@ -1420,23 +1361,17 @@ object MatchAnalysis extends StrictLogging:
                       val matches                        = reconciled.matches
                       val parallelMatchesGroupIdsByMatch =
                         updatedParallelMatchesGroupIdsByMatch
-                          .filterSets((key, _) => matches.contains(key))
+                          .filter((key, _) => matches.contains(key))
 
                       val groupIdsWithPossibleGaps: Map[
                         ParallelMatchesGroupId,
                         ParallelMatchesGroupId
                       ] =
-                        parallelMatchesGroupIdsByMatch.sets.values
-                          .foldLeft(
-                            Set.empty[ParallelMatchesGroupId]
-                          )(_ ++ _)
-                          .zipWithIndex
-                          .toMap
+                        parallelMatchesGroupIdsByMatch.values.zipWithIndex.toMap
 
                       val parallelMatchesWithReorganisedGroupIdsByMatch =
-                        parallelMatchesGroupIdsByMatch.mapSets(
-                          (aMatch, groupIds) =>
-                            aMatch -> groupIds.map(groupIdsWithPossibleGaps)
+                        parallelMatchesGroupIdsByMatch.map((aMatch, groupId) =>
+                          aMatch -> groupIdsWithPossibleGaps(groupId)
                         )
 
                       Right(
@@ -1455,7 +1390,7 @@ object MatchAnalysis extends StrictLogging:
               .tailRecM(matches.collect {
                 case allSides: Match.AllSides[Section[Element]] => allSides
               })(reconcileUsing)
-              .runA(MultiDict.empty)
+              .runA(Map.empty)
               .value
           }: @unchecked
 
@@ -1723,7 +1658,7 @@ object MatchAnalysis extends StrictLogging:
           backTranslatedMatchesAndTheirSections.matches
 
         val parallelMatchesGroupIdsByMatch =
-          MultiDict.from(
+          Map.from(
             groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
               (parallelMatches, groupId) =>
                 parallelMatches
@@ -1753,6 +1688,99 @@ object MatchAnalysis extends StrictLogging:
 
         withoutTheseMatches(redundantMatches)
       end withoutRedundantPairwiseMatches
+
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(allSides)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
+            )
+        }
+      end withoutTheseMatches
 
       private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
         aMatch match

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1725,7 +1725,10 @@ object MatchAnalysis extends StrictLogging:
         val parallelMatchesGroupIdsByMatch =
           MultiDict.from(
             groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
-              (parallelMatches, groupId) => parallelMatches.map(_ -> groupId)
+              (parallelMatches, groupId) =>
+                parallelMatches
+                  .filter(backTranslatedMatches.contains)
+                  .map(_ -> groupId)
             )
           )
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -877,7 +877,7 @@ object MatchAnalysis extends StrictLogging:
                               // We don't reuse the group id of the original
                               // pairwise match being bitten into because that
                               // might result in multiple fragments sharing the
-                              // saem group id but with intervening bites
+                              // same group id but with intervening bites
                               // belonging to other groups.
                               freshGroupId
                             else State.pure(groupIdFromSucceedingBite)
@@ -1323,7 +1323,8 @@ object MatchAnalysis extends StrictLogging:
               this.checkInvariant()
 
               for
-                // Reset the state for each iteration of `reconcileUsing`.
+                // Reset the state for each iteration of `reconcileUsing`. Refer
+                // to the assumption below as well...
                 _ <- State.set(parallelMatchesGroupIdsByMatch)
 
                 fragments <- fragmentsOf(pairwiseMatchesToBeEaten).map(
@@ -1352,6 +1353,15 @@ object MatchAnalysis extends StrictLogging:
                 paredDownAllSidesMatches = paredDownMatches.collect {
                   case allSides: Match.AllSides[Section[Element]] => allSides
                 }
+
+                _ =
+                  // NOTE: `pareDownOrSuppressCompletely` does not create
+                  // modified all-sides matches, it always pares down to either
+                  // a pairwise match or nothing at all. Advantage is taken of
+                  // this when the state is reset above for each recursion step
+                  // - we don't have to enrol the group ids for any modified
+                  // all-sides matches.
+                  assume(paredDownAllSidesMatches.subsetOf(allSidesMatches))
 
                 stepResult <-
                   if paredDownAllSidesMatches == allSidesMatches then
@@ -1452,611 +1462,6 @@ object MatchAnalysis extends StrictLogging:
         result
 
       end reconcileMatches
-
-      def parallelMatchesOnly: MatchesAndTheirSections =
-        // PLAN:
-
-        // 1. Build up sources composed of matched sections concatenated
-        // together by path preserving their original order.
-
-        val baseMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(baseSection, _, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndLeft(baseSection, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndRight(baseSection, _))
-                  if section == baseSection =>
-                section
-            }
-
-        val leftMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, leftSection, _))
-                  if section == leftSection =>
-                section
-              case (section, Match.BaseAndLeft(_, leftSection))
-                  if section == leftSection =>
-                section
-              case (section, Match.LeftAndRight(leftSection, _))
-                  if section == leftSection =>
-                section
-            }
-
-        val rightMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, _, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.BaseAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.LeftAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-            }
-
-        case class MetaMatchContentSources(
-            override val contentsByPath: Map[Path, IndexedSeq[
-              Section[Element]
-            ]],
-            override val label: String
-        ) extends MappedContentSources[Path, Section[Element]]
-
-        def sourcesForMetaMatching(label: String)(
-            sources: Sources[Path, Element],
-            matchedSections: Iterable[Section[Element]]
-        ) = MetaMatchContentSources(
-          contentsByPath = matchedSections
-            .groupBy(sources.pathFor)
-            .map((path, sections) =>
-              path -> sections.toIndexedSeq
-                .sortBy(section =>
-                  // NOTE: use the negative of the section size as a tiebreaker
-                  // if more than one section has the same start offset. This
-                  // makes sure that a subsuming section comes *before* any
-                  // sections that it might subsume, so it can't interpose
-                  // itself within what would have been a run of parallel
-                  // subsumed sections; that way we don't accidentally split
-                  // what should be larger meta-matches. That can occur when the
-                  // subsuming section is contributed by a larger pairwise match
-                  // that subsumes several all-sides matches, and the first
-                  // all-sides match aligns with the start of the pairwise
-                  // match. The test
-                  // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation`
-                  // has an example of this.
-                  section.startOffset -> -section.size
-                )
-            ),
-          label = label
-        )
-
-        val baseSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-base")(
-            baseSources,
-            baseMatchedSections
-          )
-        val leftSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-left")(
-            leftSources,
-            leftMatchedSections
-          )
-        val rightSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-right")(
-            rightSources,
-            rightMatchedSections
-          )
-
-        // 2. Apply `MatchAnalysis.of` to these sections, using the
-        // potential match key of the section to underpin equality and
-        // hashing.
-
-        object metaMatchConfiguration extends AbstractConfiguration:
-          override val minimumMatchSize: Int                    = 1
-          override val thresholdSizeFractionForMatching: Double = 0
-          override val minimumAmbiguousMatchSize: Int           = 1
-          override val ambiguousMatchesThreshold: Int           = Int.MaxValue
-          override val progressRecording: ProgressRecording     =
-            configuration.progressRecording
-        end metaMatchConfiguration
-
-        given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
-
-        given Funnel[Section[Element]] with
-          override def funnel(
-              from: Section[Element],
-              into: PrimitiveSink
-          ): Unit =
-            from.content.foreach(summon[Funnel[Element]].funnel(_, into))
-
-        end given
-
-        val metaMatchAnalysis = of(
-          baseSourcesForMetaMatching,
-          leftSourcesForMetaMatching,
-          rightSourcesForMetaMatching
-        )(metaMatchConfiguration)
-
-        // 3. The resulting meta-matches provide parallel sequences of sections
-        // that are unzipped to yield corresponding all-sides and pairwise
-        // matches.
-
-        val metaMatches = metaMatchAnalysis.matches
-
-        // NOTE: because meta-matching starts with matched *sections* and
-        // ignores gaps, we have to guard against sections that would have
-        // formed the sides of a suppressed outer match making a second attempt
-        // at building a match.
-        val groupsOfBackTranslatedParallelMatches = metaMatches
-          .map {
-            case Match.AllSides(
-                  baseMetaSection,
-                  leftMetaSection,
-                  rightMetaSection
-                ) =>
-              (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAnAllSidesMatch(
-                        baseSection,
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.AllSides(baseSection, leftSection, rightSection)
-                }
-            case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
-              (baseMetaSection.content lazyZip leftMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-                        baseSection,
-                        leftSection
-                      ) =>
-                    Match.BaseAndLeft(baseSection, leftSection)
-                }
-            case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
-              (baseMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-                        baseSection,
-                        rightSection
-                      ) =>
-                    Match.BaseAndRight(baseSection, rightSection)
-                }
-            case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
-              (leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.LeftAndRight(leftSection, rightSection)
-                }
-          }
-          .filter(_.nonEmpty)
-          .toSeq
-
-        // 4. Put the back-translated matches into their own disjoint sets, then
-        // unify those matches that come from the same group of parallel
-        // matches, then unify all-sides matches with pairwise matches that
-        // subsume them, regardless of the original group.
-
-        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
-        // the back-translated matches, because the thinning out of ambiguous
-        // matches performed by the meta-matching and back translation above
-        // means there are new opportunities for matches to be generated - while
-        // the vast majority of these are redundant pairwise matches, there are
-        // some that are vital to capture things such as moves with migrated
-        // edits / deletions - the test
-        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
-        // an example of this.
-        val backTranslatedMatchesAndTheirSections =
-          MatchesAndTheirSections.empty
-            .withMatches(
-              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
-              haveTrimmedMatches = false
-            )
-            .matchesAndTheirSections
-            .withoutRedundantPairwiseMatches
-
-        val backTranslatedMatches =
-          backTranslatedMatchesAndTheirSections.matches
-
-        val parallelMatchesGroupIdsByMatch =
-          Map.from(
-            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
-              (parallelMatches, groupId) =>
-                parallelMatches
-                  .filter(backTranslatedMatches.contains)
-                  .map(_ -> groupId)
-            )
-          )
-
-        backTranslatedMatchesAndTheirSections
-          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
-      end parallelMatchesOnly
-
-      // Cleans up the state when a putative all-sides match that would have
-      // been ambiguous on one side with another all-sides match was partially
-      // suppressed by a larger pairwise match. This situation results in a
-      // pairwise match that shares its sections on both sides with the other
-      // all-sides match; remove any such redundant pairwise matches.
-      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
-        val redundantMatches =
-          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
-
-        if redundantMatches.nonEmpty then
-          logger.debug(
-            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
-          )
-        end if
-
-        withoutTheseMatches(redundantMatches)
-      end withoutRedundantPairwiseMatches
-
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(allSides)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
-            )
-        }
-      end withoutTheseMatches
-
-      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
-        aMatch match
-          case Match.BaseAndLeft(baseSection, leftSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(leftSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.BaseAndRight(baseSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.LeftAndRight(leftSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(leftSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case _: Match.AllSides[Section[Element]] => false
-
-      private def isSubsumedNonTriviallyByAnAllSidesMatch(
-          baseSection: Section[Element],
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAnAllSidesMatch
-
-      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-          baseSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-          baseSection: Section[Element],
-          leftSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
-
-      private def withMatches(
-          matches: Set[GenericMatch[Element]],
-          haveTrimmedMatches: Boolean
-      ): MatchingResult =
-        val updatedMatchesAndTheirSections =
-          matches.foldLeft(this)(_ withMatch _)
-
-        val pathInclusions =
-          if !haveTrimmedMatches then
-            case class PathInclusionsImplementation(
-                basePaths: Set[Path],
-                leftPaths: Set[Path],
-                rightPaths: Set[Path]
-            ) extends PathInclusions:
-              override def isIncludedOnBase(basePath: Path): Boolean =
-                basePaths.contains(basePath)
-
-              override def isIncludedOnLeft(leftPath: Path): Boolean =
-                leftPaths.contains(leftPath)
-
-              override def isIncludedOnRight(rightPath: Path): Boolean =
-                rightPaths.contains(rightPath)
-
-              def addPathOnBaseFor(
-                  baseSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
-              def addPathOnLeftFor(
-                  leftSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
-              def addPathOnRightFor(
-                  rightSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(rightPaths =
-                  rightPaths + rightSources.pathFor(rightSection)
-                )
-            end PathInclusionsImplementation
-
-            matches.foldLeft(
-              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
-            )((partialPathInclusions, aMatch) =>
-              aMatch match
-                case Match.AllSides(baseSection, leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.BaseAndLeft(baseSection, leftSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                case Match.BaseAndRight(baseSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.LeftAndRight(leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-            )
-          else PathInclusions.all
-
-        MatchingResult(
-          matchesAndTheirSections = updatedMatchesAndTheirSections,
-          numberOfMatchesForTheGivenWindowSize = matches.size,
-          estimatedWindowSizeForOptimalMatch =
-            estimateOptimalMatchSize(matches),
-          pathInclusions = pathInclusions
-        )
-      end withMatches
-
-      private def withMatch(
-          aMatch: GenericMatch[Element]
-      ): MatchesAndTheirSections =
-        aMatch match
-          case Match.AllSides(baseSection, leftSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
-              baseFingerprintedInclusionsByPath =
-                knockOutFromBaseFingerprintedInclusions(baseSection),
-              leftFingerprintedInclusionsByPath =
-                knockOutFromLeftFingerprintedInclusions(leftSection),
-              rightFingerprintedInclusionsByPath =
-                knockOutFromRightFingerprintedInclusions(rightSection)
-            )
-          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
-            )
-          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
-            )
-          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
-            copy(
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
-            )
-        end match
-      end withMatch
 
       private def checkInvariant(): Unit =
         // We expect to tally either two lots of a given pairwise match or three
@@ -2736,6 +2141,610 @@ object MatchAnalysis extends StrictLogging:
             )
         }
       end pairwiseMatchesSubsumingOnBothSidesWithBiteEdges
+
+      def parallelMatchesOnly: MatchesAndTheirSections =
+        // PLAN:
+
+        // 1. Build up sources composed of matched sections concatenated
+        // together by path preserving their original order.
+
+        val baseMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(baseSection, _, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndLeft(baseSection, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndRight(baseSection, _))
+                  if section == baseSection =>
+                section
+            }
+
+        val leftMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, leftSection, _))
+                  if section == leftSection =>
+                section
+              case (section, Match.BaseAndLeft(_, leftSection))
+                  if section == leftSection =>
+                section
+              case (section, Match.LeftAndRight(leftSection, _))
+                  if section == leftSection =>
+                section
+            }
+
+        val rightMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, _, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.BaseAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.LeftAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+            }
+
+        case class MetaMatchContentSources(
+            override val contentsByPath: Map[Path, IndexedSeq[
+              Section[Element]
+            ]],
+            override val label: String
+        ) extends MappedContentSources[Path, Section[Element]]
+
+        def sourcesForMetaMatching(label: String)(
+            sources: Sources[Path, Element],
+            matchedSections: Iterable[Section[Element]]
+        ) = MetaMatchContentSources(
+          contentsByPath = matchedSections
+            .groupBy(sources.pathFor)
+            .map((path, sections) =>
+              path -> sections.toIndexedSeq
+                .sortBy(section =>
+                  // NOTE: use the negative of the section size as a tiebreaker
+                  // if more than one section has the same start offset. This
+                  // makes sure that a subsuming section comes *before* any
+                  // sections that it might subsume, so it can't interpose
+                  // itself within what would have been a run of parallel
+                  // subsumed sections; that way we don't accidentally split
+                  // what should be larger meta-matches. That can occur when the
+                  // subsuming section is contributed by a larger pairwise match
+                  // that subsumes several all-sides matches, and the first
+                  // all-sides match aligns with the start of the pairwise
+                  // match. The test
+                  // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation`
+                  // has an example of this.
+                  section.startOffset -> -section.size
+                )
+            ),
+          label = label
+        )
+
+        val baseSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-base")(
+            baseSources,
+            baseMatchedSections
+          )
+        val leftSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-left")(
+            leftSources,
+            leftMatchedSections
+          )
+        val rightSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-right")(
+            rightSources,
+            rightMatchedSections
+          )
+
+        // 2. Apply `MatchAnalysis.of` to these sections, using the
+        // potential match key of the section to underpin equality and
+        // hashing.
+
+        object metaMatchConfiguration extends AbstractConfiguration:
+          override val minimumMatchSize: Int                    = 1
+          override val thresholdSizeFractionForMatching: Double = 0
+          override val minimumAmbiguousMatchSize: Int           = 1
+          override val ambiguousMatchesThreshold: Int           = Int.MaxValue
+          override val progressRecording: ProgressRecording     =
+            configuration.progressRecording
+        end metaMatchConfiguration
+
+        given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
+
+        given Funnel[Section[Element]] with
+          override def funnel(
+              from: Section[Element],
+              into: PrimitiveSink
+          ): Unit =
+            from.content.foreach(summon[Funnel[Element]].funnel(_, into))
+
+        end given
+
+        val metaMatchAnalysis = of(
+          baseSourcesForMetaMatching,
+          leftSourcesForMetaMatching,
+          rightSourcesForMetaMatching
+        )(metaMatchConfiguration)
+
+        // 3. The resulting meta-matches provide parallel sequences of sections
+        // that are unzipped to yield corresponding all-sides and pairwise
+        // matches.
+
+        val metaMatches = metaMatchAnalysis.matches
+
+        // NOTE: because meta-matching starts with matched *sections* and
+        // ignores gaps, we have to guard against sections that would have
+        // formed the sides of a suppressed outer match making a second attempt
+        // at building a match.
+        val groupsOfBackTranslatedParallelMatches = metaMatches
+          .map {
+            case Match.AllSides(
+                  baseMetaSection,
+                  leftMetaSection,
+                  rightMetaSection
+                ) =>
+              (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (baseSection, leftSection, rightSection)
+                      if !isSubsumedNonTriviallyByAnAllSidesMatch(
+                        baseSection,
+                        leftSection,
+                        rightSection
+                      ) =>
+                    Match.AllSides(baseSection, leftSection, rightSection)
+                }
+            case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
+              (baseMetaSection.content lazyZip leftMetaSection.content)
+                .collect {
+                  case (baseSection, leftSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+                        baseSection,
+                        leftSection
+                      ) =>
+                    Match.BaseAndLeft(baseSection, leftSection)
+                }
+            case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
+              (baseMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (baseSection, rightSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+                        baseSection,
+                        rightSection
+                      ) =>
+                    Match.BaseAndRight(baseSection, rightSection)
+                }
+            case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
+              (leftMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (leftSection, rightSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+                        leftSection,
+                        rightSection
+                      ) =>
+                    Match.LeftAndRight(leftSection, rightSection)
+                }
+          }
+          .filter(_.nonEmpty)
+          .toSeq
+
+        // 4. Build putative groups from the back-translated matches. These
+        // won't be perfectly accurate, but are refined later by
+        // `reconcileMatches`.
+
+        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
+        // the back-translated matches, because the thinning out of ambiguous
+        // matches performed by the meta-matching and back translation above
+        // means there are new opportunities for matches to be generated - while
+        // the vast majority of these are redundant pairwise matches, there are
+        // some that are vital to capture things such as moves with migrated
+        // edits / deletions - the test
+        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
+        // an example of this.
+        val backTranslatedMatchesAndTheirSections =
+          MatchesAndTheirSections.empty
+            .withMatches(
+              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
+              haveTrimmedMatches = false
+            )
+            .matchesAndTheirSections
+            .withoutRedundantPairwiseMatches
+
+        val backTranslatedMatches =
+          backTranslatedMatchesAndTheirSections.matches
+
+        val parallelMatchesGroupIdsByMatch =
+          Map.from(
+            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
+              (parallelMatches, groupId) =>
+                parallelMatches
+                  .filter(backTranslatedMatches.contains)
+                  .map(_ -> groupId)
+            )
+          )
+
+        backTranslatedMatchesAndTheirSections
+          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
+      end parallelMatchesOnly
+
+      // Cleans up the state when a putative all-sides match that would have
+      // been ambiguous on one side with another all-sides match was partially
+      // suppressed by a larger pairwise match. This situation results in a
+      // pairwise match that shares its sections on both sides with the other
+      // all-sides match; remove any such redundant pairwise matches.
+      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
+        val redundantMatches =
+          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
+
+        if redundantMatches.nonEmpty then
+          logger.debug(
+            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
+          )
+        end if
+
+        withoutTheseMatches(redundantMatches)
+      end withoutRedundantPairwiseMatches
+
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(allSides)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
+            )
+        }
+      end withoutTheseMatches
+
+      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
+        aMatch match
+          case Match.BaseAndLeft(baseSection, leftSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(leftSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.BaseAndRight(baseSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.LeftAndRight(leftSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(leftSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case _: Match.AllSides[Section[Element]] => false
+
+      private def isSubsumedNonTriviallyByAnAllSidesMatch(
+          baseSection: Section[Element],
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAnAllSidesMatch
+
+      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+          baseSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+          baseSection: Section[Element],
+          leftSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
+
+      private def withMatches(
+          matches: Set[GenericMatch[Element]],
+          haveTrimmedMatches: Boolean
+      ): MatchingResult =
+        val updatedMatchesAndTheirSections =
+          matches.foldLeft(this)(_ withMatch _)
+
+        val pathInclusions =
+          if !haveTrimmedMatches then
+            case class PathInclusionsImplementation(
+                basePaths: Set[Path],
+                leftPaths: Set[Path],
+                rightPaths: Set[Path]
+            ) extends PathInclusions:
+              override def isIncludedOnBase(basePath: Path): Boolean =
+                basePaths.contains(basePath)
+
+              override def isIncludedOnLeft(leftPath: Path): Boolean =
+                leftPaths.contains(leftPath)
+
+              override def isIncludedOnRight(rightPath: Path): Boolean =
+                rightPaths.contains(rightPath)
+
+              def addPathOnBaseFor(
+                  baseSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
+              def addPathOnLeftFor(
+                  leftSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
+              def addPathOnRightFor(
+                  rightSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(rightPaths =
+                  rightPaths + rightSources.pathFor(rightSection)
+                )
+            end PathInclusionsImplementation
+
+            matches.foldLeft(
+              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
+            )((partialPathInclusions, aMatch) =>
+              aMatch match
+                case Match.AllSides(baseSection, leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.BaseAndLeft(baseSection, leftSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                case Match.BaseAndRight(baseSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.LeftAndRight(leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+            )
+          else PathInclusions.all
+
+        MatchingResult(
+          matchesAndTheirSections = updatedMatchesAndTheirSections,
+          numberOfMatchesForTheGivenWindowSize = matches.size,
+          estimatedWindowSizeForOptimalMatch =
+            estimateOptimalMatchSize(matches),
+          pathInclusions = pathInclusions
+        )
+      end withMatches
+
+      private def withMatch(
+          aMatch: GenericMatch[Element]
+      ): MatchesAndTheirSections =
+        aMatch match
+          case Match.AllSides(baseSection, leftSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
+              baseFingerprintedInclusionsByPath =
+                knockOutFromBaseFingerprintedInclusions(baseSection),
+              leftFingerprintedInclusionsByPath =
+                knockOutFromLeftFingerprintedInclusions(leftSection),
+              rightFingerprintedInclusionsByPath =
+                knockOutFromRightFingerprintedInclusions(rightSection)
+            )
+          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
+            )
+          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
+            )
+          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
+            copy(
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
+            )
+        end match
+      end withMatch
 
       private def pairwiseMatchesSubsumingOnBothSides(
           allSides: Match.AllSides[Section[Element]]

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1555,37 +1555,13 @@ object MatchAnalysis extends StrictLogging:
         // 1. Build up sources composed of matched sections concatenated
         // together by path preserving their original order.
 
-        val baseAllSidesMatchedSections =
+        val baseMatchedSections =
           sectionsAndTheirMatches.sets
             .map((key, values) => key -> values.head)
             .collect {
               case (section, Match.AllSides(baseSection, _, _))
                   if section == baseSection =>
                 section
-            }
-
-        val leftAllSidesMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, leftSection, _))
-                  if section == leftSection =>
-                section
-            }
-
-        val rightAllSidesMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, _, rightSection))
-                  if section == rightSection =>
-                section
-            }
-
-        val basePairwiseMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
               case (section, Match.BaseAndLeft(baseSection, _))
                   if section == baseSection =>
                 section
@@ -1594,10 +1570,13 @@ object MatchAnalysis extends StrictLogging:
                 section
             }
 
-        val leftPairwiseMatchedSections =
+        val leftMatchedSections =
           sectionsAndTheirMatches.sets
             .map((key, values) => key -> values.head)
             .collect {
+              case (section, Match.AllSides(_, leftSection, _))
+                  if section == leftSection =>
+                section
               case (section, Match.BaseAndLeft(_, leftSection))
                   if section == leftSection =>
                 section
@@ -1606,10 +1585,13 @@ object MatchAnalysis extends StrictLogging:
                 section
             }
 
-        val rightPairwiseMatchedSections =
+        val rightMatchedSections =
           sectionsAndTheirMatches.sets
             .map((key, values) => key -> values.head)
             .collect {
+              case (section, Match.AllSides(_, _, rightSection))
+                  if section == rightSection =>
+                section
               case (section, Match.BaseAndRight(_, rightSection))
                   if section == rightSection =>
                 section
@@ -1767,27 +1749,11 @@ object MatchAnalysis extends StrictLogging:
         end groupsOfBackTranslatedParallelMatchesFrom
 
         val groupsOfBackTranslatedParallelMatches =
-          val groupsOfBackTranslatedParallelAllSidesMatches =
-            // NOTE: resist the temptation to filter out any pairwise
-            // meta-matches here. Yes, most of them expand out to redundant
-            // pairwise matches, but some of them are required. See the
-            // following comment that mentions
-            // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation`.
-            groupsOfBackTranslatedParallelMatchesFrom(
-              baseAllSidesMatchedSections,
-              leftAllSidesMatchedSections,
-              rightAllSidesMatchedSections
-            )
-
-          val groupsOfBackTranslatedParallelPairwiseMatches =
-            groupsOfBackTranslatedParallelMatchesFrom(
-              basePairwiseMatchedSections,
-              leftPairwiseMatchedSections,
-              rightPairwiseMatchedSections
-            )
-
-          groupsOfBackTranslatedParallelAllSidesMatches ++ groupsOfBackTranslatedParallelPairwiseMatches
-        end groupsOfBackTranslatedParallelMatches
+          groupsOfBackTranslatedParallelMatchesFrom(
+            baseMatchedSections,
+            leftMatchedSections,
+            rightMatchedSections
+          )
 
         // 4. Build putative groups from the back-translated matches. These
         // won't be perfectly accurate, but are refined later by
@@ -2527,18 +2493,6 @@ object MatchAnalysis extends StrictLogging:
             Some(baseSection.startOffset)
           case _ => None
 
-      private def startOffsetOnRight(
-          aMatch: GenericMatch[Element]
-      ): Option[Int] =
-        aMatch match
-          case Match.AllSides(_, _, rightSection) =>
-            Some(rightSection.startOffset)
-          case Match.BaseAndRight(_, rightSection) =>
-            Some(rightSection.startOffset)
-          case Match.LeftAndRight(_, rightSection) =>
-            Some(rightSection.startOffset)
-          case _ => None
-
       private def startOffsetOnLeft(
           aMatch: GenericMatch[Element]
       ): Option[Int] =
@@ -2549,6 +2503,18 @@ object MatchAnalysis extends StrictLogging:
             Some(leftSection.startOffset)
           case Match.LeftAndRight(leftSection, _) =>
             Some(leftSection.startOffset)
+          case _ => None
+
+      private def startOffsetOnRight(
+          aMatch: GenericMatch[Element]
+      ): Option[Int] =
+        aMatch match
+          case Match.AllSides(_, _, rightSection) =>
+            Some(rightSection.startOffset)
+          case Match.BaseAndRight(_, rightSection) =>
+            Some(rightSection.startOffset)
+          case Match.LeftAndRight(_, rightSection) =>
+            Some(rightSection.startOffset)
           case _ => None
 
       private def pareDownOrSuppressCompletely[MatchType <: GenericMatch[

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -33,7 +33,7 @@ import scala.collection.immutable.{
   SortedSet
 }
 import scala.collection.parallel.CollectionConverters.*
-import scala.collection.{View, immutable, mutable}
+import scala.collection.{immutable, mutable}
 import scala.util.{Success, Using}
 
 trait MatchAnalysis[Path, Element]:
@@ -1282,99 +1282,6 @@ object MatchAnalysis extends StrictLogging:
         end if
       end purgedOfMatchesWithOverlappingSections
 
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(allSides)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
-            )
-        }
-      end withoutTheseMatches
-
       def reconcileMatches: MatchesAndTheirSections =
         val matches = sectionsAndTheirMatches.values.toSet
 
@@ -1548,530 +1455,6 @@ object MatchAnalysis extends StrictLogging:
         result
 
       end reconcileMatches
-
-      def parallelMatchesOnly: MatchesAndTheirSections =
-        // PLAN:
-
-        // 1. Build up sources composed of matched sections concatenated
-        // together by path preserving their original order.
-
-        val baseMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(baseSection, _, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndLeft(baseSection, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndRight(baseSection, _))
-                  if section == baseSection =>
-                section
-            }
-
-        val leftMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, leftSection, _))
-                  if section == leftSection =>
-                section
-              case (section, Match.BaseAndLeft(_, leftSection))
-                  if section == leftSection =>
-                section
-              case (section, Match.LeftAndRight(leftSection, _))
-                  if section == leftSection =>
-                section
-            }
-
-        val rightMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, _, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.BaseAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.LeftAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-            }
-
-        // 2. Apply `MatchAnalysis.of` to these sections, using the
-        // potential match key of the section to underpin equality and
-        // hashing.
-
-        def groupsOfBackTranslatedParallelMatchesFrom(
-            baseMatchedSections: Iterable[Section[Element]],
-            leftMatchedSections: Iterable[Section[Element]],
-            rightMatchedSections: Iterable[Section[Element]]
-        ): Seq[View[Match[Section[Element]]]] =
-          case class MetaMatchContentSources(
-              override val contentsByPath: Map[Path, IndexedSeq[
-                Section[Element]
-              ]],
-              override val label: String
-          ) extends MappedContentSources[Path, Section[Element]]
-
-          def sourcesForMetaMatching(label: String)(
-              sources: Sources[Path, Element],
-              matchedSections: Iterable[Section[Element]]
-          ) = MetaMatchContentSources(
-            contentsByPath = matchedSections
-              .groupBy(sources.pathFor)
-              .map((path, sections) =>
-                path -> sections.toIndexedSeq
-                  .sortBy(section =>
-                    // NOTE: use the negative of the section size as a
-                    // tiebreaker if more than one section has the same start
-                    // offset. This makes sure that a subsuming section comes
-                    // *before* any sections that it might subsume, so it can't
-                    // interpose itself within what would have been a run of
-                    // parallel subsumed sections; that way we don't
-                    // accidentally split what should be larger meta-matches.
-                    // That can occur when the subsuming section is contributed
-                    // by a larger pairwise match that subsumes several
-                    // all-sides matches, and the first all-sides match aligns
-                    // with the start of the pairwise match. The test
-                    // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation`
-                    // has an example of this.
-                    section.startOffset -> -section.size
-                  )
-              ),
-            label = label
-          )
-
-          val baseSourcesForMetaMatching =
-            sourcesForMetaMatching("meta-base")(
-              baseSources,
-              baseMatchedSections
-            )
-          val leftSourcesForMetaMatching =
-            sourcesForMetaMatching("meta-left")(
-              leftSources,
-              leftMatchedSections
-            )
-          val rightSourcesForMetaMatching =
-            sourcesForMetaMatching("meta-right")(
-              rightSources,
-              rightMatchedSections
-            )
-
-          object metaMatchConfiguration extends AbstractConfiguration:
-            override val minimumMatchSize: Int                    = 1
-            override val thresholdSizeFractionForMatching: Double = 0
-            override val minimumAmbiguousMatchSize: Int           = 1
-            override val ambiguousMatchesThreshold: Int           = Int.MaxValue
-            override val progressRecording: ProgressRecording     =
-              configuration.progressRecording
-          end metaMatchConfiguration
-
-          given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
-
-          given Funnel[Section[Element]] with
-            override def funnel(
-                from: Section[Element],
-                into: PrimitiveSink
-            ): Unit =
-              from.content.foreach(summon[Funnel[Element]].funnel(_, into))
-
-          end given
-
-          val metaMatchAnalysis = of(
-            baseSourcesForMetaMatching,
-            leftSourcesForMetaMatching,
-            rightSourcesForMetaMatching
-          )(metaMatchConfiguration)
-
-          // 3. The resulting meta-matches provide parallel sequences of
-          // sections that are unzipped to yield corresponding all-sides and
-          // pairwise matches.
-
-          val metaMatches = metaMatchAnalysis.matches
-
-          // NOTE: because meta-matching starts with matched *sections* and
-          // ignores gaps, we have to guard against sections that would have
-          // formed the sides of a suppressed outer match making a second
-          // attempt at building a match.
-          metaMatches
-            .map {
-              case Match.AllSides(
-                    baseMetaSection,
-                    leftMetaSection,
-                    rightMetaSection
-                  ) =>
-                (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
-                  .collect {
-                    case (baseSection, leftSection, rightSection)
-                        if !isSubsumedNonTriviallyByAnAllSidesMatch(
-                          baseSection,
-                          leftSection,
-                          rightSection
-                        ) =>
-                      Match.AllSides(baseSection, leftSection, rightSection)
-                  }
-              case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
-                (baseMetaSection.content lazyZip leftMetaSection.content)
-                  .collect {
-                    case (baseSection, leftSection)
-                        if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-                          baseSection,
-                          leftSection
-                        ) =>
-                      Match.BaseAndLeft(baseSection, leftSection)
-                  }
-              case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
-                (baseMetaSection.content lazyZip rightMetaSection.content)
-                  .collect {
-                    case (baseSection, rightSection)
-                        if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-                          baseSection,
-                          rightSection
-                        ) =>
-                      Match.BaseAndRight(baseSection, rightSection)
-                  }
-              case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
-                (leftMetaSection.content lazyZip rightMetaSection.content)
-                  .collect {
-                    case (leftSection, rightSection)
-                        if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-                          leftSection,
-                          rightSection
-                        ) =>
-                      Match.LeftAndRight(leftSection, rightSection)
-                  }
-            }
-            .filter(_.nonEmpty)
-            .toSeq
-        end groupsOfBackTranslatedParallelMatchesFrom
-
-        val groupsOfBackTranslatedParallelMatches =
-          groupsOfBackTranslatedParallelMatchesFrom(
-            baseMatchedSections,
-            leftMatchedSections,
-            rightMatchedSections
-          )
-
-        // 4. Build putative groups from the back-translated matches. These
-        // won't be perfectly accurate, but are refined later by
-        // `reconcileMatches`.
-
-        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
-        // the back-translated matches, because the thinning out of ambiguous
-        // matches performed by the meta-matching and back translation above
-        // means there are new opportunities for matches to be generated - while
-        // the vast majority of these are redundant pairwise matches, there are
-        // some that are vital to capture things such as moves with migrated
-        // edits / deletions - the test
-        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
-        // an example of this.
-        val backTranslatedMatchesAndTheirSections =
-          MatchesAndTheirSections.empty
-            .withMatches(
-              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
-              haveTrimmedMatches = false
-            )
-            .matchesAndTheirSections
-            .withoutRedundantPairwiseMatches
-
-        val backTranslatedMatches =
-          backTranslatedMatchesAndTheirSections.matches
-
-        val parallelMatchesGroupIdsByMatch =
-          Map.from(
-            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
-              (parallelMatches, groupId) =>
-                parallelMatches
-                  .filter(backTranslatedMatches.contains)
-                  .map(_ -> groupId)
-            )
-          )
-
-        backTranslatedMatchesAndTheirSections
-          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
-      end parallelMatchesOnly
-
-      // Cleans up the state when a putative all-sides match that would have
-      // been ambiguous on one side with another all-sides match was partially
-      // suppressed by a larger pairwise match. This situation results in a
-      // pairwise match that shares its sections on both sides with the other
-      // all-sides match; remove any such redundant pairwise matches.
-      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
-        val redundantMatches =
-          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
-
-        if redundantMatches.nonEmpty then
-          logger.debug(
-            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
-          )
-        end if
-
-        withoutTheseMatches(redundantMatches)
-      end withoutRedundantPairwiseMatches
-
-      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
-        aMatch match
-          case Match.BaseAndLeft(baseSection, leftSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(leftSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.BaseAndRight(baseSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.LeftAndRight(leftSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(leftSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case _: Match.AllSides[Section[Element]] => false
-
-      private def isSubsumedNonTriviallyByAnAllSidesMatch(
-          baseSection: Section[Element],
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAnAllSidesMatch
-
-      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-          baseSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-          baseSection: Section[Element],
-          leftSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
-
-      private def withMatches(
-          matches: Set[GenericMatch[Element]],
-          haveTrimmedMatches: Boolean
-      ): MatchingResult =
-        val updatedMatchesAndTheirSections =
-          matches.foldLeft(this)(_ withMatch _)
-
-        val pathInclusions =
-          if !haveTrimmedMatches then
-            case class PathInclusionsImplementation(
-                basePaths: Set[Path],
-                leftPaths: Set[Path],
-                rightPaths: Set[Path]
-            ) extends PathInclusions:
-              override def isIncludedOnBase(basePath: Path): Boolean =
-                basePaths.contains(basePath)
-
-              override def isIncludedOnLeft(leftPath: Path): Boolean =
-                leftPaths.contains(leftPath)
-
-              override def isIncludedOnRight(rightPath: Path): Boolean =
-                rightPaths.contains(rightPath)
-
-              def addPathOnBaseFor(
-                  baseSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
-              def addPathOnLeftFor(
-                  leftSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
-              def addPathOnRightFor(
-                  rightSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(rightPaths =
-                  rightPaths + rightSources.pathFor(rightSection)
-                )
-            end PathInclusionsImplementation
-
-            matches.foldLeft(
-              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
-            )((partialPathInclusions, aMatch) =>
-              aMatch match
-                case Match.AllSides(baseSection, leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.BaseAndLeft(baseSection, leftSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                case Match.BaseAndRight(baseSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.LeftAndRight(leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-            )
-          else PathInclusions.all
-
-        MatchingResult(
-          matchesAndTheirSections = updatedMatchesAndTheirSections,
-          numberOfMatchesForTheGivenWindowSize = matches.size,
-          estimatedWindowSizeForOptimalMatch =
-            estimateOptimalMatchSize(matches),
-          pathInclusions = pathInclusions
-        )
-      end withMatches
-
-      private def withMatch(
-          aMatch: GenericMatch[Element]
-      ): MatchesAndTheirSections =
-        aMatch match
-          case Match.AllSides(baseSection, leftSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
-              baseFingerprintedInclusionsByPath =
-                knockOutFromBaseFingerprintedInclusions(baseSection),
-              leftFingerprintedInclusionsByPath =
-                knockOutFromLeftFingerprintedInclusions(leftSection),
-              rightFingerprintedInclusionsByPath =
-                knockOutFromRightFingerprintedInclusions(rightSection)
-            )
-          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
-            )
-          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
-            )
-          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
-            copy(
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
-            )
-        end match
-      end withMatch
 
       private def checkInvariant(): Unit =
         // We expect to tally either two lots of a given pairwise match or three
@@ -2751,6 +2134,610 @@ object MatchAnalysis extends StrictLogging:
             )
         }
       end pairwiseMatchesSubsumingOnBothSidesWithBiteEdges
+
+      def parallelMatchesOnly: MatchesAndTheirSections =
+        // PLAN:
+
+        // 1. Build up sources composed of matched sections concatenated
+        // together by path preserving their original order.
+
+        val baseMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(baseSection, _, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndLeft(baseSection, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndRight(baseSection, _))
+                  if section == baseSection =>
+                section
+            }
+
+        val leftMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, leftSection, _))
+                  if section == leftSection =>
+                section
+              case (section, Match.BaseAndLeft(_, leftSection))
+                  if section == leftSection =>
+                section
+              case (section, Match.LeftAndRight(leftSection, _))
+                  if section == leftSection =>
+                section
+            }
+
+        val rightMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, _, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.BaseAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.LeftAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+            }
+
+        case class MetaMatchContentSources(
+            override val contentsByPath: Map[Path, IndexedSeq[
+              Section[Element]
+            ]],
+            override val label: String
+        ) extends MappedContentSources[Path, Section[Element]]
+
+        def sourcesForMetaMatching(label: String)(
+            sources: Sources[Path, Element],
+            matchedSections: Iterable[Section[Element]]
+        ) = MetaMatchContentSources(
+          contentsByPath = matchedSections
+            .groupBy(sources.pathFor)
+            .map((path, sections) =>
+              path -> sections.toIndexedSeq
+                .sortBy(section =>
+                  // NOTE: use the negative of the section size as a tiebreaker
+                  // if more than one section has the same start offset. This
+                  // makes sure that a subsuming section comes *before* any
+                  // sections that it might subsume, so it can't interpose
+                  // itself within what would have been a run of parallel
+                  // subsumed sections; that way we don't accidentally split
+                  // what should be larger meta-matches. That can occur when the
+                  // subsuming section is contributed by a larger pairwise match
+                  // that subsumes several all-sides matches, and the first
+                  // all-sides match aligns with the start of the pairwise
+                  // match. The test
+                  // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation`
+                  // has an example of this.
+                  section.startOffset -> -section.size
+                )
+            ),
+          label = label
+        )
+
+        val baseSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-base")(
+            baseSources,
+            baseMatchedSections
+          )
+        val leftSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-left")(
+            leftSources,
+            leftMatchedSections
+          )
+        val rightSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-right")(
+            rightSources,
+            rightMatchedSections
+          )
+
+        // 2. Apply `MatchAnalysis.of` to these sections, using the
+        // potential match key of the section to underpin equality and
+        // hashing.
+
+        object metaMatchConfiguration extends AbstractConfiguration:
+          override val minimumMatchSize: Int                    = 1
+          override val thresholdSizeFractionForMatching: Double = 0
+          override val minimumAmbiguousMatchSize: Int           = 1
+          override val ambiguousMatchesThreshold: Int           = Int.MaxValue
+          override val progressRecording: ProgressRecording     =
+            configuration.progressRecording
+        end metaMatchConfiguration
+
+        given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
+
+        given Funnel[Section[Element]] with
+          override def funnel(
+              from: Section[Element],
+              into: PrimitiveSink
+          ): Unit =
+            from.content.foreach(summon[Funnel[Element]].funnel(_, into))
+
+        end given
+
+        val metaMatchAnalysis = of(
+          baseSourcesForMetaMatching,
+          leftSourcesForMetaMatching,
+          rightSourcesForMetaMatching
+        )(metaMatchConfiguration)
+
+        // 3. The resulting meta-matches provide parallel sequences of sections
+        // that are unzipped to yield corresponding all-sides and pairwise
+        // matches.
+
+        val metaMatches = metaMatchAnalysis.matches
+
+        // NOTE: because meta-matching starts with matched *sections* and
+        // ignores gaps, we have to guard against sections that would have
+        // formed the sides of a suppressed outer match making a second attempt
+        // at building a match.
+        val groupsOfBackTranslatedParallelMatches = metaMatches
+          .map {
+            case Match.AllSides(
+                  baseMetaSection,
+                  leftMetaSection,
+                  rightMetaSection
+                ) =>
+              (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (baseSection, leftSection, rightSection)
+                      if !isSubsumedNonTriviallyByAnAllSidesMatch(
+                        baseSection,
+                        leftSection,
+                        rightSection
+                      ) =>
+                    Match.AllSides(baseSection, leftSection, rightSection)
+                }
+            case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
+              (baseMetaSection.content lazyZip leftMetaSection.content)
+                .collect {
+                  case (baseSection, leftSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+                        baseSection,
+                        leftSection
+                      ) =>
+                    Match.BaseAndLeft(baseSection, leftSection)
+                }
+            case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
+              (baseMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (baseSection, rightSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+                        baseSection,
+                        rightSection
+                      ) =>
+                    Match.BaseAndRight(baseSection, rightSection)
+                }
+            case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
+              (leftMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (leftSection, rightSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+                        leftSection,
+                        rightSection
+                      ) =>
+                    Match.LeftAndRight(leftSection, rightSection)
+                }
+          }
+          .filter(_.nonEmpty)
+          .toSeq
+
+        // 4. Build putative groups from the back-translated matches. These
+        // won't be perfectly accurate, but are refined later by
+        // `reconcileMatches`.
+
+        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
+        // the back-translated matches, because the thinning out of ambiguous
+        // matches performed by the meta-matching and back translation above
+        // means there are new opportunities for matches to be generated - while
+        // the vast majority of these are redundant pairwise matches, there are
+        // some that are vital to capture things such as moves with migrated
+        // edits / deletions - the test
+        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
+        // an example of this.
+        val backTranslatedMatchesAndTheirSections =
+          MatchesAndTheirSections.empty
+            .withMatches(
+              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
+              haveTrimmedMatches = false
+            )
+            .matchesAndTheirSections
+            .withoutRedundantPairwiseMatches
+
+        val backTranslatedMatches =
+          backTranslatedMatchesAndTheirSections.matches
+
+        val parallelMatchesGroupIdsByMatch =
+          Map.from(
+            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
+              (parallelMatches, groupId) =>
+                parallelMatches
+                  .filter(backTranslatedMatches.contains)
+                  .map(_ -> groupId)
+            )
+          )
+
+        backTranslatedMatchesAndTheirSections
+          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
+      end parallelMatchesOnly
+
+      // Cleans up the state when a putative all-sides match that would have
+      // been ambiguous on one side with another all-sides match was partially
+      // suppressed by a larger pairwise match. This situation results in a
+      // pairwise match that shares its sections on both sides with the other
+      // all-sides match; remove any such redundant pairwise matches.
+      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
+        val redundantMatches =
+          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
+
+        if redundantMatches.nonEmpty then
+          logger.debug(
+            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
+          )
+        end if
+
+        withoutTheseMatches(redundantMatches)
+      end withoutRedundantPairwiseMatches
+
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(allSides)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
+            )
+        }
+      end withoutTheseMatches
+
+      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
+        aMatch match
+          case Match.BaseAndLeft(baseSection, leftSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(leftSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.BaseAndRight(baseSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.LeftAndRight(leftSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(leftSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case _: Match.AllSides[Section[Element]] => false
+
+      private def isSubsumedNonTriviallyByAnAllSidesMatch(
+          baseSection: Section[Element],
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAnAllSidesMatch
+
+      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+          baseSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+          baseSection: Section[Element],
+          leftSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
+
+      private def withMatches(
+          matches: Set[GenericMatch[Element]],
+          haveTrimmedMatches: Boolean
+      ): MatchingResult =
+        val updatedMatchesAndTheirSections =
+          matches.foldLeft(this)(_ withMatch _)
+
+        val pathInclusions =
+          if !haveTrimmedMatches then
+            case class PathInclusionsImplementation(
+                basePaths: Set[Path],
+                leftPaths: Set[Path],
+                rightPaths: Set[Path]
+            ) extends PathInclusions:
+              override def isIncludedOnBase(basePath: Path): Boolean =
+                basePaths.contains(basePath)
+
+              override def isIncludedOnLeft(leftPath: Path): Boolean =
+                leftPaths.contains(leftPath)
+
+              override def isIncludedOnRight(rightPath: Path): Boolean =
+                rightPaths.contains(rightPath)
+
+              def addPathOnBaseFor(
+                  baseSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
+              def addPathOnLeftFor(
+                  leftSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
+              def addPathOnRightFor(
+                  rightSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(rightPaths =
+                  rightPaths + rightSources.pathFor(rightSection)
+                )
+            end PathInclusionsImplementation
+
+            matches.foldLeft(
+              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
+            )((partialPathInclusions, aMatch) =>
+              aMatch match
+                case Match.AllSides(baseSection, leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.BaseAndLeft(baseSection, leftSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                case Match.BaseAndRight(baseSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.LeftAndRight(leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+            )
+          else PathInclusions.all
+
+        MatchingResult(
+          matchesAndTheirSections = updatedMatchesAndTheirSections,
+          numberOfMatchesForTheGivenWindowSize = matches.size,
+          estimatedWindowSizeForOptimalMatch =
+            estimateOptimalMatchSize(matches),
+          pathInclusions = pathInclusions
+        )
+      end withMatches
+
+      private def withMatch(
+          aMatch: GenericMatch[Element]
+      ): MatchesAndTheirSections =
+        aMatch match
+          case Match.AllSides(baseSection, leftSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
+              baseFingerprintedInclusionsByPath =
+                knockOutFromBaseFingerprintedInclusions(baseSection),
+              leftFingerprintedInclusionsByPath =
+                knockOutFromLeftFingerprintedInclusions(leftSection),
+              rightFingerprintedInclusionsByPath =
+                knockOutFromRightFingerprintedInclusions(rightSection)
+            )
+          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
+            )
+          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
+            )
+          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
+            copy(
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
+            )
+        end match
+      end withMatch
 
       private def pairwiseMatchesSubsumingOnBothSides(
           allSides: Match.AllSides[Section[Element]]

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -48,7 +48,7 @@ trait MatchAnalysis[Path, Element]:
       enabled: Boolean
   ): MatchAnalysis[Path, Element]
 
-  def tinyMatchesOnly(): MatchAnalysis[Path, Element]
+  def withTinyMatches: MatchAnalysis[Path, Element]
 
   def baseSections: Set[Section[Element]]
 
@@ -1086,7 +1086,7 @@ object MatchAnalysis extends StrictLogging:
         else this
       end withAllSmallFryMatches
 
-      def tinyMatchesOnly(): MatchesAndTheirSections =
+      def withTinyMatches: MatchesAndTheirSections =
         val withContentCoveredByNonTinyMatchesKnockedOut =
           val nonTinyMatches = sectionsAndTheirMatches.values.filter {
             case Match.AllSides(baseSection, _, _) =>
@@ -1167,7 +1167,7 @@ object MatchAnalysis extends StrictLogging:
           }
         end withContentCoveredByNonTinyMatchesKnockedOut
 
-        Using(
+        val tinyMatches = Using(
           progressRecording.newSession(
             label = "Minimum match size considered:",
             maximumProgress = minimumWindowSizeAcrossAllFilesOverAllSides
@@ -1184,8 +1184,52 @@ object MatchAnalysis extends StrictLogging:
             looseExclusiveUpperBoundOnMaximumMatchSize =
               minimumWindowSizeAcrossAllFilesOverAllSides
           )(using progressRecordingSession)
-        }.get
-      end tinyMatchesOnly
+        }.get.purgedOfMatchesWithOverlappingSections(enabled = true).matches
+
+        tinyMatches.foldLeft(this)(_ withMatch _)
+      end withTinyMatches
+
+      private def withMatch(
+          aMatch: GenericMatch[Element]
+      ): MatchesAndTheirSections =
+        aMatch match
+          case Match.AllSides(baseSection, leftSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
+              baseFingerprintedInclusionsByPath =
+                knockOutFromBaseFingerprintedInclusions(baseSection),
+              leftFingerprintedInclusionsByPath =
+                knockOutFromLeftFingerprintedInclusions(leftSection),
+              rightFingerprintedInclusionsByPath =
+                knockOutFromRightFingerprintedInclusions(rightSection)
+            )
+          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
+            )
+          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
+            )
+          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
+            copy(
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
+            )
+        end match
+      end withMatch
 
       def purgedOfMatchesWithOverlappingSections(
           enabled: Boolean
@@ -1969,48 +2013,6 @@ object MatchAnalysis extends StrictLogging:
           pathInclusions = pathInclusions
         )
       end withMatches
-
-      private def withMatch(
-          aMatch: GenericMatch[Element]
-      ): MatchesAndTheirSections =
-        aMatch match
-          case Match.AllSides(baseSection, leftSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
-              baseFingerprintedInclusionsByPath =
-                knockOutFromBaseFingerprintedInclusions(baseSection),
-              leftFingerprintedInclusionsByPath =
-                knockOutFromLeftFingerprintedInclusions(leftSection),
-              rightFingerprintedInclusionsByPath =
-                knockOutFromRightFingerprintedInclusions(rightSection)
-            )
-          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
-            )
-          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
-            )
-          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
-            copy(
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
-            )
-        end match
-      end withMatch
 
       private def checkInvariant(): Unit =
         // We expect to tally either two lots of a given pairwise match or three

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1282,6 +1282,99 @@ object MatchAnalysis extends StrictLogging:
         end if
       end purgedOfMatchesWithOverlappingSections
 
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(allSides)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
+            )
+        }
+      end withoutTheseMatches
+
       def reconcileMatches: MatchesAndTheirSections =
         val matches = sectionsAndTheirMatches.values.toSet
 
@@ -1455,6 +1548,529 @@ object MatchAnalysis extends StrictLogging:
         result
 
       end reconcileMatches
+
+      def parallelMatchesOnly: MatchesAndTheirSections =
+        // PLAN:
+
+        // 1. Build up sources composed of matched sections concatenated
+        // together by path preserving their original order.
+
+        val baseMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(baseSection, _, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndLeft(baseSection, _))
+                  if section == baseSection =>
+                section
+              case (section, Match.BaseAndRight(baseSection, _))
+                  if section == baseSection =>
+                section
+            }
+
+        val leftMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, leftSection, _))
+                  if section == leftSection =>
+                section
+              case (section, Match.BaseAndLeft(_, leftSection))
+                  if section == leftSection =>
+                section
+              case (section, Match.LeftAndRight(leftSection, _))
+                  if section == leftSection =>
+                section
+            }
+
+        val rightMatchedSections =
+          sectionsAndTheirMatches.sets
+            .map((key, values) => key -> values.head)
+            .collect {
+              case (section, Match.AllSides(_, _, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.BaseAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+              case (section, Match.LeftAndRight(_, rightSection))
+                  if section == rightSection =>
+                section
+            }
+
+        case class MetaMatchContentSources(
+            override val contentsByPath: Map[Path, IndexedSeq[
+              Section[Element]
+            ]],
+            override val label: String
+        ) extends MappedContentSources[Path, Section[Element]]
+
+        def sourcesForMetaMatching(label: String)(
+            sources: Sources[Path, Element],
+            matchedSections: Iterable[Section[Element]]
+        ) = MetaMatchContentSources(
+          contentsByPath = matchedSections
+            .groupBy(sources.pathFor)
+            .map((path, sections) =>
+              path -> sections.toIndexedSeq
+                .sortBy(section =>
+                  // NOTE: use the negative of the section size as a tiebreaker
+                  // if more than one section has the same start offset. This
+                  // makes sure that a subsuming section comes *before* any
+                  // sections that it might subsume, so it can't interpose
+                  // itself within what would have been a run of parallel
+                  // subsumed sections; that way we don't accidentally split
+                  // what should be larger meta-matches. That can occur when the
+                  // subsuming section is contributed by a larger pairwise match
+                  // that subsumes several all-sides matches, and the first
+                  // all-sides match aligns with the start of the pairwise
+                  // match. The test
+                  // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation`
+                  // has an example of this.
+                  section.startOffset -> -section.size
+                )
+            ),
+          label = label
+        )
+
+        val baseSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-base")(
+            baseSources,
+            baseMatchedSections
+          )
+        val leftSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-left")(
+            leftSources,
+            leftMatchedSections
+          )
+        val rightSourcesForMetaMatching =
+          sourcesForMetaMatching("meta-right")(
+            rightSources,
+            rightMatchedSections
+          )
+
+        // 2. Apply `MatchAnalysis.of` to these sections, using the
+        // potential match key of the section to underpin equality and
+        // hashing.
+
+        object metaMatchConfiguration extends AbstractConfiguration:
+          override val minimumMatchSize: Int                    = 1
+          override val thresholdSizeFractionForMatching: Double = 0
+          override val minimumAmbiguousMatchSize: Int           = 1
+          override val ambiguousMatchesThreshold: Int           = Int.MaxValue
+          override val progressRecording: ProgressRecording     =
+            configuration.progressRecording
+        end metaMatchConfiguration
+
+        given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
+
+        given Funnel[Section[Element]] with
+          override def funnel(
+              from: Section[Element],
+              into: PrimitiveSink
+          ): Unit =
+            from.content.foreach(summon[Funnel[Element]].funnel(_, into))
+
+        end given
+
+        val metaMatchAnalysis = of(
+          baseSourcesForMetaMatching,
+          leftSourcesForMetaMatching,
+          rightSourcesForMetaMatching
+        )(metaMatchConfiguration)
+
+        // 3. The resulting meta-matches provide parallel sequences of sections
+        // that are unzipped to yield corresponding all-sides and pairwise
+        // matches.
+
+        val metaMatches = metaMatchAnalysis.matches
+
+        // NOTE: because meta-matching starts with matched *sections* and
+        // ignores gaps, we have to guard against sections that would have
+        // formed the sides of a suppressed outer match making a second attempt
+        // at building a match.
+        val groupsOfBackTranslatedParallelMatches = metaMatches
+          .flatMap {
+            case Match.AllSides(
+                  baseMetaSection,
+                  leftMetaSection,
+                  rightMetaSection
+                ) =>
+              // NOTE: an all-sides meta-match implies a group of all-sides
+              // matches. Contrast this to a pairwise meta-match, which is
+              // exploded into singleton groups of pairwise matches. This is
+              // done because the pairwise matches can land on either side of an
+              // intervening all-sides group; we don't want to have group ids
+              // that are shared across such split groups.
+              // TODO: finesse this so that an attempt is made at grouping
+              // pairwise matches together if possible without violating the
+              // unique group id constraint, or at least do something about the
+              // nasty wrapping in `Seq` and then flat-mapping.
+              Seq(
+                (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
+                  .collect {
+                    case (baseSection, leftSection, rightSection)
+                        if !isSubsumedNonTriviallyByAnAllSidesMatch(
+                          baseSection,
+                          leftSection,
+                          rightSection
+                        ) =>
+                      Match.AllSides(baseSection, leftSection, rightSection)
+                  }
+              )
+            case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
+              (baseMetaSection.content lazyZip leftMetaSection.content)
+                .collect {
+                  case (baseSection, leftSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+                        baseSection,
+                        leftSection
+                      ) =>
+                    Seq(Match.BaseAndLeft(baseSection, leftSection))
+                }
+            case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
+              (baseMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (baseSection, rightSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+                        baseSection,
+                        rightSection
+                      ) =>
+                    Seq(Match.BaseAndRight(baseSection, rightSection))
+                }
+            case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
+              (leftMetaSection.content lazyZip rightMetaSection.content)
+                .collect {
+                  case (leftSection, rightSection)
+                      if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+                        leftSection,
+                        rightSection
+                      ) =>
+                    Seq(Match.LeftAndRight(leftSection, rightSection))
+                }
+          }
+          .filter(_.nonEmpty)
+          .toSeq
+
+        // 4. Build putative groups from the back-translated matches. These
+        // won't be perfectly accurate, but are refined later by
+        // `reconcileMatches`.
+
+        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
+        // the back-translated matches, because the thinning out of ambiguous
+        // matches performed by the meta-matching and back translation above
+        // means there are new opportunities for matches to be generated - while
+        // the vast majority of these are redundant pairwise matches, there are
+        // some that are vital to capture things such as moves with migrated
+        // edits / deletions - the test
+        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
+        // an example of this.
+        val backTranslatedMatchesAndTheirSections =
+          MatchesAndTheirSections.empty
+            .withMatches(
+              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
+              haveTrimmedMatches = false
+            )
+            .matchesAndTheirSections
+            .withoutRedundantPairwiseMatches
+
+        val backTranslatedMatches =
+          backTranslatedMatchesAndTheirSections.matches
+
+        val parallelMatchesGroupIdsByMatch =
+          Map.from(
+            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
+              (parallelMatches, groupId) =>
+                parallelMatches
+                  .filter(backTranslatedMatches.contains)
+                  .map(_ -> groupId)
+            )
+          )
+
+        backTranslatedMatchesAndTheirSections
+          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
+      end parallelMatchesOnly
+
+      // Cleans up the state when a putative all-sides match that would have
+      // been ambiguous on one side with another all-sides match was partially
+      // suppressed by a larger pairwise match. This situation results in a
+      // pairwise match that shares its sections on both sides with the other
+      // all-sides match; remove any such redundant pairwise matches.
+      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
+        val redundantMatches =
+          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
+
+        if redundantMatches.nonEmpty then
+          logger.debug(
+            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
+          )
+        end if
+
+        withoutTheseMatches(redundantMatches)
+      end withoutRedundantPairwiseMatches
+
+      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
+        aMatch match
+          case Match.BaseAndLeft(baseSection, leftSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(leftSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.BaseAndRight(baseSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.LeftAndRight(leftSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(leftSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case _: Match.AllSides[Section[Element]] => false
+
+      private def isSubsumedNonTriviallyByAnAllSidesMatch(
+          baseSection: Section[Element],
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAnAllSidesMatch
+
+      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+          leftSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+          baseSection: Section[Element],
+          rightSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnRight =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            rightSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnRight).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
+
+      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+          baseSection: Section[Element],
+          leftSection: Section[Element]
+      ) =
+        val subsumingOnBase =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            baseSection,
+            includeTrivialSubsumption = false
+          )
+
+        val subsumingOnLeft =
+          subsumingMatches(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            leftSection,
+            includeTrivialSubsumption = false
+          )
+
+        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
+      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
+
+      private def withMatches(
+          matches: Set[GenericMatch[Element]],
+          haveTrimmedMatches: Boolean
+      ): MatchingResult =
+        val updatedMatchesAndTheirSections =
+          matches.foldLeft(this)(_ withMatch _)
+
+        val pathInclusions =
+          if !haveTrimmedMatches then
+            case class PathInclusionsImplementation(
+                basePaths: Set[Path],
+                leftPaths: Set[Path],
+                rightPaths: Set[Path]
+            ) extends PathInclusions:
+              override def isIncludedOnBase(basePath: Path): Boolean =
+                basePaths.contains(basePath)
+
+              override def isIncludedOnLeft(leftPath: Path): Boolean =
+                leftPaths.contains(leftPath)
+
+              override def isIncludedOnRight(rightPath: Path): Boolean =
+                rightPaths.contains(rightPath)
+
+              def addPathOnBaseFor(
+                  baseSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
+              def addPathOnLeftFor(
+                  leftSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
+              def addPathOnRightFor(
+                  rightSection: Section[Element]
+              ): PathInclusionsImplementation =
+                copy(rightPaths =
+                  rightPaths + rightSources.pathFor(rightSection)
+                )
+            end PathInclusionsImplementation
+
+            matches.foldLeft(
+              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
+            )((partialPathInclusions, aMatch) =>
+              aMatch match
+                case Match.AllSides(baseSection, leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.BaseAndLeft(baseSection, leftSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnLeftFor(leftSection)
+                case Match.BaseAndRight(baseSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnBaseFor(baseSection)
+                    .addPathOnRightFor(rightSection)
+                case Match.LeftAndRight(leftSection, rightSection) =>
+                  partialPathInclusions
+                    .addPathOnLeftFor(leftSection)
+                    .addPathOnRightFor(rightSection)
+            )
+          else PathInclusions.all
+
+        MatchingResult(
+          matchesAndTheirSections = updatedMatchesAndTheirSections,
+          numberOfMatchesForTheGivenWindowSize = matches.size,
+          estimatedWindowSizeForOptimalMatch =
+            estimateOptimalMatchSize(matches),
+          pathInclusions = pathInclusions
+        )
+      end withMatches
+
+      private def withMatch(
+          aMatch: GenericMatch[Element]
+      ): MatchesAndTheirSections =
+        aMatch match
+          case Match.AllSides(baseSection, leftSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
+              baseFingerprintedInclusionsByPath =
+                knockOutFromBaseFingerprintedInclusions(baseSection),
+              leftFingerprintedInclusionsByPath =
+                knockOutFromLeftFingerprintedInclusions(leftSection),
+              rightFingerprintedInclusionsByPath =
+                knockOutFromRightFingerprintedInclusions(rightSection)
+            )
+          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
+            )
+          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
+            )
+          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
+            copy(
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
+            )
+        end match
+      end withMatch
 
       private def checkInvariant(): Unit =
         // We expect to tally either two lots of a given pairwise match or three
@@ -2134,610 +2750,6 @@ object MatchAnalysis extends StrictLogging:
             )
         }
       end pairwiseMatchesSubsumingOnBothSidesWithBiteEdges
-
-      def parallelMatchesOnly: MatchesAndTheirSections =
-        // PLAN:
-
-        // 1. Build up sources composed of matched sections concatenated
-        // together by path preserving their original order.
-
-        val baseMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(baseSection, _, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndLeft(baseSection, _))
-                  if section == baseSection =>
-                section
-              case (section, Match.BaseAndRight(baseSection, _))
-                  if section == baseSection =>
-                section
-            }
-
-        val leftMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, leftSection, _))
-                  if section == leftSection =>
-                section
-              case (section, Match.BaseAndLeft(_, leftSection))
-                  if section == leftSection =>
-                section
-              case (section, Match.LeftAndRight(leftSection, _))
-                  if section == leftSection =>
-                section
-            }
-
-        val rightMatchedSections =
-          sectionsAndTheirMatches.sets
-            .map((key, values) => key -> values.head)
-            .collect {
-              case (section, Match.AllSides(_, _, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.BaseAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-              case (section, Match.LeftAndRight(_, rightSection))
-                  if section == rightSection =>
-                section
-            }
-
-        case class MetaMatchContentSources(
-            override val contentsByPath: Map[Path, IndexedSeq[
-              Section[Element]
-            ]],
-            override val label: String
-        ) extends MappedContentSources[Path, Section[Element]]
-
-        def sourcesForMetaMatching(label: String)(
-            sources: Sources[Path, Element],
-            matchedSections: Iterable[Section[Element]]
-        ) = MetaMatchContentSources(
-          contentsByPath = matchedSections
-            .groupBy(sources.pathFor)
-            .map((path, sections) =>
-              path -> sections.toIndexedSeq
-                .sortBy(section =>
-                  // NOTE: use the negative of the section size as a tiebreaker
-                  // if more than one section has the same start offset. This
-                  // makes sure that a subsuming section comes *before* any
-                  // sections that it might subsume, so it can't interpose
-                  // itself within what would have been a run of parallel
-                  // subsumed sections; that way we don't accidentally split
-                  // what should be larger meta-matches. That can occur when the
-                  // subsuming section is contributed by a larger pairwise match
-                  // that subsumes several all-sides matches, and the first
-                  // all-sides match aligns with the start of the pairwise
-                  // match. The test
-                  // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation`
-                  // has an example of this.
-                  section.startOffset -> -section.size
-                )
-            ),
-          label = label
-        )
-
-        val baseSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-base")(
-            baseSources,
-            baseMatchedSections
-          )
-        val leftSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-left")(
-            leftSources,
-            leftMatchedSections
-          )
-        val rightSourcesForMetaMatching =
-          sourcesForMetaMatching("meta-right")(
-            rightSources,
-            rightMatchedSections
-          )
-
-        // 2. Apply `MatchAnalysis.of` to these sections, using the
-        // potential match key of the section to underpin equality and
-        // hashing.
-
-        object metaMatchConfiguration extends AbstractConfiguration:
-          override val minimumMatchSize: Int                    = 1
-          override val thresholdSizeFractionForMatching: Double = 0
-          override val minimumAmbiguousMatchSize: Int           = 1
-          override val ambiguousMatchesThreshold: Int           = Int.MaxValue
-          override val progressRecording: ProgressRecording     =
-            configuration.progressRecording
-        end metaMatchConfiguration
-
-        given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
-
-        given Funnel[Section[Element]] with
-          override def funnel(
-              from: Section[Element],
-              into: PrimitiveSink
-          ): Unit =
-            from.content.foreach(summon[Funnel[Element]].funnel(_, into))
-
-        end given
-
-        val metaMatchAnalysis = of(
-          baseSourcesForMetaMatching,
-          leftSourcesForMetaMatching,
-          rightSourcesForMetaMatching
-        )(metaMatchConfiguration)
-
-        // 3. The resulting meta-matches provide parallel sequences of sections
-        // that are unzipped to yield corresponding all-sides and pairwise
-        // matches.
-
-        val metaMatches = metaMatchAnalysis.matches
-
-        // NOTE: because meta-matching starts with matched *sections* and
-        // ignores gaps, we have to guard against sections that would have
-        // formed the sides of a suppressed outer match making a second attempt
-        // at building a match.
-        val groupsOfBackTranslatedParallelMatches = metaMatches
-          .map {
-            case Match.AllSides(
-                  baseMetaSection,
-                  leftMetaSection,
-                  rightMetaSection
-                ) =>
-              (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAnAllSidesMatch(
-                        baseSection,
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.AllSides(baseSection, leftSection, rightSection)
-                }
-            case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
-              (baseMetaSection.content lazyZip leftMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-                        baseSection,
-                        leftSection
-                      ) =>
-                    Match.BaseAndLeft(baseSection, leftSection)
-                }
-            case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
-              (baseMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-                        baseSection,
-                        rightSection
-                      ) =>
-                    Match.BaseAndRight(baseSection, rightSection)
-                }
-            case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
-              (leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.LeftAndRight(leftSection, rightSection)
-                }
-          }
-          .filter(_.nonEmpty)
-          .toSeq
-
-        // 4. Build putative groups from the back-translated matches. These
-        // won't be perfectly accurate, but are refined later by
-        // `reconcileMatches`.
-
-        // NOTE: need to build a new instance of `MatchesAndTheirSections` for
-        // the back-translated matches, because the thinning out of ambiguous
-        // matches performed by the meta-matching and back translation above
-        // means there are new opportunities for matches to be generated - while
-        // the vast majority of these are redundant pairwise matches, there are
-        // some that are vital to capture things such as moves with migrated
-        // edits / deletions - the test
-        // `SectionedCodeExtensionTest.codeMotionAmbiguousWithAPreservation` has
-        // an example of this.
-        val backTranslatedMatchesAndTheirSections =
-          MatchesAndTheirSections.empty
-            .withMatches(
-              groupsOfBackTranslatedParallelMatches.foldLeft(Set.empty)(_ ++ _),
-              haveTrimmedMatches = false
-            )
-            .matchesAndTheirSections
-            .withoutRedundantPairwiseMatches
-
-        val backTranslatedMatches =
-          backTranslatedMatchesAndTheirSections.matches
-
-        val parallelMatchesGroupIdsByMatch =
-          Map.from(
-            groupsOfBackTranslatedParallelMatches.zipWithIndex.flatMap(
-              (parallelMatches, groupId) =>
-                parallelMatches
-                  .filter(backTranslatedMatches.contains)
-                  .map(_ -> groupId)
-            )
-          )
-
-        backTranslatedMatchesAndTheirSections
-          .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
-      end parallelMatchesOnly
-
-      // Cleans up the state when a putative all-sides match that would have
-      // been ambiguous on one side with another all-sides match was partially
-      // suppressed by a larger pairwise match. This situation results in a
-      // pairwise match that shares its sections on both sides with the other
-      // all-sides match; remove any such redundant pairwise matches.
-      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
-        val redundantMatches =
-          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
-
-        if redundantMatches.nonEmpty then
-          logger.debug(
-            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
-          )
-        end if
-
-        withoutTheseMatches(redundantMatches)
-      end withoutRedundantPairwiseMatches
-
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(allSides)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndLeft)
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(baseAndRight)
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                parallelMatchesGroupIdsByMatch.removed(leftAndRight)
-            )
-        }
-      end withoutTheseMatches
-
-      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
-        aMatch match
-          case Match.BaseAndLeft(baseSection, leftSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(leftSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.BaseAndRight(baseSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.LeftAndRight(leftSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(leftSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case _: Match.AllSides[Section[Element]] => false
-
-      private def isSubsumedNonTriviallyByAnAllSidesMatch(
-          baseSection: Section[Element],
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAnAllSidesMatch
-
-      private def isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-          leftSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnLeft intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheLeftAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-          baseSection: Section[Element],
-          rightSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnRight =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            rightSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnRight).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndRight
-
-      private def isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-          baseSection: Section[Element],
-          leftSection: Section[Element]
-      ) =
-        val subsumingOnBase =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            baseSection,
-            includeTrivialSubsumption = false
-          )
-
-        val subsumingOnLeft =
-          subsumingMatches(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            leftSection,
-            includeTrivialSubsumption = false
-          )
-
-        (subsumingOnBase intersect subsumingOnLeft).nonEmpty
-      end isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft
-
-      private def withMatches(
-          matches: Set[GenericMatch[Element]],
-          haveTrimmedMatches: Boolean
-      ): MatchingResult =
-        val updatedMatchesAndTheirSections =
-          matches.foldLeft(this)(_ withMatch _)
-
-        val pathInclusions =
-          if !haveTrimmedMatches then
-            case class PathInclusionsImplementation(
-                basePaths: Set[Path],
-                leftPaths: Set[Path],
-                rightPaths: Set[Path]
-            ) extends PathInclusions:
-              override def isIncludedOnBase(basePath: Path): Boolean =
-                basePaths.contains(basePath)
-
-              override def isIncludedOnLeft(leftPath: Path): Boolean =
-                leftPaths.contains(leftPath)
-
-              override def isIncludedOnRight(rightPath: Path): Boolean =
-                rightPaths.contains(rightPath)
-
-              def addPathOnBaseFor(
-                  baseSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(basePaths = basePaths + baseSources.pathFor(baseSection))
-              def addPathOnLeftFor(
-                  leftSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(leftPaths = leftPaths + leftSources.pathFor(leftSection))
-              def addPathOnRightFor(
-                  rightSection: Section[Element]
-              ): PathInclusionsImplementation =
-                copy(rightPaths =
-                  rightPaths + rightSources.pathFor(rightSection)
-                )
-            end PathInclusionsImplementation
-
-            matches.foldLeft(
-              PathInclusionsImplementation(Set.empty, Set.empty, Set.empty)
-            )((partialPathInclusions, aMatch) =>
-              aMatch match
-                case Match.AllSides(baseSection, leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.BaseAndLeft(baseSection, leftSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnLeftFor(leftSection)
-                case Match.BaseAndRight(baseSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnBaseFor(baseSection)
-                    .addPathOnRightFor(rightSection)
-                case Match.LeftAndRight(leftSection, rightSection) =>
-                  partialPathInclusions
-                    .addPathOnLeftFor(leftSection)
-                    .addPathOnRightFor(rightSection)
-            )
-          else PathInclusions.all
-
-        MatchingResult(
-          matchesAndTheirSections = updatedMatchesAndTheirSections,
-          numberOfMatchesForTheGivenWindowSize = matches.size,
-          estimatedWindowSizeForOptimalMatch =
-            estimateOptimalMatchSize(matches),
-          pathInclusions = pathInclusions
-        )
-      end withMatches
-
-      private def withMatch(
-          aMatch: GenericMatch[Element]
-      ): MatchesAndTheirSections =
-        aMatch match
-          case Match.AllSides(baseSection, leftSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
-              baseFingerprintedInclusionsByPath =
-                knockOutFromBaseFingerprintedInclusions(baseSection),
-              leftFingerprintedInclusionsByPath =
-                knockOutFromLeftFingerprintedInclusions(leftSection),
-              rightFingerprintedInclusionsByPath =
-                knockOutFromRightFingerprintedInclusions(rightSection)
-            )
-          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
-            )
-          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
-            )
-          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
-            copy(
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
-            )
-        end match
-      end withMatch
 
       private def pairwiseMatchesSubsumingOnBothSides(
           allSides: Match.AllSides[Section[Element]]

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
@@ -4,10 +4,7 @@ import cats.Eq
 import com.google.common.hash.{Funnel, HashFunction}
 import com.sageserpent.kineticmerge
 import com.sageserpent.kineticmerge.core
-import com.sageserpent.kineticmerge.core.MatchAnalysis.{
-  AbstractConfiguration,
-  AdmissibleFailure
-}
+import com.sageserpent.kineticmerge.core.MatchAnalysis.{AbstractConfiguration, AdmissibleFailure, ParallelMatchesGroupIdsByMatch}
 import com.typesafe.scalalogging.StrictLogging
 
 import scala.collection.mutable
@@ -24,6 +21,8 @@ trait SectionedCode[Path, Element]:
   def basePathFor(baseSection: Section[Element]): Path
   def leftPathFor(leftSection: Section[Element]): Path
   def rightPathFor(rightSection: Section[Element]): Path
+
+  def parallelMatchesGroupIdsByMatch: ParallelMatchesGroupIdsByMatch[Element]
 end SectionedCode
 
 object SectionedCode extends StrictLogging:
@@ -113,6 +112,8 @@ object SectionedCode extends StrictLogging:
         export baseSources.pathFor as basePathFor
         export leftSources.pathFor as leftPathFor
         export rightSources.pathFor as rightPathFor
+        
+        export matchesAndTheirSections.parallelMatchesGroupIdsByMatch
 
         {
           // Invariant: the matches are referenced only by their participating

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
@@ -101,154 +101,80 @@ object SectionedCode extends StrictLogging:
         )
 
       Right(new SectionedCode[Path, Element]:
-        private val lcsByPath: Map[Path, LongestCommonSubsequence[Section[
-          Element
-        ]]] =
-          val parallelMatchesGroupIdsByMatch =
-            matchesAndTheirSections.parallelMatchesGroupIdsByMatch
-          val tinyParallelMatchesGroupIdsByMatch =
-            tinyMatchesAndTheirSectionsOnly.parallelMatchesGroupIdsByMatch
+        private val lcsByPath: mutable.Map[Path, LongestCommonSubsequence[
+          Section[Element]
+        ]] = mutable.Map.empty
 
-          val tinyIdOffset =
-            1 + (parallelMatchesGroupIdsByMatch.values.toSeq.maxOption
-              .getOrElse(0))
+        override def base: Map[Path, File[Element]] = baseFilesByPath
 
-          def groupIdFor(m: Match[Section[Element]]): Option[Int] =
-            parallelMatchesGroupIdsByMatch
-              .get(m)
-              .headOption
-              .orElse(
-                tinyParallelMatchesGroupIdsByMatch
-                  .get(m)
-                  .headOption
-                  .map(_ + tinyIdOffset)
+        override def left: Map[Path, File[Element]] = leftFilesByPath
+
+        override def right: Map[Path, File[Element]] = rightFilesByPath
+
+        override def matchesFor(
+            section: Section[Element]
+        ): collection.Set[Match[Section[Element]]] =
+          sectionsAndTheirMatches.get(section)
+
+        override def lcsFor(
+            path: Path
+        ): LongestCommonSubsequence[Section[Element]] =
+          lcsByPath.getOrElseUpdate(
+            path, {
+              val baseSections =
+                baseFilesByPath
+                  .get(path)
+                  .map(_.sections)
+                  .getOrElse(IndexedSeq.empty)
+              val leftSections =
+                leftFilesByPath
+                  .get(path)
+                  .map(_.sections)
+                  .getOrElse(IndexedSeq.empty)
+              val rightSections =
+                rightFilesByPath
+                  .get(path)
+                  .map(_.sections)
+                  .getOrElse(IndexedSeq.empty)
+
+              given Sized[Section[Element]] = _.size
+
+              given Eq[Section[Element]] with
+                override def eqv(
+                    lhs: Section[Element],
+                    rhs: Section[Element]
+                ): Boolean =
+                  val matchesForLhs =
+                    matchesAndTheirSections.sectionsAndTheirMatches.get(lhs) ++
+                      tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
+                        .get(lhs)
+                  val matchesForRhs =
+                    matchesAndTheirSections.sectionsAndTheirMatches.get(rhs) ++
+                      tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
+                        .get(rhs)
+                  val bothBelongToTheSameMatches =
+                    matchesForLhs.intersect(matchesForRhs).nonEmpty
+
+                  bothBelongToTheSameMatches || (lhs.size == rhs.size && Eq[
+                    Seq[Element]
+                  ].eqv(lhs.content, rhs.content))
+              end given
+
+              LongestCommonSubsequence.of(
+                baseSections,
+                leftSections,
+                rightSections
+              )(using
+                Eq[Section[Element]],
+                summon[Sized[Section[Element]]],
+                com.sageserpent.kineticmerge.NoProgressRecording
               )
-
-          case class Block(
-              sections: IndexedSeq[Section[Element]]
+            }
           )
 
-          def sectionLcsFor(
-              path: Path
-          ): LongestCommonSubsequence[Section[Element]] = {
-            val baseSections =
-              baseFilesByPath
-                .get(path)
-                .map(_.sections)
-                .getOrElse(IndexedSeq.empty)
-            val leftSections =
-              leftFilesByPath
-                .get(path)
-                .map(_.sections)
-                .getOrElse(IndexedSeq.empty)
-            val rightSections =
-              rightFilesByPath
-                .get(path)
-                .map(_.sections)
-                .getOrElse(IndexedSeq.empty)
-
-            def groupIdsForSection(s: Section[Element]): Set[Int] =
-              (matchesAndTheirSections.sectionsAndTheirMatches.get(s) ++
-                tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches.get(s))
-                .flatMap(groupIdFor)
-                .toSet
-
-            def compress(
-                sections: IndexedSeq[Section[Element]]
-            ): IndexedSeq[Block] = {
-              val blocks = mutable.ArrayBuffer.empty[Block]
-              var currentGroupIds = Set.empty[Int]
-              val currentSections = mutable.ArrayBuffer.empty[Section[Element]]
-
-              for (s <- sections) {
-                val gIds = groupIdsForSection(s)
-                if (gIds.nonEmpty && gIds == currentGroupIds) {
-                  currentSections += s
-                } else {
-                  if (currentSections.nonEmpty) {
-                    blocks += Block(currentSections.toIndexedSeq)
-                    currentSections.clear()
-                  }
-                  if (gIds.nonEmpty) {
-                    currentSections += s
-                    currentGroupIds = gIds
-                  } else {
-                    blocks += Block(IndexedSeq(s))
-                    currentGroupIds = Set.empty
-                  }
-                }
-              }
-              if (currentSections.nonEmpty) {
-                blocks += Block(currentSections.toIndexedSeq)
-              }
-              blocks.toIndexedSeq
-            }
-
-            val baseBlocks = compress(baseSections)
-            val leftBlocks = compress(leftSections)
-            val rightBlocks = compress(rightSections)
-
-            given Sized[Block] = _.sections.map(_.size).sum
-
-            given Eq[Block] with
-              override def eqv(x: Block, y: Block): Boolean =
-                x.sections.size == y.sections.size &&
-                  x.sections.zip(y.sections).forall { (s1, s2) =>
-                    val ms1 =
-                      matchesAndTheirSections.sectionsAndTheirMatches.get(s1) ++
-                        tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
-                          .get(s1)
-                    val ms2 =
-                      matchesAndTheirSections.sectionsAndTheirMatches.get(s2) ++
-                        tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
-                          .get(s2)
-                    ms1.intersect(ms2).nonEmpty || (
-                      s1.size == s2.size && Eq[Seq[Element]].eqv(
-                        s1.content,
-                        s2.content
-                      )
-                    )
-                  }
-            end given
-
-            val blockLcs = LongestCommonSubsequence.of(
-              baseBlocks,
-              leftBlocks,
-              rightBlocks
-            )(using
-              Eq[Block],
-              summon[Sized[Block]],
-              com.sageserpent.kineticmerge.NoProgressRecording
-            )
-
-            def expand(
-                contributions: IndexedSeq[Contribution[Block]]
-            ): IndexedSeq[Contribution[Section[Element]]] =
-              contributions.flatMap {
-                case Contribution.Common(b) =>
-                  b.sections.map(Contribution.Common.apply)
-                case Contribution.Difference(b) =>
-                  b.sections.map(Contribution.Difference.apply)
-                case Contribution.CommonToBaseAndLeftOnly(b) =>
-                  b.sections.map(Contribution.CommonToBaseAndLeftOnly.apply)
-                case Contribution.CommonToBaseAndRightOnly(b) =>
-                  b.sections.map(Contribution.CommonToBaseAndRightOnly.apply)
-                case Contribution.CommonToLeftAndRightOnly(b) =>
-                  b.sections.map(Contribution.CommonToLeftAndRightOnly.apply)
-              }
-
-            given Sized[Section[Element]] = _.size
-
-            LongestCommonSubsequence(
-              expand(blockLcs.base),
-              expand(blockLcs.left),
-              expand(blockLcs.right)
-            )(summon[Sized[Section[Element]]].sizeOf)
-          }
-
-          val paths =
-            baseFilesByPath.keySet ++ leftFilesByPath.keySet ++ rightFilesByPath.keySet
-          paths.map(path => path -> sectionLcsFor(path)).toMap
+        export baseSources.pathFor as basePathFor
+        export leftSources.pathFor as leftPathFor
+        export rightSources.pathFor as rightPathFor
         {
           // Invariant: the matches are referenced only by their participating
           // sections.
@@ -298,25 +224,7 @@ object SectionedCode extends StrictLogging:
             s"Found rogue matches whose sections do not belong to the breakdown: ${pprintCustomised(rogueMatches)}."
           )
         }
-
-        override def base: Map[Path, File[Element]] = baseFilesByPath
-
-        override def left: Map[Path, File[Element]] = leftFilesByPath
-
-        override def right: Map[Path, File[Element]] = rightFilesByPath
-
-        override def matchesFor(
-            section: Section[Element]
-        ): collection.Set[Match[Section[Element]]] =
-          sectionsAndTheirMatches.get(section)
-
-        override def lcsFor(
-            path: Path
-        ): LongestCommonSubsequence[Section[Element]] = lcsByPath(path)
-
-        export baseSources.pathFor as basePathFor
-        export leftSources.pathFor as leftPathFor
-        export rightSources.pathFor as rightPathFor)
+      )
     catch
       // NOTE: don't convert this to use of `Try` with a subsequent `.toEither`
       // conversion. We want most flavours of exception to propagate, as they

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
@@ -4,6 +4,10 @@ import cats.Eq
 import com.google.common.hash.{Funnel, HashFunction}
 import com.sageserpent.kineticmerge
 import com.sageserpent.kineticmerge.core
+import com.sageserpent.kineticmerge.core.LongestCommonSubsequence.{
+  Contribution,
+  Sized
+}
 import com.sageserpent.kineticmerge.core.MatchAnalysis.{
   AbstractConfiguration,
   AdmissibleFailure
@@ -18,6 +22,8 @@ trait SectionedCode[Path, Element]:
   def matchesFor(
       section: Section[Element]
   ): collection.Set[Match[Section[Element]]]
+
+  def lcsFor(path: Path): LongestCommonSubsequence[Section[Element]]
 
   def basePathFor(baseSection: Section[Element]): Path
   def leftPathFor(leftSection: Section[Element]): Path
@@ -93,6 +99,289 @@ object SectionedCode extends StrictLogging:
         )
 
       Right(new SectionedCode[Path, Element]:
+        private val lcsByPath: Map[Path, LongestCommonSubsequence[Section[
+          Element
+        ]]] =
+          val parallelMatchesGroupIdsByMatch =
+            matchesAndTheirSections.parallelMatchesGroupIdsByMatch
+          val tinyParallelMatchesGroupIdsByMatch =
+            tinyMatchesAndTheirSectionsOnly.parallelMatchesGroupIdsByMatch
+
+          val tinyIdOffset =
+            1 + (parallelMatchesGroupIdsByMatch.values.toSeq.maxOption
+              .getOrElse(0))
+
+          def groupIdFor(m: Match[Section[Element]]): Option[Int] =
+            parallelMatchesGroupIdsByMatch
+              .get(m)
+              .headOption
+              .orElse(
+                tinyParallelMatchesGroupIdsByMatch
+                  .get(m)
+                  .headOption
+                  .map(_ + tinyIdOffset)
+              )
+
+          val allMatches =
+            matchesAndTheirSections.matches ++ tinyMatchesAndTheirSectionsOnly.matches
+
+          val blockSizes: Map[Int, Int] =
+            allMatches.toSeq
+              .flatMap(m =>
+                groupIdFor(m).map(g =>
+                  g -> (m match
+                    case m: Match.AllSides[Section[Element]] =>
+                      m.baseElement.size
+                    case m: Match.BaseAndLeft[Section[Element]] =>
+                      m.baseElement.size
+                    case m: Match.BaseAndRight[Section[Element]] =>
+                      m.baseElement.size
+                    case m: Match.LeftAndRight[Section[Element]] =>
+                      m.leftElement.size
+                  )
+                )
+              )
+              .groupBy(_._1)
+              .map { case (g, pairs) => g -> pairs.map(_._2).sum }
+
+          enum ThreeWaySide {
+            case Base, Left, Right
+          }
+
+          case class Block(groupId: Int)
+          given Sized[Block] with
+            override def sizeOf(block: Block): Int = blockSizes(block.groupId)
+          given Eq[Block] = Eq.fromUniversalEquals
+
+          def sectionLcsFor(
+              path: Path
+          ): LongestCommonSubsequence[Section[Element]] = {
+            val baseSections =
+              baseFilesByPath
+                .get(path)
+                .map(_.sections)
+                .getOrElse(IndexedSeq.empty)
+            val leftSections =
+              leftFilesByPath
+                .get(path)
+                .map(_.sections)
+                .getOrElse(IndexedSeq.empty)
+            val rightSections =
+              rightFilesByPath
+                .get(path)
+                .map(_.sections)
+                .getOrElse(IndexedSeq.empty)
+
+            def blocksFor(
+                sections: IndexedSeq[Section[Element]]
+            ): IndexedSeq[Block] =
+              sections
+                .flatMap(s =>
+                  matchesAndTheirSections.sectionsAndTheirMatches.get(s) ++
+                    tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
+                      .get(s)
+                )
+                .flatMap(groupIdFor)
+                .distinct
+                .map(Block.apply)
+
+            val baseBlocks  = blocksFor(baseSections)
+            val leftBlocks  = blocksFor(leftSections)
+            val rightBlocks = blocksFor(rightSections)
+
+            val blockLcs = LongestCommonSubsequence.of(
+              baseBlocks,
+              leftBlocks,
+              rightBlocks
+            )(using Eq[Block], summon[Sized[Block]], com.sageserpent.kineticmerge.NoProgressRecording)
+
+            def blockContributionsByGroupId(
+                side: ThreeWaySide,
+                contributions: IndexedSeq[Contribution[Block]]
+            ): Map[Int, Contribution[Block]] =
+              contributions.collect {
+                case c @ Contribution.Common(Block(g)) => g -> c
+                case c @ Contribution.CommonToBaseAndLeftOnly(Block(g))
+                    if side != ThreeWaySide.Right =>
+                  g -> c
+                case c @ Contribution.CommonToBaseAndRightOnly(Block(g))
+                    if side != ThreeWaySide.Left =>
+                  g -> c
+                case c @ Contribution.CommonToLeftAndRightOnly(Block(g))
+                    if side != ThreeWaySide.Base =>
+                  g -> c
+                case c @ Contribution.Difference(Block(g)) => g -> c
+              }.toMap
+
+            val blockContributionByGroupIdOnBase =
+              blockContributionsByGroupId(ThreeWaySide.Base, blockLcs.base)
+            val blockContributionByGroupIdOnLeft =
+              blockContributionsByGroupId(ThreeWaySide.Left, blockLcs.left)
+            val blockContributionByGroupIdOnRight =
+              blockContributionsByGroupId(ThreeWaySide.Right, blockLcs.right)
+
+            def contributionFor(
+                section: Section[Element],
+                side: ThreeWaySide
+            ): Contribution[Section[Element]] =
+              val matches =
+                matchesAndTheirSections.sectionsAndTheirMatches.get(section) ++
+                  tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
+                    .get(section)
+
+              val currentPath = path
+
+              val alignedContributions = matches.flatMap { m =>
+                groupIdFor(m).flatMap { g =>
+                  val blockContrib = side match
+                    case ThreeWaySide.Base =>
+                      blockContributionByGroupIdOnBase.get(g)
+                    case ThreeWaySide.Left =>
+                      blockContributionByGroupIdOnLeft.get(g)
+                    case ThreeWaySide.Right =>
+                      blockContributionByGroupIdOnRight.get(g)
+                  blockContrib.map(bc => m -> bc)
+                }
+              }
+
+              def isCompatible(
+                  m: Match[Section[Element]],
+                  bc: Contribution[Block]
+              ): Boolean = bc match
+                case Contribution.Common(_) => true
+                case Contribution.CommonToBaseAndLeftOnly(_) =>
+                  side != ThreeWaySide.Right
+                case Contribution.CommonToBaseAndRightOnly(_) =>
+                  side != ThreeWaySide.Left
+                case Contribution.CommonToLeftAndRightOnly(_) =>
+                  side != ThreeWaySide.Base
+                case Contribution.Difference(_) => true
+
+              val compatibleAligned =
+                alignedContributions.filter { case (m, bc) =>
+                  isCompatible(m, bc)
+                }
+
+              if compatibleAligned.isEmpty then
+                Contribution.Difference(section)
+              else
+                val (m, bc) = compatibleAligned.maxBy { case (m, bc) =>
+                  bc match
+                    case Contribution.Common(_) => 3
+                    case Contribution.CommonToBaseAndLeftOnly(_) |
+                        Contribution.CommonToBaseAndRightOnly(_) |
+                        Contribution.CommonToLeftAndRightOnly(_) =>
+                      2
+                    case _ => 1
+                }
+
+                bc match
+                  case Contribution.Common(_) =>
+                    m match
+                      case Match.AllSides(b, l, r) =>
+                        val baseIsLocal  = basePathFor(b) == currentPath
+                        val leftIsLocal  = leftPathFor(l) == currentPath
+                        val rightIsLocal = rightPathFor(r) == currentPath
+
+                        (baseIsLocal, leftIsLocal, rightIsLocal) match
+                          case (true, true, true) => Contribution.Common(section)
+                          case (true, true, false) if side != ThreeWaySide.Right =>
+                            Contribution.CommonToBaseAndLeftOnly(section)
+                          case (true, false, true) if side != ThreeWaySide.Left =>
+                            Contribution.CommonToBaseAndRightOnly(section)
+                          case (false, true, true) if side != ThreeWaySide.Base =>
+                            Contribution.CommonToLeftAndRightOnly(section)
+                          case _ => Contribution.Difference(section)
+
+                      case Match.BaseAndLeft(b, l) if side != ThreeWaySide.Right =>
+                        if basePathFor(b) == currentPath && leftPathFor(
+                            l
+                          ) == currentPath
+                        then Contribution.CommonToBaseAndLeftOnly(section)
+                        else Contribution.Difference(section)
+                      case Match.BaseAndRight(b, r) if side != ThreeWaySide.Left =>
+                        if basePathFor(b) == currentPath && rightPathFor(
+                            r
+                          ) == currentPath
+                        then Contribution.CommonToBaseAndRightOnly(section)
+                        else Contribution.Difference(section)
+                      case Match.LeftAndRight(l, r) if side != ThreeWaySide.Base =>
+                        if leftPathFor(l) == currentPath && rightPathFor(
+                            r
+                          ) == currentPath
+                        then Contribution.CommonToLeftAndRightOnly(section)
+                        else Contribution.Difference(section)
+                      case _ => Contribution.Difference(section)
+                  case Contribution.CommonToBaseAndLeftOnly(_) =>
+                    m match
+                      case Match.AllSides(b, l, _) if side != ThreeWaySide.Right =>
+                        if basePathFor(b) == currentPath && leftPathFor(
+                            l
+                          ) == currentPath
+                        then Contribution.CommonToBaseAndLeftOnly(section)
+                        else Contribution.Difference(section)
+                      case Match.BaseAndLeft(b, l) if side != ThreeWaySide.Right =>
+                        if basePathFor(b) == currentPath && leftPathFor(
+                            l
+                          ) == currentPath
+                        then Contribution.CommonToBaseAndLeftOnly(section)
+                        else Contribution.Difference(section)
+                      case _ => Contribution.Difference(section)
+                  case Contribution.CommonToBaseAndRightOnly(_) =>
+                    m match
+                      case Match.AllSides(b, _, r) if side != ThreeWaySide.Left =>
+                        if basePathFor(b) == currentPath && rightPathFor(
+                            r
+                          ) == currentPath
+                        then Contribution.CommonToBaseAndRightOnly(section)
+                        else Contribution.Difference(section)
+                      case Match.BaseAndRight(b, r) if side != ThreeWaySide.Left =>
+                        if basePathFor(b) == currentPath && rightPathFor(
+                            r
+                          ) == currentPath
+                        then Contribution.CommonToBaseAndRightOnly(section)
+                        else Contribution.Difference(section)
+                      case _ => Contribution.Difference(section)
+                  case Contribution.CommonToLeftAndRightOnly(_) =>
+                    m match
+                      case Match.AllSides(_, l, r) if side != ThreeWaySide.Base =>
+                        if leftPathFor(l) == currentPath && rightPathFor(
+                            r
+                          ) == currentPath
+                        then Contribution.CommonToLeftAndRightOnly(section)
+                        else Contribution.Difference(section)
+                      case Match.LeftAndRight(l, r) if side != ThreeWaySide.Base =>
+                        if leftPathFor(l) == currentPath && rightPathFor(
+                            r
+                          ) == currentPath
+                        then Contribution.CommonToLeftAndRightOnly(section)
+                        else Contribution.Difference(section)
+                      case _ => Contribution.Difference(section)
+                  case _ => Contribution.Difference(section)
+                end match
+              end if
+            end contributionFor
+
+            def elementSize(section: Section[Element]): Int = section.size
+
+            val baseContributions =
+              baseSections.map(contributionFor(_, ThreeWaySide.Base))
+            val leftContributions =
+              leftSections.map(contributionFor(_, ThreeWaySide.Left))
+            val rightContributions =
+              rightSections.map(contributionFor(_, ThreeWaySide.Right))
+
+            LongestCommonSubsequence(
+              baseContributions,
+              leftContributions,
+              rightContributions
+            )(elementSize)
+          }
+
+          val paths =
+            baseFilesByPath.keySet ++ leftFilesByPath.keySet ++ rightFilesByPath.keySet
+          paths.map(path => path -> sectionLcsFor(path)).toMap
+
         {
           // Invariant: the matches are referenced only by their participating
           // sections.
@@ -153,6 +442,10 @@ object SectionedCode extends StrictLogging:
             section: Section[Element]
         ): collection.Set[Match[Section[Element]]] =
           sectionsAndTheirMatches.get(section)
+
+        override def lcsFor(
+            path: Path
+        ): LongestCommonSubsequence[Section[Element]] = lcsByPath(path)
 
         export baseSources.pathFor as basePathFor
         export leftSources.pathFor as leftPathFor

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
@@ -14,6 +14,8 @@ import com.sageserpent.kineticmerge.core.MatchAnalysis.{
 }
 import com.typesafe.scalalogging.StrictLogging
 
+import scala.collection.mutable
+
 trait SectionedCode[Path, Element]:
   def base: Map[Path, File[Element]]
   def left: Map[Path, File[Element]]
@@ -122,36 +124,9 @@ object SectionedCode extends StrictLogging:
                   .map(_ + tinyIdOffset)
               )
 
-          val allMatches =
-            matchesAndTheirSections.matches ++ tinyMatchesAndTheirSectionsOnly.matches
-
-          val blockSizes: Map[Int, Int] =
-            allMatches.toSeq
-              .flatMap(m =>
-                groupIdFor(m).map(g =>
-                  g -> (m match
-                    case m: Match.AllSides[Section[Element]] =>
-                      m.baseElement.size
-                    case m: Match.BaseAndLeft[Section[Element]] =>
-                      m.baseElement.size
-                    case m: Match.BaseAndRight[Section[Element]] =>
-                      m.baseElement.size
-                    case m: Match.LeftAndRight[Section[Element]] =>
-                      m.leftElement.size
-                  )
-                )
-              )
-              .groupBy(_._1)
-              .map { case (g, pairs) => g -> pairs.map(_._2).sum }
-
-          enum ThreeWaySide {
-            case Base, Left, Right
-          }
-
-          case class Block(groupId: Int)
-          given Sized[Block] with
-            override def sizeOf(block: Block): Int = blockSizes(block.groupId)
-          given Eq[Block] = Eq.fromUniversalEquals
+          case class Block(
+              sections: IndexedSeq[Section[Element]]
+          )
 
           def sectionLcsFor(
               path: Path
@@ -172,216 +147,108 @@ object SectionedCode extends StrictLogging:
                 .map(_.sections)
                 .getOrElse(IndexedSeq.empty)
 
-            def blocksFor(
-                sections: IndexedSeq[Section[Element]]
-            ): IndexedSeq[Block] =
-              sections
-                .flatMap(s =>
-                  matchesAndTheirSections.sectionsAndTheirMatches.get(s) ++
-                    tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
-                      .get(s)
-                )
+            def groupIdsForSection(s: Section[Element]): Set[Int] =
+              (matchesAndTheirSections.sectionsAndTheirMatches.get(s) ++
+                tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches.get(s))
                 .flatMap(groupIdFor)
-                .distinct
-                .map(Block.apply)
+                .toSet
 
-            val baseBlocks  = blocksFor(baseSections)
-            val leftBlocks  = blocksFor(leftSections)
-            val rightBlocks = blocksFor(rightSections)
+            def compress(
+                sections: IndexedSeq[Section[Element]]
+            ): IndexedSeq[Block] = {
+              val blocks = mutable.ArrayBuffer.empty[Block]
+              var currentGroupIds = Set.empty[Int]
+              val currentSections = mutable.ArrayBuffer.empty[Section[Element]]
+
+              for (s <- sections) {
+                val gIds = groupIdsForSection(s)
+                if (gIds.nonEmpty && gIds == currentGroupIds) {
+                  currentSections += s
+                } else {
+                  if (currentSections.nonEmpty) {
+                    blocks += Block(currentSections.toIndexedSeq)
+                    currentSections.clear()
+                  }
+                  if (gIds.nonEmpty) {
+                    currentSections += s
+                    currentGroupIds = gIds
+                  } else {
+                    blocks += Block(IndexedSeq(s))
+                    currentGroupIds = Set.empty
+                  }
+                }
+              }
+              if (currentSections.nonEmpty) {
+                blocks += Block(currentSections.toIndexedSeq)
+              }
+              blocks.toIndexedSeq
+            }
+
+            val baseBlocks = compress(baseSections)
+            val leftBlocks = compress(leftSections)
+            val rightBlocks = compress(rightSections)
+
+            given Sized[Block] = _.sections.map(_.size).sum
+
+            given Eq[Block] with
+              override def eqv(x: Block, y: Block): Boolean =
+                x.sections.size == y.sections.size &&
+                  x.sections.zip(y.sections).forall { (s1, s2) =>
+                    val ms1 =
+                      matchesAndTheirSections.sectionsAndTheirMatches.get(s1) ++
+                        tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
+                          .get(s1)
+                    val ms2 =
+                      matchesAndTheirSections.sectionsAndTheirMatches.get(s2) ++
+                        tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
+                          .get(s2)
+                    ms1.intersect(ms2).nonEmpty || (
+                      s1.size == s2.size && Eq[Seq[Element]].eqv(
+                        s1.content,
+                        s2.content
+                      )
+                    )
+                  }
+            end given
 
             val blockLcs = LongestCommonSubsequence.of(
               baseBlocks,
               leftBlocks,
               rightBlocks
-            )(using Eq[Block], summon[Sized[Block]], com.sageserpent.kineticmerge.NoProgressRecording)
+            )(using
+              Eq[Block],
+              summon[Sized[Block]],
+              com.sageserpent.kineticmerge.NoProgressRecording
+            )
 
-            def blockContributionsByGroupId(
-                side: ThreeWaySide,
+            def expand(
                 contributions: IndexedSeq[Contribution[Block]]
-            ): Map[Int, Contribution[Block]] =
-              contributions.collect {
-                case c @ Contribution.Common(Block(g)) => g -> c
-                case c @ Contribution.CommonToBaseAndLeftOnly(Block(g))
-                    if side != ThreeWaySide.Right =>
-                  g -> c
-                case c @ Contribution.CommonToBaseAndRightOnly(Block(g))
-                    if side != ThreeWaySide.Left =>
-                  g -> c
-                case c @ Contribution.CommonToLeftAndRightOnly(Block(g))
-                    if side != ThreeWaySide.Base =>
-                  g -> c
-                case c @ Contribution.Difference(Block(g)) => g -> c
-              }.toMap
-
-            val blockContributionByGroupIdOnBase =
-              blockContributionsByGroupId(ThreeWaySide.Base, blockLcs.base)
-            val blockContributionByGroupIdOnLeft =
-              blockContributionsByGroupId(ThreeWaySide.Left, blockLcs.left)
-            val blockContributionByGroupIdOnRight =
-              blockContributionsByGroupId(ThreeWaySide.Right, blockLcs.right)
-
-            def contributionFor(
-                section: Section[Element],
-                side: ThreeWaySide
-            ): Contribution[Section[Element]] =
-              val matches =
-                matchesAndTheirSections.sectionsAndTheirMatches.get(section) ++
-                  tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
-                    .get(section)
-
-              val currentPath = path
-
-              val alignedContributions = matches.flatMap { m =>
-                groupIdFor(m).flatMap { g =>
-                  val blockContrib = side match
-                    case ThreeWaySide.Base =>
-                      blockContributionByGroupIdOnBase.get(g)
-                    case ThreeWaySide.Left =>
-                      blockContributionByGroupIdOnLeft.get(g)
-                    case ThreeWaySide.Right =>
-                      blockContributionByGroupIdOnRight.get(g)
-                  blockContrib.map(bc => m -> bc)
-                }
+            ): IndexedSeq[Contribution[Section[Element]]] =
+              contributions.flatMap {
+                case Contribution.Common(b) =>
+                  b.sections.map(Contribution.Common.apply)
+                case Contribution.Difference(b) =>
+                  b.sections.map(Contribution.Difference.apply)
+                case Contribution.CommonToBaseAndLeftOnly(b) =>
+                  b.sections.map(Contribution.CommonToBaseAndLeftOnly.apply)
+                case Contribution.CommonToBaseAndRightOnly(b) =>
+                  b.sections.map(Contribution.CommonToBaseAndRightOnly.apply)
+                case Contribution.CommonToLeftAndRightOnly(b) =>
+                  b.sections.map(Contribution.CommonToLeftAndRightOnly.apply)
               }
 
-              def isCompatible(
-                  m: Match[Section[Element]],
-                  bc: Contribution[Block]
-              ): Boolean = bc match
-                case Contribution.Common(_) => true
-                case Contribution.CommonToBaseAndLeftOnly(_) =>
-                  side != ThreeWaySide.Right
-                case Contribution.CommonToBaseAndRightOnly(_) =>
-                  side != ThreeWaySide.Left
-                case Contribution.CommonToLeftAndRightOnly(_) =>
-                  side != ThreeWaySide.Base
-                case Contribution.Difference(_) => true
-
-              val compatibleAligned =
-                alignedContributions.filter { case (m, bc) =>
-                  isCompatible(m, bc)
-                }
-
-              if compatibleAligned.isEmpty then
-                Contribution.Difference(section)
-              else
-                val (m, bc) = compatibleAligned.maxBy { case (m, bc) =>
-                  bc match
-                    case Contribution.Common(_) => 3
-                    case Contribution.CommonToBaseAndLeftOnly(_) |
-                        Contribution.CommonToBaseAndRightOnly(_) |
-                        Contribution.CommonToLeftAndRightOnly(_) =>
-                      2
-                    case _ => 1
-                }
-
-                bc match
-                  case Contribution.Common(_) =>
-                    m match
-                      case Match.AllSides(b, l, r) =>
-                        val baseIsLocal  = basePathFor(b) == currentPath
-                        val leftIsLocal  = leftPathFor(l) == currentPath
-                        val rightIsLocal = rightPathFor(r) == currentPath
-
-                        (baseIsLocal, leftIsLocal, rightIsLocal) match
-                          case (true, true, true) => Contribution.Common(section)
-                          case (true, true, false) if side != ThreeWaySide.Right =>
-                            Contribution.CommonToBaseAndLeftOnly(section)
-                          case (true, false, true) if side != ThreeWaySide.Left =>
-                            Contribution.CommonToBaseAndRightOnly(section)
-                          case (false, true, true) if side != ThreeWaySide.Base =>
-                            Contribution.CommonToLeftAndRightOnly(section)
-                          case _ => Contribution.Difference(section)
-
-                      case Match.BaseAndLeft(b, l) if side != ThreeWaySide.Right =>
-                        if basePathFor(b) == currentPath && leftPathFor(
-                            l
-                          ) == currentPath
-                        then Contribution.CommonToBaseAndLeftOnly(section)
-                        else Contribution.Difference(section)
-                      case Match.BaseAndRight(b, r) if side != ThreeWaySide.Left =>
-                        if basePathFor(b) == currentPath && rightPathFor(
-                            r
-                          ) == currentPath
-                        then Contribution.CommonToBaseAndRightOnly(section)
-                        else Contribution.Difference(section)
-                      case Match.LeftAndRight(l, r) if side != ThreeWaySide.Base =>
-                        if leftPathFor(l) == currentPath && rightPathFor(
-                            r
-                          ) == currentPath
-                        then Contribution.CommonToLeftAndRightOnly(section)
-                        else Contribution.Difference(section)
-                      case _ => Contribution.Difference(section)
-                  case Contribution.CommonToBaseAndLeftOnly(_) =>
-                    m match
-                      case Match.AllSides(b, l, _) if side != ThreeWaySide.Right =>
-                        if basePathFor(b) == currentPath && leftPathFor(
-                            l
-                          ) == currentPath
-                        then Contribution.CommonToBaseAndLeftOnly(section)
-                        else Contribution.Difference(section)
-                      case Match.BaseAndLeft(b, l) if side != ThreeWaySide.Right =>
-                        if basePathFor(b) == currentPath && leftPathFor(
-                            l
-                          ) == currentPath
-                        then Contribution.CommonToBaseAndLeftOnly(section)
-                        else Contribution.Difference(section)
-                      case _ => Contribution.Difference(section)
-                  case Contribution.CommonToBaseAndRightOnly(_) =>
-                    m match
-                      case Match.AllSides(b, _, r) if side != ThreeWaySide.Left =>
-                        if basePathFor(b) == currentPath && rightPathFor(
-                            r
-                          ) == currentPath
-                        then Contribution.CommonToBaseAndRightOnly(section)
-                        else Contribution.Difference(section)
-                      case Match.BaseAndRight(b, r) if side != ThreeWaySide.Left =>
-                        if basePathFor(b) == currentPath && rightPathFor(
-                            r
-                          ) == currentPath
-                        then Contribution.CommonToBaseAndRightOnly(section)
-                        else Contribution.Difference(section)
-                      case _ => Contribution.Difference(section)
-                  case Contribution.CommonToLeftAndRightOnly(_) =>
-                    m match
-                      case Match.AllSides(_, l, r) if side != ThreeWaySide.Base =>
-                        if leftPathFor(l) == currentPath && rightPathFor(
-                            r
-                          ) == currentPath
-                        then Contribution.CommonToLeftAndRightOnly(section)
-                        else Contribution.Difference(section)
-                      case Match.LeftAndRight(l, r) if side != ThreeWaySide.Base =>
-                        if leftPathFor(l) == currentPath && rightPathFor(
-                            r
-                          ) == currentPath
-                        then Contribution.CommonToLeftAndRightOnly(section)
-                        else Contribution.Difference(section)
-                      case _ => Contribution.Difference(section)
-                  case _ => Contribution.Difference(section)
-                end match
-              end if
-            end contributionFor
-
-            def elementSize(section: Section[Element]): Int = section.size
-
-            val baseContributions =
-              baseSections.map(contributionFor(_, ThreeWaySide.Base))
-            val leftContributions =
-              leftSections.map(contributionFor(_, ThreeWaySide.Left))
-            val rightContributions =
-              rightSections.map(contributionFor(_, ThreeWaySide.Right))
+            given Sized[Section[Element]] = _.size
 
             LongestCommonSubsequence(
-              baseContributions,
-              leftContributions,
-              rightContributions
-            )(elementSize)
+              expand(blockLcs.base),
+              expand(blockLcs.left),
+              expand(blockLcs.right)
+            )(summon[Sized[Section[Element]]].sizeOf)
           }
 
           val paths =
             baseFilesByPath.keySet ++ leftFilesByPath.keySet ++ rightFilesByPath.keySet
           paths.map(path => path -> sectionLcsFor(path)).toMap
-
         {
           // Invariant: the matches are referenced only by their participating
           // sections.

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
@@ -10,7 +10,8 @@ import com.sageserpent.kineticmerge.core.LongestCommonSubsequence.{
 }
 import com.sageserpent.kineticmerge.core.MatchAnalysis.{
   AbstractConfiguration,
-  AdmissibleFailure
+  AdmissibleFailure,
+  ParallelMatchesGroupIdsByMatch
 }
 import com.typesafe.scalalogging.StrictLogging
 
@@ -137,44 +138,129 @@ object SectionedCode extends StrictLogging:
                   .map(_.sections)
                   .getOrElse(IndexedSeq.empty)
 
-              given Sized[Section[Element]] = _.size
+              val parallelMatchesGroupIdsByMatch =
+                matchesAndTheirSections.parallelMatchesGroupIdsByMatch
+              val tinyParallelMatchesGroupIdsByMatch =
+                tinyMatchesAndTheirSectionsOnly.parallelMatchesGroupIdsByMatch
 
-              given Eq[Section[Element]] with
-                override def eqv(
-                    lhs: Section[Element],
-                    rhs: Section[Element]
-                ): Boolean =
-                  val matchesForLhs =
-                    matchesAndTheirSections.sectionsAndTheirMatches.get(lhs) ++
-                      tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
-                        .get(lhs)
-                  val matchesForRhs =
-                    matchesAndTheirSections.sectionsAndTheirMatches.get(rhs) ++
-                      tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
-                        .get(rhs)
-                  val bothBelongToTheSameMatches =
-                    matchesForLhs.intersect(matchesForRhs).nonEmpty
+              val tinyIdOffset =
+                1 + parallelMatchesGroupIdsByMatch.values
+                  .foldLeft(0)(_ max _)
 
-                  bothBelongToTheSameMatches || (lhs.size == rhs.size && Eq[
-                    Seq[Element]
-                  ].eqv(lhs.content, rhs.content))
+              def groupIdFor(m: Match[Section[Element]]): Option[Int] =
+                parallelMatchesGroupIdsByMatch
+                  .get(m)
+                  .headOption
+                  .orElse(
+                    tinyParallelMatchesGroupIdsByMatch
+                      .get(m)
+                      .headOption
+                      .map(_ + tinyIdOffset)
+                  )
+
+              def groupIdsForSection(s: Section[Element]): Set[Int] =
+                (matchesAndTheirSections.sectionsAndTheirMatches.get(s) ++
+                  tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches.get(s))
+                  .flatMap(groupIdFor)
+                  .toSet
+
+              case class Block(
+                  groupIds: Set[Int],
+                  sections: IndexedSeq[Section[Element]]
+              )
+
+              def compress(
+                  sections: IndexedSeq[Section[Element]]
+              ): IndexedSeq[Block] = {
+                val blocks = mutable.ArrayBuffer.empty[Block]
+                var currentGroupIds = Set.empty[Int]
+                val currentSections = mutable.ArrayBuffer.empty[Section[Element]]
+
+                for (s <- sections) {
+                  val gIds = groupIdsForSection(s)
+                  if (gIds.nonEmpty && gIds == currentGroupIds) {
+                    currentSections += s
+                  } else {
+                    if (currentSections.nonEmpty) {
+                      blocks += Block(currentGroupIds, currentSections.toIndexedSeq)
+                      currentSections.clear()
+                    }
+                    if (gIds.nonEmpty) {
+                      currentSections += s
+                      currentGroupIds = gIds
+                    } else {
+                      blocks += Block(Set.empty, IndexedSeq(s))
+                      currentGroupIds = Set.empty
+                    }
+                  }
+                }
+                if (currentSections.nonEmpty) {
+                  blocks += Block(currentGroupIds, currentSections.toIndexedSeq)
+                }
+                blocks.toIndexedSeq
+              }
+
+              val baseBlocks  = compress(baseSections)
+              val leftBlocks  = compress(leftSections)
+              val rightBlocks = compress(rightSections)
+
+              given blockSized: Sized[Block] = _.sections.map(_.size).sum
+
+              given Eq[Block] with
+                override def eqv(x: Block, y: Block): Boolean =
+                  x.sections.size == y.sections.size && {
+                    val commonGroups = x.groupIds.intersect(y.groupIds)
+                    if (commonGroups.nonEmpty) true
+                    else
+                      x.sections.zip(y.sections).forall { (s1, s2) =>
+                        s1.size == s2.size && Eq[Seq[Element]].eqv(
+                          s1.content,
+                          s2.content
+                        )
+                      }
+                  }
               end given
 
-              LongestCommonSubsequence.of(
-                baseSections,
-                leftSections,
-                rightSections
+              val blockLcs = LongestCommonSubsequence.of(
+                baseBlocks,
+                leftBlocks,
+                rightBlocks
               )(using
-                Eq[Section[Element]],
-                summon[Sized[Section[Element]]],
+                Eq[Block],
+                blockSized,
                 com.sageserpent.kineticmerge.NoProgressRecording
               )
+
+              def expand(
+                  contributions: IndexedSeq[Contribution[Block]]
+              ): IndexedSeq[Contribution[Section[Element]]] =
+                contributions.flatMap {
+                  case Contribution.Common(b) =>
+                    b.sections.map(Contribution.Common.apply)
+                  case Contribution.Difference(b) =>
+                    b.sections.map(Contribution.Difference.apply)
+                  case Contribution.CommonToBaseAndLeftOnly(b) =>
+                    b.sections.map(Contribution.CommonToBaseAndLeftOnly.apply)
+                  case Contribution.CommonToBaseAndRightOnly(b) =>
+                    b.sections.map(Contribution.CommonToBaseAndRightOnly.apply)
+                  case Contribution.CommonToLeftAndRightOnly(b) =>
+                    b.sections.map(Contribution.CommonToLeftAndRightOnly.apply)
+                }
+
+              given sectionSized: Sized[Section[Element]] = _.size
+
+              LongestCommonSubsequence.apply(
+                expand(blockLcs.base),
+                expand(blockLcs.left),
+                expand(blockLcs.right)
+              )(sectionSized.sizeOf)
             }
           )
 
         export baseSources.pathFor as basePathFor
         export leftSources.pathFor as leftPathFor
         export rightSources.pathFor as rightPathFor
+
         {
           // Invariant: the matches are referenced only by their participating
           // sections.

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
@@ -4,14 +4,9 @@ import cats.Eq
 import com.google.common.hash.{Funnel, HashFunction}
 import com.sageserpent.kineticmerge
 import com.sageserpent.kineticmerge.core
-import com.sageserpent.kineticmerge.core.LongestCommonSubsequence.{
-  Contribution,
-  Sized
-}
 import com.sageserpent.kineticmerge.core.MatchAnalysis.{
   AbstractConfiguration,
-  AdmissibleFailure,
-  ParallelMatchesGroupIdsByMatch
+  AdmissibleFailure
 }
 import com.typesafe.scalalogging.StrictLogging
 
@@ -25,8 +20,6 @@ trait SectionedCode[Path, Element]:
   def matchesFor(
       section: Section[Element]
   ): collection.Set[Match[Section[Element]]]
-
-  def lcsFor(path: Path): LongestCommonSubsequence[Section[Element]]
 
   def basePathFor(baseSection: Section[Element]): Path
   def leftPathFor(leftSection: Section[Element]): Path
@@ -117,146 +110,6 @@ object SectionedCode extends StrictLogging:
         ): collection.Set[Match[Section[Element]]] =
           sectionsAndTheirMatches.get(section)
 
-        override def lcsFor(
-            path: Path
-        ): LongestCommonSubsequence[Section[Element]] =
-          lcsByPath.getOrElseUpdate(
-            path, {
-              val baseSections =
-                baseFilesByPath
-                  .get(path)
-                  .map(_.sections)
-                  .getOrElse(IndexedSeq.empty)
-              val leftSections =
-                leftFilesByPath
-                  .get(path)
-                  .map(_.sections)
-                  .getOrElse(IndexedSeq.empty)
-              val rightSections =
-                rightFilesByPath
-                  .get(path)
-                  .map(_.sections)
-                  .getOrElse(IndexedSeq.empty)
-
-              val parallelMatchesGroupIdsByMatch =
-                matchesAndTheirSections.parallelMatchesGroupIdsByMatch
-              val tinyParallelMatchesGroupIdsByMatch =
-                tinyMatchesAndTheirSectionsOnly.parallelMatchesGroupIdsByMatch
-
-              val tinyIdOffset =
-                1 + parallelMatchesGroupIdsByMatch.values
-                  .foldLeft(0)(_ max _)
-
-              def groupIdFor(m: Match[Section[Element]]): Option[Int] =
-                parallelMatchesGroupIdsByMatch
-                  .get(m)
-                  .headOption
-                  .orElse(
-                    tinyParallelMatchesGroupIdsByMatch
-                      .get(m)
-                      .headOption
-                      .map(_ + tinyIdOffset)
-                  )
-
-              def groupIdsForSection(s: Section[Element]): Set[Int] =
-                (matchesAndTheirSections.sectionsAndTheirMatches.get(s) ++
-                  tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches.get(s))
-                  .flatMap(groupIdFor)
-                  .toSet
-
-              case class Block(
-                  groupIds: Set[Int],
-                  sections: IndexedSeq[Section[Element]]
-              )
-
-              def compress(
-                  sections: IndexedSeq[Section[Element]]
-              ): IndexedSeq[Block] = {
-                val blocks = mutable.ArrayBuffer.empty[Block]
-                var currentGroupIds = Set.empty[Int]
-                val currentSections = mutable.ArrayBuffer.empty[Section[Element]]
-
-                for (s <- sections) {
-                  val gIds = groupIdsForSection(s)
-                  if (gIds.nonEmpty && gIds == currentGroupIds) {
-                    currentSections += s
-                  } else {
-                    if (currentSections.nonEmpty) {
-                      blocks += Block(currentGroupIds, currentSections.toIndexedSeq)
-                      currentSections.clear()
-                    }
-                    if (gIds.nonEmpty) {
-                      currentSections += s
-                      currentGroupIds = gIds
-                    } else {
-                      blocks += Block(Set.empty, IndexedSeq(s))
-                      currentGroupIds = Set.empty
-                    }
-                  }
-                }
-                if (currentSections.nonEmpty) {
-                  blocks += Block(currentGroupIds, currentSections.toIndexedSeq)
-                }
-                blocks.toIndexedSeq
-              }
-
-              val baseBlocks  = compress(baseSections)
-              val leftBlocks  = compress(leftSections)
-              val rightBlocks = compress(rightSections)
-
-              given blockSized: Sized[Block] = _.sections.map(_.size).sum
-
-              given Eq[Block] with
-                override def eqv(x: Block, y: Block): Boolean =
-                  x.sections.size == y.sections.size && {
-                    val commonGroups = x.groupIds.intersect(y.groupIds)
-                    if (commonGroups.nonEmpty) true
-                    else
-                      x.sections.zip(y.sections).forall { (s1, s2) =>
-                        s1.size == s2.size && Eq[Seq[Element]].eqv(
-                          s1.content,
-                          s2.content
-                        )
-                      }
-                  }
-              end given
-
-              val blockLcs = LongestCommonSubsequence.of(
-                baseBlocks,
-                leftBlocks,
-                rightBlocks
-              )(using
-                Eq[Block],
-                blockSized,
-                com.sageserpent.kineticmerge.NoProgressRecording
-              )
-
-              def expand(
-                  contributions: IndexedSeq[Contribution[Block]]
-              ): IndexedSeq[Contribution[Section[Element]]] =
-                contributions.flatMap {
-                  case Contribution.Common(b) =>
-                    b.sections.map(Contribution.Common.apply)
-                  case Contribution.Difference(b) =>
-                    b.sections.map(Contribution.Difference.apply)
-                  case Contribution.CommonToBaseAndLeftOnly(b) =>
-                    b.sections.map(Contribution.CommonToBaseAndLeftOnly.apply)
-                  case Contribution.CommonToBaseAndRightOnly(b) =>
-                    b.sections.map(Contribution.CommonToBaseAndRightOnly.apply)
-                  case Contribution.CommonToLeftAndRightOnly(b) =>
-                    b.sections.map(Contribution.CommonToLeftAndRightOnly.apply)
-                }
-
-              given sectionSized: Sized[Section[Element]] = _.size
-
-              LongestCommonSubsequence.apply(
-                expand(blockLcs.base),
-                expand(blockLcs.left),
-                expand(blockLcs.right)
-              )(sectionSized.sizeOf)
-            }
-          )
-
         export baseSources.pathFor as basePathFor
         export leftSources.pathFor as leftPathFor
         export rightSources.pathFor as rightPathFor
@@ -309,8 +162,7 @@ object SectionedCode extends StrictLogging:
             rogueMatches.isEmpty,
             s"Found rogue matches whose sections do not belong to the breakdown: ${pprintCustomised(rogueMatches)}."
           )
-        }
-      )
+        })
     catch
       // NOTE: don't convert this to use of `Try` with a subsequent `.toEither`
       // conversion. We want most flavours of exception to propagate, as they

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
@@ -65,6 +65,10 @@ object SectionedCode extends StrictLogging:
             suppressMatchesInvolvingOverlappingSections
           ) -> parallelMatchesOnly
           .tinyMatchesOnly()
+          // TODO: this precariously protects some downstream logic in
+          // `reconcileMatches` that assumes that all matches will have a
+          // parallel matches group id. Need to make this more robust.
+          .parallelMatchesOnly
           .reconcileMatches
           .purgedOfMatchesWithOverlappingSections(enabled = true)
       end val

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
@@ -55,27 +55,22 @@ object SectionedCode extends StrictLogging:
     val withAllMatchesOfAtLeastTheMinimumWindowSize =
       withAllMatchesOfAtLeastTheSureFireWindowSize.withAllSmallFryMatches()
 
-    val parallelMatchesOnly =
-      withAllMatchesOfAtLeastTheMinimumWindowSize.parallelMatchesOnly
+    val withTinyMatchesIncluded =
+      withAllMatchesOfAtLeastTheMinimumWindowSize.withTinyMatches
+
+    val parallelMatchesOnly = withTinyMatchesIncluded.parallelMatchesOnly
+
+    val reconciled = parallelMatchesOnly.reconcileMatches
 
     try
-      val (matchesAndTheirSections, tinyMatchesAndTheirSectionsOnly) =
-        parallelMatchesOnly.reconcileMatches
+      val matchesAndTheirSections =
+        reconciled
           .purgedOfMatchesWithOverlappingSections(
             suppressMatchesInvolvingOverlappingSections
-          ) -> parallelMatchesOnly
-          .tinyMatchesOnly()
-          // Force the tiny matches to be parallel too.
-          .parallelMatchesOnly
-          .reconcileMatches
-          .purgedOfMatchesWithOverlappingSections(enabled = true)
-      end val
+          )
 
       val sectionsAndTheirMatches =
         matchesAndTheirSections.sectionsAndTheirMatches
-
-      val tinySectionsAndTheirMatches =
-        tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
 
       // Use the sections covered by the tiny matches to break up gap fills on
       // all sides. This gives the downstream merge a chance to make last-minute
@@ -86,38 +81,36 @@ object SectionedCode extends StrictLogging:
 
       val baseFilesByPath =
         baseSources.filesByPathUtilising(mandatorySections =
-          matchesAndTheirSections.baseSections ++ tinyMatchesAndTheirSectionsOnly.baseSections
+          matchesAndTheirSections.baseSections
         )
       val leftFilesByPath =
         leftSources.filesByPathUtilising(mandatorySections =
-          matchesAndTheirSections.leftSections ++ tinyMatchesAndTheirSectionsOnly.leftSections
+          matchesAndTheirSections.leftSections
         )
       val rightFilesByPath =
         rightSources.filesByPathUtilising(mandatorySections =
-          matchesAndTheirSections.rightSections ++ tinyMatchesAndTheirSectionsOnly.rightSections
+          matchesAndTheirSections.rightSections
         )
 
       Right(new SectionedCode[Path, Element]:
         {
           // Invariant: the matches are referenced only by their participating
           // sections.
-          val allMatchKeys =
-            sectionsAndTheirMatches.keySet union tinySectionsAndTheirMatches.keySet
+          val allMatchKeys = sectionsAndTheirMatches.keySet
 
-          val allParticipatingSections =
-            (sectionsAndTheirMatches.values.toSet union tinySectionsAndTheirMatches.values.toSet)
-              .map {
-                case Match.AllSides(baseSection, leftSection, rightSection) =>
-                  Set(baseSection, leftSection, rightSection)
-                case Match.BaseAndLeft(baseSection, leftSection) =>
-                  Set(baseSection, leftSection)
-                case Match.BaseAndRight(baseSection, rightSection) =>
-                  Set(baseSection, rightSection)
-                case Match.LeftAndRight(leftSection, rightSection) =>
-                  Set(leftSection, rightSection)
-              }
-              .reduceOption(_ union _)
-              .getOrElse(Set.empty)
+          val allParticipatingSections = sectionsAndTheirMatches.values.toSet
+            .map {
+              case Match.AllSides(baseSection, leftSection, rightSection) =>
+                Set(baseSection, leftSection, rightSection)
+              case Match.BaseAndLeft(baseSection, leftSection) =>
+                Set(baseSection, leftSection)
+              case Match.BaseAndRight(baseSection, rightSection) =>
+                Set(baseSection, rightSection)
+              case Match.LeftAndRight(leftSection, rightSection) =>
+                Set(leftSection, rightSection)
+            }
+            .reduceOption(_ union _)
+            .getOrElse(Set.empty)
 
           require(allMatchKeys == allParticipatingSections)
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
@@ -82,9 +82,6 @@ object SectionedCode extends StrictLogging:
       val sectionsAndTheirMatches =
         matchesAndTheirSections.sectionsAndTheirMatches
 
-      val tinySectionsAndTheirMatches =
-        tinyMatchesAndTheirSectionsOnly.sectionsAndTheirMatches
-
       // Use the sections covered by the tiny matches to break up gap fills on
       // all sides. This gives the downstream merge a chance to make last-minute
       // matches of its own between small unmatched sections that are deleted
@@ -104,14 +101,6 @@ object SectionedCode extends StrictLogging:
         rightSources.filesByPathUtilising(mandatorySections =
           matchesAndTheirSections.rightSections ++ tinyMatchesAndTheirSectionsOnly.rightSections
         )
-
-      val combinedParallelMatchesGroupIdsByMatch =
-        matchesAndTheirSections.parallelMatchesGroupIdsByMatch
-          ++ tinyMatchesAndTheirSectionsOnly.parallelMatchesGroupIdsByMatch.map(
-            (aMatch, groupId) =>
-              val negativeGroupIdToSegregateFromPrimaryGroupIds = -1 - groupId
-              aMatch -> negativeGroupIdToSegregateFromPrimaryGroupIds
-          )
 
       Right(new SectionedCode[Path, Element]:
         private val lcsByPath: mutable.Map[Path, LongestCommonSubsequence[
@@ -133,18 +122,15 @@ object SectionedCode extends StrictLogging:
         export leftSources.pathFor as leftPathFor
         export rightSources.pathFor as rightPathFor
 
-        override def parallelMatchesGroupIdsByMatch
-            : ParallelMatchesGroupIdsByMatch[Element] =
-          combinedParallelMatchesGroupIdsByMatch
+        export matchesAndTheirSections.parallelMatchesGroupIdsByMatch
 
         {
           // Invariant: the matches are referenced only by their participating
           // sections.
-          val allMatchKeys =
-            sectionsAndTheirMatches.keySet union tinySectionsAndTheirMatches.keySet
+          val allMatchKeys = sectionsAndTheirMatches.keySet
 
           val allParticipatingSections =
-            (sectionsAndTheirMatches.values.toSet union tinySectionsAndTheirMatches.values.toSet)
+            sectionsAndTheirMatches.values.toSet
               .map {
                 case Match.AllSides(baseSection, leftSection, rightSection) =>
                   Set(baseSection, leftSection, rightSection)

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -29,7 +29,7 @@ import com.typesafe.scalalogging.StrictLogging
 import monocle.syntax.all.*
 
 import scala.annotation.tailrec
-import scala.collection.immutable.{MultiDict, SortedMap}
+import scala.collection.immutable.MultiDict
 import scala.collection.{IndexedSeqView, Searching}
 import scala.math.Ordering.Implicits.seqOrdering
 
@@ -54,10 +54,14 @@ object SectionedCodeExtension extends StrictLogging:
         .flatMap(sectionedCode.parallelMatchesGroupIdsByMatch.get)
 
       case class Block(
-          parallelMatchesGroupId: Option[ParallelMatchesGroupId],
+          parallelMatchesGroupId: ParallelMatchesGroupId,
           sectionsCoveredByGroup: IndexedSeq[Section[Element]]
       ):
         require(sectionsCoveredByGroup.nonEmpty)
+        sectionsCoveredByGroup.zip(sectionsCoveredByGroup.tail).foreach {
+          case (predecessor, successor) =>
+            require(predecessor.onePastEndOffset == successor.startOffset)
+        }
 
         // TODO: do we actually need the sections at all if we've got these? Why
         // not just store an offset interval?
@@ -75,15 +79,22 @@ object SectionedCodeExtension extends StrictLogging:
         import cats.syntax.foldable.toFoldableOps
 
         case class BlocksUnderConstruction(
-            pendingBlocks: Map[Option[ParallelMatchesGroupId], IndexedSeq[Section[Element]]], // TODO: map to offset intervals instead.
+            pendingBlocks: Map[ParallelMatchesGroupId, IndexedSeq[
+              Section[Element]
+            ]], // TODO: map to offset intervals instead.
+            deferredFillerSections: IndexedSeq[Section[Element]],
             groupIdsOfCompletedBlocks: Set[ParallelMatchesGroupId]
         )
 
         type BlocksUnderConstructionState[X] = State[BlocksUnderConstruction, X]
 
-        def buildBlocks(partialResult: IndexedSeq[Block],
-                        groupIdsFinishingConstruction: Set[Option[ParallelMatchesGroupId]],
-                        pendingBlocks: Map[Option[ParallelMatchesGroupId], IndexedSeq[Section[Element]]]) = {
+        def buildBlocks(
+            partialResult: IndexedSeq[Block],
+            groupIdsFinishingConstruction: Set[ParallelMatchesGroupId],
+            pendingBlocks: Map[ParallelMatchesGroupId, IndexedSeq[
+              Section[Element]
+            ]]
+        ) =
           partialResult ++ groupIdsFinishingConstruction.toSeq
             .map(groupId => Block(groupId, pendingBlocks(groupId)))
             .sortBy(block =>
@@ -93,57 +104,112 @@ object SectionedCodeExtension extends StrictLogging:
                 block.parallelMatchesGroupId
               )
             )
-        }
 
         val workflow =
-          for resultForAllButFinalBlocks <-
-            sections.foldM[BlocksUnderConstructionState, IndexedSeq[Block]](
-              IndexedSeq.empty
-            )((partialResult, section) =>
-              val groupIds = groupIdsOf(section)
-  
-              val liftedGroupIds: collection.Set[Option[ParallelMatchesGroupId]] =
-                if groupIds.nonEmpty then groupIds.map(Some.apply) else Set(None)
-  
-              for
-                BlocksUnderConstruction(pendingBlocks, groupIdsOfCompletedBlocks) <- State.get[BlocksUnderConstruction]
+          for
+            resultForAllButFinalBlocks <-
+              sections.foldM[BlocksUnderConstructionState, IndexedSeq[Block]](
+                IndexedSeq.empty
+              )((partialResult, section) =>
+                val groupIdsRelevantToSection = groupIdsOf(section)
 
-                _ = groupIds.foreach{ groupId =>
-                  require(!groupIdsOfCompletedBlocks.contains(groupId), s"Encountered group id: $groupId of a previously completed block again.")
-                }
+                for
+                  BlocksUnderConstruction(
+                    pendingBlocks,
+                    deferredFillerSections,
+                    groupIdsOfCompletedBlocks
+                  ) <- State.get[BlocksUnderConstruction]
 
-                blockGroupIds = pendingBlocks.keySet
-
-                groupIdsFinishingConstruction = blockGroupIds diff liftedGroupIds
-
-                updatedPendingBlocks = liftedGroupIds.foldLeft(
-                  pendingBlocks -- groupIdsFinishingConstruction
-                )((partialBlocksUnderConstruction, groupId) =>
-                  partialBlocksUnderConstruction.updatedWith(groupId) {
-                    case Some(existingBlockUnderConstruction) =>
-                      Some(existingBlockUnderConstruction :+ section)
-                    case None => Some(IndexedSeq(section))
+                  _ = groupIdsRelevantToSection.foreach { groupId =>
+                    require(
+                      !groupIdsOfCompletedBlocks.contains(groupId),
+                      s"Encountered group id: $groupId of a previously completed block again."
+                    )
                   }
-                )
 
-                _ <- State.set[BlocksUnderConstruction](
-                  BlocksUnderConstruction(updatedPendingBlocks, groupIdsOfCompletedBlocks union groupIdsFinishingConstruction.collect{case Some(groupId) => groupId})
-                )
-              yield buildBlocks(partialResult, groupIdsFinishingConstruction, pendingBlocks)
-              end for
-            )
+                  blockGroupIds = pendingBlocks.keySet
 
-            BlocksUnderConstruction(pendingBlocks, groupIdsOfCompletedBlocks) <- State.get[BlocksUnderConstruction]
+                  groupIdsFinishingConstruction =
+                    if groupIdsRelevantToSection.nonEmpty
+                    then blockGroupIds diff groupIdsRelevantToSection
+                    else
+                      // If the section is filler, then it may lie inside a
+                      // block that is yet to be finalised: so we can't claim
+                      // that any of the pending blocks are ready for
+                      // construction.
+                      Set.empty
+
+                  updatedPendingBlocks = groupIdsRelevantToSection.foldLeft(
+                    pendingBlocks -- groupIdsFinishingConstruction
+                  )((partialBlocksUnderConstruction, groupId) =>
+                    partialBlocksUnderConstruction.updatedWith(groupId) {
+                      case Some(existingBlockUnderConstruction) =>
+                        // A pending block that is being extended with a section
+                        // that is relevant to the block's group should claim
+                        // the deferred filler sections, because we know that
+                        // there was some other section beforehand that was also
+                        // relevant to the group; so the filler sections will be
+                        // bracketed inside the block.
+                        Some(
+                          existingBlockUnderConstruction ++ deferredFillerSections :+ section
+                        )
+                      case None =>
+                        // Starting a new pending block means that any deferred
+                        // filler sections are irrelevant, because they can't be
+                        // bracketed by sections in the new block.
+                        Some(IndexedSeq(section))
+                    }
+                  )
+
+                  updatedDeferredFillerSections =
+                    if groupIdsRelevantToSection.isEmpty
+                    then deferredFillerSections :+ section
+                    else IndexedSeq.empty
+
+                  _ <- State.set[BlocksUnderConstruction](
+                    BlocksUnderConstruction(
+                      updatedPendingBlocks,
+                      updatedDeferredFillerSections,
+                      groupIdsOfCompletedBlocks union groupIdsFinishingConstruction
+                    )
+                  )
+                yield buildBlocks(
+                  partialResult,
+                  groupIdsFinishingConstruction,
+                  pendingBlocks
+                )
+                end for
+              )
+
+            BlocksUnderConstruction(
+              pendingBlocks,
+              _,
+              groupIdsOfCompletedBlocks
+            ) <- State.get[BlocksUnderConstruction]
 
             groupIdsFinishingConstruction = pendingBlocks.keySet
-            
-          yield buildBlocks(resultForAllButFinalBlocks, groupIdsFinishingConstruction, pendingBlocks)
+          yield buildBlocks(
+            resultForAllButFinalBlocks,
+            groupIdsFinishingConstruction,
+            pendingBlocks
+          )
 
-        val result = workflow.runA(BlocksUnderConstruction(pendingBlocks = SortedMap.empty, groupIdsOfCompletedBlocks = Set.empty)).value
+        val result = workflow
+          .runA(
+            BlocksUnderConstruction(
+              pendingBlocks = Map.empty,
+              deferredFillerSections = IndexedSeq.empty,
+              groupIdsOfCompletedBlocks = Set.empty
+            )
+          )
+          .value
 
-        result.collect{case block @ Block(Some(groupId), _) => groupId -> block}.groupBy(_._1).foreach{
+        result.groupBy(_.parallelMatchesGroupId).foreach {
           case (groupId, potentialDuplicates) =>
-            require(1 == potentialDuplicates.size, s"Group id: $groupId occurs in multiple blocks: ${potentialDuplicates.map(_._2)}")
+            require(
+              1 == potentialDuplicates.size,
+              s"Group id: $groupId occurs in multiple blocks: $potentialDuplicates"
+            )
         }
 
         result
@@ -153,12 +219,7 @@ object SectionedCodeExtension extends StrictLogging:
       val leftBlocks  = blocksFrom(leftSections)
       val rightBlocks = blocksFrom(rightSections)
 
-      given Eq[Block] with
-        override def eqv(x: Block, y: Block): Boolean =
-          (x.parallelMatchesGroupId, y.parallelMatchesGroupId) match
-            case (Some(xGroupId), Some(yGroupId)) => Eq.eqv(xGroupId, yGroupId)
-            case _ => false // Not only are purely filler blocks unequal to those associated with groups, they are unequal to each other.
-      end given
+      given Eq[Block]    = Eq.by(_.parallelMatchesGroupId)
       given Sized[Block] = _.size
 
       val LongestCommonSubsequence(
@@ -179,9 +240,6 @@ object SectionedCodeExtension extends StrictLogging:
           .map(contribution =>
             contribution.element.parallelMatchesGroupId -> contribution
           )
-          .collect { case (Some(groupId), contribution) =>
-            groupId -> contribution
-          }
           .toMap
 
       val baseContributionKindsByGroupId = contributionKindsByGroupId(

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -139,7 +139,12 @@ object SectionedCodeExtension extends StrictLogging:
       val leftBlocks  = blocksFrom(leftSections)
       val rightBlocks = blocksFrom(rightSections)
 
-      given Eq[Block]    = Eq.by(_.parallelMatchesGroupId)  // TODO: what about if blocks from either side are filler blocks? Oops...
+      given Eq[Block] with
+        override def eqv(x: Block, y: Block): Boolean =
+          (x.parallelMatchesGroupId, y.parallelMatchesGroupId) match
+            case (Some(xGroupId), Some(yGroupId)) => Eq.eqv(xGroupId, yGroupId)
+            case _ => false // Not only are purely filler blocks unequal to those associated with groups, they are unequal to each other.
+      end given
       given Sized[Block] = _.size
 
       val LongestCommonSubsequence(

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -1,7 +1,6 @@
 package com.sageserpent.kineticmerge.core
 
 import cats.{Eq, Order}
-import com.sageserpent.kineticmerge.core.merge.mergeUsing
 import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 import com.sageserpent.kineticmerge.core.CoreMergeAlgebra.MultiSidedMergeResult
 import com.sageserpent.kineticmerge.core.FirstPassMergeResult.{
@@ -15,7 +14,7 @@ import com.sageserpent.kineticmerge.core.MoveDestinationsReport.{
   MoveEvaluation,
   OppositeSideAnchor
 }
-import com.sageserpent.kineticmerge.core.merge.of as mergeOf
+import com.sageserpent.kineticmerge.core.merge.{mergeUsing, of as mergeOf}
 import com.sageserpent.kineticmerge.{
   NoProgressRecording,
   ProgressRecording,
@@ -32,16 +31,23 @@ import scala.math.Ordering.Implicits.seqOrdering
 
 object SectionedCodeExtension extends StrictLogging:
 
-  /** Add merging capability to a [[SectionedCode]].
-    *
-    * Not sure exactly where this capability should be implemented - is it
-    * really a core part of the API for [[SectionedCode]]? Hence the extension
-    * as a temporary measure.
-    */
-
+  /** Add merging capability to a [[SectionedCode]]. */
   extension [Path, Element: Eq: Order](
       sectionedCode: SectionedCode[Path, Element]
   )
+    // TODO: need to add the phase one computation from
+    // https://github.com/sageserpent-open/kineticMerge/issues/321#issuecomment-4319818815.
+
+    private def longestCommonSubsequenceOf(
+        base: IndexedSeq[Section[Element]],
+        left: IndexedSeq[Section[Element]],
+        right: IndexedSeq[Section[Element]]
+    ): LongestCommonSubsequence[Section[Element]] =
+      // TODO: see
+      // https://github.com/sageserpent-open/kineticMerge/issues/321#issuecomment-4319818815,
+      // phase two.
+      ???
+
     def merge(using
         progressRecording: ProgressRecording
     ): (
@@ -270,14 +276,14 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  mergeOf(mergeAlgebra =
-                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                      FileDeletionContext.Left
-                    )
-                  )(
+                  longestCommonSubsequenceOf(
                     base = baseSections,
                     left = IndexedSeq.empty,
                     right = rightSections
+                  ).mergeUsing(mergeAlgebra =
+                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                      FileDeletionContext.Left
+                    )
                   )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
@@ -290,14 +296,14 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  mergeOf(mergeAlgebra =
-                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                      FileDeletionContext.Right
-                    )
-                  )(
+                  longestCommonSubsequenceOf(
                     base = baseSections,
                     left = leftSections,
                     right = IndexedSeq.empty
+                  ).mergeUsing(mergeAlgebra =
+                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                      FileDeletionContext.Right
+                    )
                   )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
@@ -315,14 +321,14 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  mergeOf(mergeAlgebra =
-                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                      FileDeletionContext.None
-                    )
-                  )(
+                  longestCommonSubsequenceOf(
                     base = optionalBaseSections.getOrElse(IndexedSeq.empty),
                     left = leftSections,
                     right = rightSections
+                  ).mergeUsing(mergeAlgebra =
+                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                      FileDeletionContext.None
+                    )
                   )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -132,7 +132,14 @@ object SectionedCodeExtension extends StrictLogging:
             
           yield buildBlocks(resultForAllButFinalBlocks, groupIdsFinishingConstruction, blocksUnderConstruction)
 
-        workflow.runA(SortedMap.empty).value
+        val result = workflow.runA(SortedMap.empty).value
+        
+        result.collect{case block @ Block(Some(groupId), _) => groupId -> block}.groupBy(_._1).foreach{
+          case (groupId, potentialDuplicates) =>
+            require(1 == potentialDuplicates.size, s"Group id: $groupId occurs in multiple blocks: ${potentialDuplicates.map(_._2)}")
+        }
+        
+        result
       end blocksFrom
 
       val baseBlocks  = blocksFrom(baseSections)

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -7,7 +7,11 @@ import com.sageserpent.kineticmerge.core.FirstPassMergeResult.{
   FileDeletionContext,
   Recording
 }
-import com.sageserpent.kineticmerge.core.LongestCommonSubsequence.Sized
+import com.sageserpent.kineticmerge.core.LongestCommonSubsequence.{
+  Contribution,
+  Sized
+}
+import com.sageserpent.kineticmerge.core.MatchAnalysis.ParallelMatchesGroupId
 import com.sageserpent.kineticmerge.core.MergeResult.given
 import com.sageserpent.kineticmerge.core.MoveDestinationsReport.{
   AnchoredMove,
@@ -25,20 +29,23 @@ import com.typesafe.scalalogging.StrictLogging
 import monocle.syntax.all.*
 
 import scala.annotation.tailrec
-import scala.collection.immutable.MultiDict
+import scala.collection.immutable.{MultiDict, SortedMap}
 import scala.collection.{IndexedSeqView, Searching}
 import scala.math.Ordering.Implicits.seqOrdering
 
 object SectionedCodeExtension extends StrictLogging:
+  given elementSized[X]: Sized[Section[X]] = _.size
 
   /** Add merging capability to a [[SectionedCode]]. */
   extension [Path, Element: Eq: Order](
       sectionedCode: SectionedCode[Path, Element]
   )
     private def longestCommonSubsequenceOf(
-        base: IndexedSeq[Section[Element]],
-        left: IndexedSeq[Section[Element]],
-        right: IndexedSeq[Section[Element]]
+        baseSections: IndexedSeq[Section[Element]],
+        leftSections: IndexedSeq[Section[Element]],
+        rightSections: IndexedSeq[Section[Element]]
+    )(using
+        progressRecording: ProgressRecording
     ): LongestCommonSubsequence[Section[Element]] =
       // PLAN:
       // 1. Form blocks composed of runs of contiguous sections that form one
@@ -82,7 +89,167 @@ object SectionedCodeExtension extends StrictLogging:
       // partially common contributions, filler sections being assigned
       // difference contributions.
 
-      ???
+      case class Block(
+          parallelMatchesGroupId: Option[ParallelMatchesGroupId],
+          sectionsCoveredByGroup: IndexedSeq[Section[Element]]
+      ):
+        require(sectionsCoveredByGroup.nonEmpty)
+
+        // TODO: do we actually need the sections at all if we've got these? Why
+        // not just store an offset interval?
+        def startOffset: Int = sectionsCoveredByGroup.head.startOffset
+
+        def onePastEndOffset: Int = sectionsCoveredByGroup.last.onePastEndOffset
+
+        def size: Int = sectionsCoveredByGroup.map(_.size).sum
+      end Block
+
+      def blocksFrom(
+          sections: Seq[Section[Element]]
+      ): IndexedSeq[Block] =
+        def groupIdsOf(
+            section: Section[Element]
+        ): collection.Set[ParallelMatchesGroupId] = sectionedCode
+          .matchesFor(section)
+          .flatMap(sectionedCode.parallelMatchesGroupIdsByMatch.get)
+
+        import cats.data.State
+        import cats.syntax.foldable.toFoldableOps
+
+        type BlocksUnderConstruction =
+          Map[Option[ParallelMatchesGroupId], IndexedSeq[
+            Section[Element]
+          ]] // TODO: map to offset intervals instead.
+        type BlocksUnderConstructionState[X] = State[BlocksUnderConstruction, X]
+
+        val workflow =
+          sections.foldM[BlocksUnderConstructionState, IndexedSeq[Block]](
+            IndexedSeq.empty
+          )((partialResult, section) =>
+            val groupIds = groupIdsOf(section)
+
+            val liftedGroupIds: collection.Set[Option[ParallelMatchesGroupId]] =
+              if groupIds.nonEmpty then groupIds.map(Some.apply) else Set(None)
+
+            for
+              blocksUnderConstruction <- State.get[BlocksUnderConstruction]
+
+              blockGroupIds = blocksUnderConstruction.keySet
+
+              groupIdsFinishingConstruction = blockGroupIds diff liftedGroupIds
+
+              updatedBlocksUnderConstruction = liftedGroupIds.foldLeft(
+                blocksUnderConstruction -- groupIdsFinishingConstruction
+              )((partialBlocksUnderConstruction, groupId) =>
+                partialBlocksUnderConstruction.updatedWith(groupId) {
+                  case Some(existingBlockUnderConstruction) =>
+                    Some(existingBlockUnderConstruction :+ section)
+                  case None => Some(IndexedSeq(section))
+                }
+              )
+
+              _ <- State.set[BlocksUnderConstruction](
+                updatedBlocksUnderConstruction
+              )
+            yield partialResult ++ groupIdsFinishingConstruction.toSeq
+              .map(groupId => Block(groupId, blocksUnderConstruction(groupId)))
+              .sortBy(block =>
+                (
+                  block.startOffset,
+                  block.onePastEndOffset,
+                  block.parallelMatchesGroupId
+                )
+              )
+            end for
+          )
+
+        workflow.runA(SortedMap.empty).value
+      end blocksFrom
+
+      val baseBlocks  = blocksFrom(baseSections)
+      val leftBlocks  = blocksFrom(leftSections)
+      val rightBlocks = blocksFrom(rightSections)
+
+      given Eq[Block]    = Eq.by(_.parallelMatchesGroupId)
+      given Sized[Block] = _.size
+
+      val LongestCommonSubsequence(
+        baseBlockContributions,
+        leftBlockContributions,
+        rightBlockContributions,
+        _,
+        _,
+        _,
+        _
+      ) =
+        LongestCommonSubsequence.of(baseBlocks, leftBlocks, rightBlocks)
+
+      def contributionKindsByGroupId(
+          blockContributions: IndexedSeq[Contribution[Block]]
+      ): Map[ParallelMatchesGroupId, Contribution[?]] =
+        blockContributions
+          .map(contribution =>
+            contribution.element.parallelMatchesGroupId -> contribution.ordinal
+          )
+          .collect { case (Some(groupId), ordinal) =>
+            groupId -> Contribution.fromOrdinal(ordinal)
+          }
+          .toMap
+
+      val baseContributionKindsByGroupId = contributionKindsByGroupId(
+        baseBlockContributions
+      )
+
+      val leftContributionKindsByGroupId = contributionKindsByGroupId(
+        leftBlockContributions
+      )
+
+      val rightContributionKindsByGroupId = contributionKindsByGroupId(
+        rightBlockContributions
+      )
+
+      given contributionRanking[X]: Ordering[Contribution[X]] with
+        override def compare(x: Contribution[X], y: Contribution[X]): Int =
+          (x, y) match
+            // A common contribution is the best.
+            case (Contribution.Common(_), Contribution.Common(_)) => 0
+            case (Contribution.Common(_), _)                      => 1
+            case (_, Contribution.Common(_))                      => -1
+
+            // A difference contribution is the worst.
+            case (Contribution.Difference(_), Contribution.Difference(_)) => 0
+            case (Contribution.Difference(_), _)                          => -1
+            case (_, Contribution.Difference(_))                          => 1
+
+            // What remains are the partially common contributions in comparison
+            // to each other: they are all just as good.
+            case _ => 0
+      end contributionRanking
+
+      def assignContributionUsing(
+          contributionKindsByGroupId: Map[ParallelMatchesGroupId, Contribution[
+            ?
+          ]]
+      )(section: Section[Element]): Contribution[Section[Element]] = ???
+
+      val baseSectionContributions = baseSections.map(
+        assignContributionUsing(baseContributionKindsByGroupId)
+      )
+
+      val leftSectionContributions = leftSections.map(
+        assignContributionUsing(leftContributionKindsByGroupId)
+      )
+
+      val rightSectionContributions = rightSections.map(
+        assignContributionUsing(rightContributionKindsByGroupId)
+      )
+
+      LongestCommonSubsequence.apply(
+        baseSectionContributions,
+        leftSectionContributions,
+        rightSectionContributions
+      )
+    end longestCommonSubsequenceOf
 
     def merge(using
         progressRecording: ProgressRecording
@@ -112,8 +279,6 @@ object SectionedCodeExtension extends StrictLogging:
             .eqv(lhs.content, rhs.content)
         end eqv
       end given
-
-      given Sized[Section[Element]] = _.size
 
       extension [Item: Sized](multiSided: MultiSided[Item])
         private def size: Int =
@@ -313,9 +478,9 @@ object SectionedCodeExtension extends StrictLogging:
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
                   longestCommonSubsequenceOf(
-                    base = baseSections,
-                    left = IndexedSeq.empty,
-                    right = rightSections
+                    baseSections = baseSections,
+                    leftSections = IndexedSeq.empty,
+                    rightSections = rightSections
                   ).mergeUsing(mergeAlgebra =
                     FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
                       FileDeletionContext.Left
@@ -333,9 +498,9 @@ object SectionedCodeExtension extends StrictLogging:
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
                   longestCommonSubsequenceOf(
-                    base = baseSections,
-                    left = leftSections,
-                    right = IndexedSeq.empty
+                    baseSections = baseSections,
+                    leftSections = leftSections,
+                    rightSections = IndexedSeq.empty
                   ).mergeUsing(mergeAlgebra =
                     FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
                       FileDeletionContext.Right
@@ -358,9 +523,10 @@ object SectionedCodeExtension extends StrictLogging:
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
                   longestCommonSubsequenceOf(
-                    base = optionalBaseSections.getOrElse(IndexedSeq.empty),
-                    left = leftSections,
-                    right = rightSections
+                    baseSections =
+                      optionalBaseSections.getOrElse(IndexedSeq.empty),
+                    leftSections = leftSections,
+                    rightSections = rightSections
                   ).mergeUsing(mergeAlgebra =
                     FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
                       FileDeletionContext.None

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -80,46 +80,57 @@ object SectionedCodeExtension extends StrictLogging:
           ]] // TODO: map to offset intervals instead.
         type BlocksUnderConstructionState[X] = State[BlocksUnderConstruction, X]
 
+        def buildBlocks(partialResult: IndexedSeq[Block], groupIdsFinishingConstruction: Set[Option[ParallelMatchesGroupId]], blocksUnderConstruction: BlocksUnderConstruction) = {
+          partialResult ++ groupIdsFinishingConstruction.toSeq
+            .map(groupId => Block(groupId, blocksUnderConstruction(groupId)))
+            .sortBy(block =>
+              (
+                block.startOffset,
+                block.onePastEndOffset,
+                block.parallelMatchesGroupId
+              )
+            )
+        }
+
         val workflow =
-          sections.foldM[BlocksUnderConstructionState, IndexedSeq[Block]](
-            IndexedSeq.empty
-          )((partialResult, section) =>
-            val groupIds = groupIdsOf(section)
-
-            val liftedGroupIds: collection.Set[Option[ParallelMatchesGroupId]] =
-              if groupIds.nonEmpty then groupIds.map(Some.apply) else Set(None)
-
-            for
-              blocksUnderConstruction <- State.get[BlocksUnderConstruction]
-
-              blockGroupIds = blocksUnderConstruction.keySet
-
-              groupIdsFinishingConstruction = blockGroupIds diff liftedGroupIds
-
-              updatedBlocksUnderConstruction = liftedGroupIds.foldLeft(
-                blocksUnderConstruction -- groupIdsFinishingConstruction
-              )((partialBlocksUnderConstruction, groupId) =>
-                partialBlocksUnderConstruction.updatedWith(groupId) {
-                  case Some(existingBlockUnderConstruction) =>
-                    Some(existingBlockUnderConstruction :+ section)
-                  case None => Some(IndexedSeq(section))
-                }
-              )
-
-              _ <- State.set[BlocksUnderConstruction](
-                updatedBlocksUnderConstruction
-              )
-            yield partialResult ++ groupIdsFinishingConstruction.toSeq
-              .map(groupId => Block(groupId, blocksUnderConstruction(groupId)))
-              .sortBy(block =>
-                (
-                  block.startOffset,
-                  block.onePastEndOffset,
-                  block.parallelMatchesGroupId
+          for resultForAlButFinalBlocks <-
+            sections.foldM[BlocksUnderConstructionState, IndexedSeq[Block]](
+              IndexedSeq.empty
+            )((partialResult, section) =>
+              val groupIds = groupIdsOf(section)
+  
+              val liftedGroupIds: collection.Set[Option[ParallelMatchesGroupId]] =
+                if groupIds.nonEmpty then groupIds.map(Some.apply) else Set(None)
+  
+              for
+                blocksUnderConstruction <- State.get[BlocksUnderConstruction]
+  
+                blockGroupIds = blocksUnderConstruction.keySet
+  
+                groupIdsFinishingConstruction = blockGroupIds diff liftedGroupIds
+  
+                updatedBlocksUnderConstruction = liftedGroupIds.foldLeft(
+                  blocksUnderConstruction -- groupIdsFinishingConstruction
+                )((partialBlocksUnderConstruction, groupId) =>
+                  partialBlocksUnderConstruction.updatedWith(groupId) {
+                    case Some(existingBlockUnderConstruction) =>
+                      Some(existingBlockUnderConstruction :+ section)
+                    case None => Some(IndexedSeq(section))
+                  }
                 )
-              )
-            end for
-          )
+  
+                _ <- State.set[BlocksUnderConstruction](
+                  updatedBlocksUnderConstruction
+                )
+              yield buildBlocks(partialResult, groupIdsFinishingConstruction, blocksUnderConstruction)
+              end for
+            )
+
+            blocksUnderConstruction <- State.get[BlocksUnderConstruction]
+
+            groupIdsFinishingConstruction = blocksUnderConstruction.keySet
+            
+          yield buildBlocks(resultForAlButFinalBlocks, groupIdsFinishingConstruction, blocksUnderConstruction)
 
         workflow.runA(SortedMap.empty).value
       end blocksFrom
@@ -128,7 +139,7 @@ object SectionedCodeExtension extends StrictLogging:
       val leftBlocks  = blocksFrom(leftSections)
       val rightBlocks = blocksFrom(rightSections)
 
-      given Eq[Block]    = Eq.by(_.parallelMatchesGroupId)
+      given Eq[Block]    = Eq.by(_.parallelMatchesGroupId)  // TODO: what about if blocks from either side are filler blocks? Oops...
       given Sized[Block] = _.size
 
       val LongestCommonSubsequence(

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -189,10 +189,10 @@ object SectionedCodeExtension extends StrictLogging:
       ): Map[ParallelMatchesGroupId, Contribution[?]] =
         blockContributions
           .map(contribution =>
-            contribution.element.parallelMatchesGroupId -> contribution.ordinal
+            contribution.element.parallelMatchesGroupId -> contribution
           )
-          .collect { case (Some(groupId), ordinal) =>
-            groupId -> Contribution.fromOrdinal(ordinal)
+          .collect { case (Some(groupId), contribution) =>
+            groupId -> contribution // Lose the precise type here, as we don't care about the payload anyway.
           }
           .toMap
 
@@ -208,8 +208,8 @@ object SectionedCodeExtension extends StrictLogging:
         rightBlockContributions
       )
 
-      val contributionRanking: Ordering[Contribution[Any]] =
-        (x: Contribution[Any], y: Contribution[Any]) =>
+      object contributionRanking extends Ordering[Contribution[Any]]:
+        override def compare(x: Contribution[Any], y: Contribution[Any]): Int =
           (x, y) match
             // A common contribution is the best.
             case (Contribution.Common(_), Contribution.Common(_)) => 0
@@ -234,12 +234,13 @@ object SectionedCodeExtension extends StrictLogging:
         val groupIds = groupIdsOf(section)
 
         val contributions = groupIds.toSeq
-          .map(contributionKindsByGroupId)
+          .flatMap(contributionKindsByGroupId.get)
           .sorted(
-            contributionRanking.reversed.asInstanceOf[Ordering[Contribution[?]]]
+            contributionRanking.reverse.asInstanceOf[Ordering[Contribution[?]]]
           )
 
-        val bestRankedContribution = contributions.head
+        val bestRankedContribution =
+          contributions.headOption.getOrElse(Contribution.Difference(null))
 
         val onePastTheBestRankedContributions = contributions.indexWhere(
           0 < contributionRanking

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -89,6 +89,12 @@ object SectionedCodeExtension extends StrictLogging:
       // partially common contributions, filler sections being assigned
       // difference contributions.
 
+      def groupIdsOf(
+          section: Section[Element]
+      ): collection.Set[ParallelMatchesGroupId] = sectionedCode
+        .matchesFor(section)
+        .flatMap(sectionedCode.parallelMatchesGroupIdsByMatch.get)
+
       case class Block(
           parallelMatchesGroupId: Option[ParallelMatchesGroupId],
           sectionsCoveredByGroup: IndexedSeq[Section[Element]]
@@ -107,12 +113,6 @@ object SectionedCodeExtension extends StrictLogging:
       def blocksFrom(
           sections: Seq[Section[Element]]
       ): IndexedSeq[Block] =
-        def groupIdsOf(
-            section: Section[Element]
-        ): collection.Set[ParallelMatchesGroupId] = sectionedCode
-          .matchesFor(section)
-          .flatMap(sectionedCode.parallelMatchesGroupIdsByMatch.get)
-
         import cats.data.State
         import cats.syntax.foldable.toFoldableOps
 
@@ -208,8 +208,8 @@ object SectionedCodeExtension extends StrictLogging:
         rightBlockContributions
       )
 
-      given contributionRanking[X]: Ordering[Contribution[X]] with
-        override def compare(x: Contribution[X], y: Contribution[X]): Int =
+      val contributionRanking: Ordering[Contribution[Any]] =
+        (x: Contribution[Any], y: Contribution[Any]) =>
           (x, y) match
             // A common contribution is the best.
             case (Contribution.Common(_), Contribution.Common(_)) => 0
@@ -230,7 +230,32 @@ object SectionedCodeExtension extends StrictLogging:
           contributionKindsByGroupId: Map[ParallelMatchesGroupId, Contribution[
             ?
           ]]
-      )(section: Section[Element]): Contribution[Section[Element]] = ???
+      )(section: Section[Element]): Contribution[Section[Element]] =
+        val groupIds = groupIdsOf(section)
+
+        val contributions = groupIds.toSeq
+          .map(contributionKindsByGroupId)
+          .sorted(
+            contributionRanking.reversed.asInstanceOf[Ordering[Contribution[?]]]
+          )
+
+        val bestRankedContribution = contributions.head
+
+        val onePastTheBestRankedContributions = contributions.indexWhere(
+          0 < contributionRanking
+            .asInstanceOf[Ordering[Contribution[?]]]
+            .compare(_, bestRankedContribution)
+        )
+
+        val moreThanOneBestRankedContribution =
+          1 < onePastTheBestRankedContributions
+
+        if moreThanOneBestRankedContribution then
+          Contribution.Difference(section)
+        else bestRankedContribution.constructLikeness(section)
+        end if
+
+      end assignContributionUsing
 
       val baseSectionContributions = baseSections.map(
         assignContributionUsing(baseContributionKindsByGroupId)

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -47,48 +47,6 @@ object SectionedCodeExtension extends StrictLogging:
     )(using
         progressRecording: ProgressRecording
     ): LongestCommonSubsequence[Section[Element]] =
-      // PLAN:
-      // 1. Form blocks composed of runs of contiguous sections that form one
-      // side of a group of parallel matches, including any filler sections
-      // between the matched sections. A block is associated with at most one
-      // group is, so if there are several moves that diverge from or converge
-      // from the same run of sections, then this is represented by multiple
-      // blocks that happen to have the same run of sections but differing group
-      // ids. If filler sections are not covered by one side of a group, they
-      // are placed in their own block that has no group id. Blocks on the same
-      // side are sized by the content they cover and can be compared for
-      // equality using the group id, and are ordered by a triple of (start
-      // offset, the negative of the block size, group id).
-      // 2. The dynamic programming LCS algorithm is used to form an LCS at the
-      // block level, starting with sequences of blocks from each side that are
-      // arranged according to their intrinsic ordering.
-      // 3. Because sections can be shared between multiple blocks on the same
-      // side due to diverging / converging moves, overlapping of blocks and
-      // nesting of blocks (these are all feasible and indeed desirable
-      // situations in terms of capturing code motion accurately), it is
-      // necessary to clean up the block-level LCS. Looking at each side of the
-      // block-level LCS, if a run of adjacent blocks is found that a) have some
-      // or all sections in common and b) consider the blocks to be part of a
-      // common or partially common contribution to the LCS, then the group ids
-      // of the blocks are added to an exclusion set. This is intended to stop a
-      // single section from being repeated on one side of the section-level LCS
-      // expansion later on. <<<---- TODO: this is too draconian, as it excludes
-      // *everything* covered by the group: if two blocks have a partial
-      // overlap, it should only be the shared sections and their corresponding
-      // matched sections on the other side(s) that are excluded. Nevertheless
-      // it will do as a start...
-      // 4. The blocks from each side of the block-level LCS are expanded into a
-      // section-level LCS. Each block's group id is examined - if missing, the
-      // block's sections are assigned difference contributions, if present but
-      // the group id is excluded, then again the block's sections are assigned
-      // difference contributions. Otherwise, the block uses its own
-      // contribution
-      // to guide the assignation of the sections, so a common contributed block
-      // assigns its sections participating on all-sides matches common
-      // contributions, but assigns sections participating in pairwise matches
-      // partially common contributions, filler sections being assigned
-      // difference contributions.
-
       def groupIdsOf(
           section: Section[Element]
       ): collection.Set[ParallelMatchesGroupId] = sectionedCode
@@ -186,13 +144,13 @@ object SectionedCodeExtension extends StrictLogging:
 
       def contributionKindsByGroupId(
           blockContributions: IndexedSeq[Contribution[Block]]
-      ): Map[ParallelMatchesGroupId, Contribution[?]] =
+      ): Map[ParallelMatchesGroupId, Contribution[Block]] =
         blockContributions
           .map(contribution =>
             contribution.element.parallelMatchesGroupId -> contribution
           )
           .collect { case (Some(groupId), contribution) =>
-            groupId -> contribution // Lose the precise type here, as we don't care about the payload anyway.
+            groupId -> contribution
           }
           .toMap
 
@@ -208,8 +166,11 @@ object SectionedCodeExtension extends StrictLogging:
         rightBlockContributions
       )
 
-      object contributionRanking extends Ordering[Contribution[Any]]:
-        override def compare(x: Contribution[Any], y: Contribution[Any]): Int =
+      object contributionRanking extends Ordering[Contribution[Block]]:
+        override def compare(
+            x: Contribution[Block],
+            y: Contribution[Block]
+        ): Int =
           (x, y) match
             // A common contribution is the best.
             case (Contribution.Common(_), Contribution.Common(_)) => 0
@@ -228,7 +189,7 @@ object SectionedCodeExtension extends StrictLogging:
 
       def assignContributionUsing(
           contributionKindsByGroupId: Map[ParallelMatchesGroupId, Contribution[
-            ?
+            Block
           ]]
       )(section: Section[Element]): Contribution[Section[Element]] =
         val groupIds = groupIdsOf(section)
@@ -236,7 +197,7 @@ object SectionedCodeExtension extends StrictLogging:
         val contributions = groupIds.toSeq
           .flatMap(contributionKindsByGroupId.get)
           .sorted(
-            contributionRanking.reverse.asInstanceOf[Ordering[Contribution[?]]]
+            contributionRanking.reverse
           )
 
         val bestRankedContribution =
@@ -244,7 +205,6 @@ object SectionedCodeExtension extends StrictLogging:
 
         val onePastTheBestRankedContributions = contributions.indexWhere(
           0 < contributionRanking
-            .asInstanceOf[Ordering[Contribution[?]]]
             .compare(_, bestRankedContribution)
         )
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -74,15 +74,18 @@ object SectionedCodeExtension extends StrictLogging:
         import cats.data.State
         import cats.syntax.foldable.toFoldableOps
 
-        type BlocksUnderConstruction =
-          Map[Option[ParallelMatchesGroupId], IndexedSeq[
-            Section[Element]
-          ]] // TODO: map to offset intervals instead.
+        case class BlocksUnderConstruction(
+            pendingBlocks: Map[Option[ParallelMatchesGroupId], IndexedSeq[Section[Element]]], // TODO: map to offset intervals instead.
+            groupIdsOfCompletedBlocks: Set[ParallelMatchesGroupId]
+        )
+
         type BlocksUnderConstructionState[X] = State[BlocksUnderConstruction, X]
 
-        def buildBlocks(partialResult: IndexedSeq[Block], groupIdsFinishingConstruction: Set[Option[ParallelMatchesGroupId]], blocksUnderConstruction: BlocksUnderConstruction) = {
+        def buildBlocks(partialResult: IndexedSeq[Block],
+                        groupIdsFinishingConstruction: Set[Option[ParallelMatchesGroupId]],
+                        pendingBlocks: Map[Option[ParallelMatchesGroupId], IndexedSeq[Section[Element]]]) = {
           partialResult ++ groupIdsFinishingConstruction.toSeq
-            .map(groupId => Block(groupId, blocksUnderConstruction(groupId)))
+            .map(groupId => Block(groupId, pendingBlocks(groupId)))
             .sortBy(block =>
               (
                 block.startOffset,
@@ -93,7 +96,7 @@ object SectionedCodeExtension extends StrictLogging:
         }
 
         val workflow =
-          for resultForAlButFinalBlocks <-
+          for resultForAllButFinalBlocks <-
             sections.foldM[BlocksUnderConstructionState, IndexedSeq[Block]](
               IndexedSeq.empty
             )((partialResult, section) =>
@@ -103,14 +106,18 @@ object SectionedCodeExtension extends StrictLogging:
                 if groupIds.nonEmpty then groupIds.map(Some.apply) else Set(None)
   
               for
-                blocksUnderConstruction <- State.get[BlocksUnderConstruction]
-  
-                blockGroupIds = blocksUnderConstruction.keySet
-  
+                BlocksUnderConstruction(pendingBlocks, groupIdsOfCompletedBlocks) <- State.get[BlocksUnderConstruction]
+                
+                _ = groupIds.foreach{ groupId =>
+                  require(!groupIdsOfCompletedBlocks.contains(groupId), s"Encountered group id: $groupId of a previously completed block again.")
+                }
+
+                blockGroupIds = pendingBlocks.keySet
+
                 groupIdsFinishingConstruction = blockGroupIds diff liftedGroupIds
-  
-                updatedBlocksUnderConstruction = liftedGroupIds.foldLeft(
-                  blocksUnderConstruction -- groupIdsFinishingConstruction
+
+                updatedPendingBlocks = liftedGroupIds.foldLeft(
+                  pendingBlocks -- groupIdsFinishingConstruction
                 )((partialBlocksUnderConstruction, groupId) =>
                   partialBlocksUnderConstruction.updatedWith(groupId) {
                     case Some(existingBlockUnderConstruction) =>
@@ -118,21 +125,21 @@ object SectionedCodeExtension extends StrictLogging:
                     case None => Some(IndexedSeq(section))
                   }
                 )
-  
+
                 _ <- State.set[BlocksUnderConstruction](
-                  updatedBlocksUnderConstruction
+                  BlocksUnderConstruction(updatedPendingBlocks, groupIdsOfCompletedBlocks union groupIdsFinishingConstruction.collect{case Some(groupId) => groupId})
                 )
-              yield buildBlocks(partialResult, groupIdsFinishingConstruction, blocksUnderConstruction)
+              yield buildBlocks(partialResult, groupIdsFinishingConstruction, pendingBlocks)
               end for
             )
 
-            blocksUnderConstruction <- State.get[BlocksUnderConstruction]
+            BlocksUnderConstruction(pendingBlocks, groupIdsOfCompletedBlocks) <- State.get[BlocksUnderConstruction]
 
-            groupIdsFinishingConstruction = blocksUnderConstruction.keySet
+            groupIdsFinishingConstruction = pendingBlocks.keySet
             
-          yield buildBlocks(resultForAlButFinalBlocks, groupIdsFinishingConstruction, blocksUnderConstruction)
+          yield buildBlocks(resultForAllButFinalBlocks, groupIdsFinishingConstruction, pendingBlocks)
 
-        workflow.runA(SortedMap.empty).value
+        workflow.runA(BlocksUnderConstruction(pendingBlocks = SortedMap.empty, groupIdsOfCompletedBlocks = Set.empty)).value
       end blocksFrom
 
       val baseBlocks  = blocksFrom(baseSections)

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -93,7 +93,7 @@ object SectionedCodeExtension extends StrictLogging:
         }
 
         val workflow =
-          for resultForAlButFinalBlocks <-
+          for resultForAllButFinalBlocks <-
             sections.foldM[BlocksUnderConstructionState, IndexedSeq[Block]](
               IndexedSeq.empty
             )((partialResult, section) =>
@@ -130,7 +130,7 @@ object SectionedCodeExtension extends StrictLogging:
 
             groupIdsFinishingConstruction = blocksUnderConstruction.keySet
             
-          yield buildBlocks(resultForAlButFinalBlocks, groupIdsFinishingConstruction, blocksUnderConstruction)
+          yield buildBlocks(resultForAllButFinalBlocks, groupIdsFinishingConstruction, blocksUnderConstruction)
 
         workflow.runA(SortedMap.empty).value
       end blocksFrom

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -292,7 +292,7 @@ object SectionedCodeExtension extends StrictLogging:
           contributions.headOption.getOrElse(Contribution.Difference(null))
 
         val onePastTheBestRankedContributions = contributions.indexWhere(
-          0 < contributionRanking
+          0 > contributionRanking
             .compare(_, bestRankedContribution)
         )
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -2,6 +2,7 @@ package com.sageserpent.kineticmerge.core
 
 import cats.{Eq, Order}
 import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
+import com.sageserpent.kineticmerge.core.merge.mergeUsing
 import com.sageserpent.kineticmerge.core.CoreMergeAlgebra.MultiSidedMergeResult
 import com.sageserpent.kineticmerge.core.FirstPassMergeResult.{
   FileDeletionContext,
@@ -269,15 +270,13 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  mergeOf(mergeAlgebra =
-                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                      FileDeletionContext.Left
+                  sectionedCode
+                    .lcsFor(path)
+                    .mergeUsing(
+                      FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                        FileDeletionContext.Left
+                      )
                     )
-                  )(
-                    base = baseSections,
-                    left = IndexedSeq.empty,
-                    right = rightSections
-                  )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
               case (Some(baseSections), Some(leftSections), None) =>
@@ -289,15 +288,13 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  mergeOf(mergeAlgebra =
-                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                      FileDeletionContext.Right
+                  sectionedCode
+                    .lcsFor(path)
+                    .mergeUsing(
+                      FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                        FileDeletionContext.Right
+                      )
                     )
-                  )(
-                    base = baseSections,
-                    left = leftSections,
-                    right = IndexedSeq.empty
-                  )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
               case (
@@ -314,15 +311,13 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  mergeOf(mergeAlgebra =
-                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                      FileDeletionContext.None
+                  sectionedCode
+                    .lcsFor(path)
+                    .mergeUsing(
+                      FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                        FileDeletionContext.None
+                      )
                     )
-                  )(
-                    base = optionalBaseSections.getOrElse(IndexedSeq.empty),
-                    left = leftSections,
-                    right = rightSections
-                  )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -35,17 +35,53 @@ object SectionedCodeExtension extends StrictLogging:
   extension [Path, Element: Eq: Order](
       sectionedCode: SectionedCode[Path, Element]
   )
-    // TODO: need to add the phase one computation from
-    // https://github.com/sageserpent-open/kineticMerge/issues/321#issuecomment-4319818815.
-
     private def longestCommonSubsequenceOf(
         base: IndexedSeq[Section[Element]],
         left: IndexedSeq[Section[Element]],
         right: IndexedSeq[Section[Element]]
     ): LongestCommonSubsequence[Section[Element]] =
-      // TODO: see
-      // https://github.com/sageserpent-open/kineticMerge/issues/321#issuecomment-4319818815,
-      // phase two.
+      // PLAN:
+      // 1. Form blocks composed of runs of contiguous sections that form one
+      // side of a group of parallel matches, including any filler sections
+      // between the matched sections. A block is associated with at most one
+      // group is, so if there are several moves that diverge from or converge
+      // from the same run of sections, then this is represented by multiple
+      // blocks that happen to have the same run of sections but differing group
+      // ids. If filler sections are not covered by one side of a group, they
+      // are placed in their own block that has no group id. Blocks on the same
+      // side are sized by the content they cover and can be compared for
+      // equality using the group id, and are ordered by a triple of (start
+      // offset, the negative of the block size, group id).
+      // 2. The dynamic programming LCS algorithm is used to form an LCS at the
+      // block level, starting with sequences of blocks from each side that are
+      // arranged according to their intrinsic ordering.
+      // 3. Because sections can be shared between multiple blocks on the same
+      // side due to diverging / converging moves, overlapping of blocks and
+      // nesting of blocks (these are all feasible and indeed desirable
+      // situations in terms of capturing code motion accurately), it is
+      // necessary to clean up the block-level LCS. Looking at each side of the
+      // block-level LCS, if a run of adjacent blocks is found that a) have some
+      // or all sections in common and b) consider the blocks to be part of a
+      // common or partially common contribution to the LCS, then the group ids
+      // of the blocks are added to an exclusion set. This is intended to stop a
+      // single section from being repeated on one side of the section-level LCS
+      // expansion later on. <<<---- TODO: this is too draconian, as it excludes
+      // *everything* covered by the group: if two blocks have a partial
+      // overlap, it should only be the shared sections and their corresponding
+      // matched sections on the other side(s) that are excluded. Nevertheless
+      // it will do as a start...
+      // 4. The blocks from each side of the block-level LCS are expanded into a
+      // section-level LCS. Each block's group id is examined - if missing, the
+      // block's sections are assigned difference contributions, if present but
+      // the group id is excluded, then again the block's sections are assigned
+      // difference contributions. Otherwise, the block uses its own
+      // contribution
+      // to guide the assignation of the sections, so a common contributed block
+      // assigns its sections participating on all-sides matches common
+      // contributions, but assigns sections participating in pairwise matches
+      // partially common contributions, filler sections being assigned
+      // difference contributions.
+
       ???
 
     def merge(using

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -1,8 +1,8 @@
 package com.sageserpent.kineticmerge.core
 
 import cats.{Eq, Order}
-import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 import com.sageserpent.kineticmerge.core.merge.mergeUsing
+import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 import com.sageserpent.kineticmerge.core.CoreMergeAlgebra.MultiSidedMergeResult
 import com.sageserpent.kineticmerge.core.FirstPassMergeResult.{
   FileDeletionContext,
@@ -270,13 +270,15 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  sectionedCode
-                    .lcsFor(path)
-                    .mergeUsing(
-                      FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                        FileDeletionContext.Left
-                      )
+                  mergeOf(mergeAlgebra =
+                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                      FileDeletionContext.Left
                     )
+                  )(
+                    base = baseSections,
+                    left = IndexedSeq.empty,
+                    right = rightSections
+                  )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
               case (Some(baseSections), Some(leftSections), None) =>
@@ -288,13 +290,15 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  sectionedCode
-                    .lcsFor(path)
-                    .mergeUsing(
-                      FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                        FileDeletionContext.Right
-                      )
+                  mergeOf(mergeAlgebra =
+                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                      FileDeletionContext.Right
                     )
+                  )(
+                    base = baseSections,
+                    left = leftSections,
+                    right = IndexedSeq.empty
+                  )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
               case (
@@ -311,13 +315,15 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  sectionedCode
-                    .lcsFor(path)
-                    .mergeUsing(
-                      FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                        FileDeletionContext.None
-                      )
+                  mergeOf(mergeAlgebra =
+                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                      FileDeletionContext.None
                     )
+                  )(
+                    base = optionalBaseSections.getOrElse(IndexedSeq.empty),
+                    left = leftSections,
+                    right = rightSections
+                  )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -34,8 +34,6 @@ import scala.collection.{IndexedSeqView, Searching}
 import scala.math.Ordering.Implicits.seqOrdering
 
 object SectionedCodeExtension extends StrictLogging:
-  given elementSized[X]: Sized[Section[X]] = _.size
-
   /** Add merging capability to a [[SectionedCode]]. */
   extension [Path, Element: Eq: Order](
       sectionedCode: SectionedCode[Path, Element]
@@ -45,7 +43,9 @@ object SectionedCodeExtension extends StrictLogging:
         leftSections: IndexedSeq[Section[Element]],
         rightSections: IndexedSeq[Section[Element]]
     )(using
-        progressRecording: ProgressRecording
+        progressRecording: ProgressRecording,
+        sectionEq: Eq[Section[Element]],
+        sectionSized: Sized[Section[Element]]
     ): LongestCommonSubsequence[Section[Element]] =
       def groupIdsOf(
           section: Section[Element]
@@ -310,6 +310,8 @@ object SectionedCodeExtension extends StrictLogging:
         MoveDestinationsReport[Section[Element]]
     ) =
       import sectionedCode.matchesFor
+
+      given sectionSized[X]: Sized[Section[X]] = _.size
 
       given Eq[Section[Element]] with
         /** This is most definitely *not* [[Section.equals]] - we want to use

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -82,8 +82,7 @@ object SectionedCodeExtension extends StrictLogging:
             pendingBlocks: Map[ParallelMatchesGroupId, IndexedSeq[
               Section[Element]
             ]], // TODO: map to offset intervals instead.
-            deferredFillerSections: IndexedSeq[Section[Element]],
-            groupIdsOfCompletedBlocks: Set[ParallelMatchesGroupId]
+            deferredFillerSections: IndexedSeq[Section[Element]]
         )
 
         type BlocksUnderConstructionState[X] = State[BlocksUnderConstruction, X]
@@ -116,16 +115,8 @@ object SectionedCodeExtension extends StrictLogging:
                 for
                   BlocksUnderConstruction(
                     pendingBlocks,
-                    deferredFillerSections,
-                    groupIdsOfCompletedBlocks
+                    deferredFillerSections
                   ) <- State.get[BlocksUnderConstruction]
-
-                  _ = groupIdsRelevantToSection.foreach { groupId =>
-                    require(
-                      !groupIdsOfCompletedBlocks.contains(groupId),
-                      s"Encountered group id: $groupId of a previously completed block again."
-                    )
-                  }
 
                   blockGroupIds = pendingBlocks.keySet
 
@@ -169,8 +160,7 @@ object SectionedCodeExtension extends StrictLogging:
                   _ <- State.set[BlocksUnderConstruction](
                     BlocksUnderConstruction(
                       updatedPendingBlocks,
-                      updatedDeferredFillerSections,
-                      groupIdsOfCompletedBlocks union groupIdsFinishingConstruction
+                      updatedDeferredFillerSections
                     )
                   )
                 yield buildBlocks(
@@ -181,11 +171,8 @@ object SectionedCodeExtension extends StrictLogging:
                 end for
               )
 
-            BlocksUnderConstruction(
-              pendingBlocks,
-              _,
-              groupIdsOfCompletedBlocks
-            ) <- State.get[BlocksUnderConstruction]
+            BlocksUnderConstruction(pendingBlocks, _) <- State
+              .get[BlocksUnderConstruction]
 
             groupIdsFinishingConstruction = pendingBlocks.keySet
           yield buildBlocks(
@@ -198,19 +185,10 @@ object SectionedCodeExtension extends StrictLogging:
           .runA(
             BlocksUnderConstruction(
               pendingBlocks = Map.empty,
-              deferredFillerSections = IndexedSeq.empty,
-              groupIdsOfCompletedBlocks = Set.empty
+              deferredFillerSections = IndexedSeq.empty
             )
           )
           .value
-
-        result.groupBy(_.parallelMatchesGroupId).foreach {
-          case (groupId, potentialDuplicates) =>
-            require(
-              1 == potentialDuplicates.size,
-              s"Group id: $groupId occurs in multiple blocks: $potentialDuplicates"
-            )
-        }
 
         result
       end blocksFrom

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -82,7 +82,8 @@ object SectionedCodeExtension extends StrictLogging:
             pendingBlocks: Map[ParallelMatchesGroupId, IndexedSeq[
               Section[Element]
             ]], // TODO: map to offset intervals instead.
-            deferredFillerSections: IndexedSeq[Section[Element]]
+            deferredFillerSections: IndexedSeq[Section[Element]],
+            groupIdsOfCompletedBlocks: Set[ParallelMatchesGroupId]
         )
 
         type BlocksUnderConstructionState[X] = State[BlocksUnderConstruction, X]
@@ -115,8 +116,16 @@ object SectionedCodeExtension extends StrictLogging:
                 for
                   BlocksUnderConstruction(
                     pendingBlocks,
-                    deferredFillerSections
+                    deferredFillerSections,
+                    groupIdsOfCompletedBlocks
                   ) <- State.get[BlocksUnderConstruction]
+
+                  _ = groupIdsRelevantToSection.foreach { groupId =>
+                    require(
+                      !groupIdsOfCompletedBlocks.contains(groupId),
+                      s"Encountered group id: $groupId of a previously completed block again."
+                    )
+                  }
 
                   blockGroupIds = pendingBlocks.keySet
 
@@ -160,7 +169,8 @@ object SectionedCodeExtension extends StrictLogging:
                   _ <- State.set[BlocksUnderConstruction](
                     BlocksUnderConstruction(
                       updatedPendingBlocks,
-                      updatedDeferredFillerSections
+                      updatedDeferredFillerSections,
+                      groupIdsOfCompletedBlocks union groupIdsFinishingConstruction
                     )
                   )
                 yield buildBlocks(
@@ -171,8 +181,11 @@ object SectionedCodeExtension extends StrictLogging:
                 end for
               )
 
-            BlocksUnderConstruction(pendingBlocks, _) <- State
-              .get[BlocksUnderConstruction]
+            BlocksUnderConstruction(
+              pendingBlocks,
+              _,
+              groupIdsOfCompletedBlocks
+            ) <- State.get[BlocksUnderConstruction]
 
             groupIdsFinishingConstruction = pendingBlocks.keySet
           yield buildBlocks(
@@ -185,10 +198,19 @@ object SectionedCodeExtension extends StrictLogging:
           .runA(
             BlocksUnderConstruction(
               pendingBlocks = Map.empty,
-              deferredFillerSections = IndexedSeq.empty
+              deferredFillerSections = IndexedSeq.empty,
+              groupIdsOfCompletedBlocks = Set.empty
             )
           )
           .value
+
+        result.groupBy(_.parallelMatchesGroupId).foreach {
+          case (groupId, potentialDuplicates) =>
+            require(
+              1 == potentialDuplicates.size,
+              s"Group id: $groupId occurs in multiple blocks: $potentialDuplicates"
+            )
+        }
 
         result
       end blocksFrom

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -282,6 +282,18 @@ object SectionedCodeExtension extends StrictLogging:
       )(section: Section[Element]): Contribution[Section[Element]] =
         val groupIds = groupIdsOf(section)
 
+        // @jules - this isn't quite right and is probably causing most of the
+        // test failures in `SectionedCodeExtensionTest`. The problem is that it
+        // considers the *group id* contribution to apply to a section that
+        // participates in that group to apply directly to the section. In
+        // reality the match that lead to the group id should also be consulted,
+        // so for example, if the overall group id maps to a
+        // `Contribution.Common`, but the section's match is a mere
+        // `BaseAndLeft`, then the contribution from the group id should be
+        // demoted to `Contribution.CommonToBaseAndLeftOnly`. On the other hand,
+        // if there is no match at all (and thus no group id either), the
+        // `getOrElse` below should assign a `Contribution.Difference` which is
+        // the right thing to do.
         val contributions = groupIds.toSeq
           .flatMap(contributionKindsByGroupId.get)
           .sorted(

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -263,7 +263,7 @@ object SectionedCodeExtension extends StrictLogging:
             preservedBaseElement: Block,
             preservedElementOnLeft: Block,
             preservedElementOnRight: Block
-        ): ThreeSidedClumps[Block] = result.prepended(
+        ): ThreeSidedClumps[Block] = result.appended(
           ThreeSidedClump(
             Vector(preservedBaseElement),
             Vector(preservedElementOnLeft),
@@ -275,7 +275,7 @@ object SectionedCodeExtension extends StrictLogging:
             result: ThreeSidedClumps[Block],
             insertedElement: Block
         ): ThreeSidedClumps[Block] =
-          result.prepended(
+          result.appended(
             ThreeSidedClump(Vector.empty, Vector(insertedElement), Vector.empty)
           )
 
@@ -283,7 +283,7 @@ object SectionedCodeExtension extends StrictLogging:
             result: ThreeSidedClumps[Block],
             insertedElement: Block
         ): ThreeSidedClumps[Block] =
-          result.prepended(
+          result.appended(
             ThreeSidedClump(Vector.empty, Vector.empty, Vector(insertedElement))
           )
 
@@ -291,7 +291,7 @@ object SectionedCodeExtension extends StrictLogging:
             result: ThreeSidedClumps[Block],
             insertedElementOnLeft: Block,
             insertedElementOnRight: Block
-        ): ThreeSidedClumps[Block] = result.prepended(
+        ): ThreeSidedClumps[Block] = result.appended(
           ThreeSidedClump(
             Vector.empty,
             Vector(insertedElementOnLeft),
@@ -303,7 +303,7 @@ object SectionedCodeExtension extends StrictLogging:
             result: ThreeSidedClumps[Block],
             deletedBaseElement: Block,
             deletedRightElement: Block
-        ): ThreeSidedClumps[Block] = result.prepended(
+        ): ThreeSidedClumps[Block] = result.appended(
           ThreeSidedClump(
             Vector(deletedBaseElement),
             Vector.empty,
@@ -315,7 +315,7 @@ object SectionedCodeExtension extends StrictLogging:
             result: ThreeSidedClumps[Block],
             deletedBaseElement: Block,
             deletedLeftElement: Block
-        ): ThreeSidedClumps[Block] = result.prepended(
+        ): ThreeSidedClumps[Block] = result.appended(
           ThreeSidedClump(
             Vector(deletedBaseElement),
             Vector(deletedLeftElement),
@@ -327,7 +327,7 @@ object SectionedCodeExtension extends StrictLogging:
             result: ThreeSidedClumps[Block],
             deletedElement: Block
         ): ThreeSidedClumps[Block] =
-          result.prepended(
+          result.appended(
             ThreeSidedClump(Vector(deletedElement), Vector.empty, Vector.empty)
           )
 
@@ -336,7 +336,7 @@ object SectionedCodeExtension extends StrictLogging:
             editedBaseElement: Block,
             editedRightElement: Block,
             editElements: IndexedSeq[Block]
-        ): ThreeSidedClumps[Block] = result.prepended(
+        ): ThreeSidedClumps[Block] = result.appended(
           ThreeSidedClump(
             Vector(editedBaseElement),
             editElements,
@@ -349,7 +349,7 @@ object SectionedCodeExtension extends StrictLogging:
             editedBaseElement: Block,
             editedLeftElement: Block,
             editElements: IndexedSeq[Block]
-        ): ThreeSidedClumps[Block] = result.prepended(
+        ): ThreeSidedClumps[Block] = result.appended(
           ThreeSidedClump(
             Vector(editedBaseElement),
             Vector(editedLeftElement),
@@ -363,7 +363,7 @@ object SectionedCodeExtension extends StrictLogging:
             editElements: IndexedSeq[(Block, Block)]
         ): ThreeSidedClumps[Block] =
           val (leftEditElements, rightEditElements) = editElements.unzip
-          result.prepended(
+          result.appended(
             ThreeSidedClump(
               Vector(editedElement),
               leftEditElements,
@@ -378,7 +378,7 @@ object SectionedCodeExtension extends StrictLogging:
             leftEditElements: IndexedSeq[Block],
             rightEditElements: IndexedSeq[Block]
         ): ThreeSidedClumps[Block] =
-          result.prepended(
+          result.appended(
             ThreeSidedClump(editedElements, leftEditElements, rightEditElements)
           )
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -18,7 +18,11 @@ import com.sageserpent.kineticmerge.core.MoveDestinationsReport.{
   MoveEvaluation,
   OppositeSideAnchor
 }
-import com.sageserpent.kineticmerge.core.merge.{mergeUsing, of as mergeOf}
+import com.sageserpent.kineticmerge.core.merge.{
+  MergeAlgebra,
+  mergeUsing,
+  of as mergeOf
+}
 import com.sageserpent.kineticmerge.{
   NoProgressRecording,
   ProgressRecording,
@@ -222,42 +226,10 @@ object SectionedCodeExtension extends StrictLogging:
       given Eq[Block]    = Eq.by(_.parallelMatchesGroupId)
       given Sized[Block] = _.size
 
-      val LongestCommonSubsequence(
-        baseBlockContributions,
-        leftBlockContributions,
-        rightBlockContributions,
-        _,
-        _,
-        _,
-        _
-      ) =
-        LongestCommonSubsequence.of(baseBlocks, leftBlocks, rightBlocks)
-
-      def contributionKindsByGroupId(
-          blockContributions: IndexedSeq[Contribution[Block]]
-      ): Map[ParallelMatchesGroupId, Contribution[Block]] =
-        blockContributions
-          .map(contribution =>
-            contribution.element.parallelMatchesGroupId -> contribution
-          )
-          .toMap
-
-      val baseContributionKindsByGroupId = contributionKindsByGroupId(
-        baseBlockContributions
-      )
-
-      val leftContributionKindsByGroupId = contributionKindsByGroupId(
-        leftBlockContributions
-      )
-
-      val rightContributionKindsByGroupId = contributionKindsByGroupId(
-        rightBlockContributions
-      )
-
-      object contributionRanking extends Ordering[Contribution[Block]]:
+      object contributionRanking extends Ordering[Contribution[?]]:
         override def compare(
-            x: Contribution[Block],
-            y: Contribution[Block]
+            x: Contribution[?],
+            y: Contribution[?]
         ): Int =
           (x, y) match
             // A common contribution is the best.
@@ -275,65 +247,214 @@ object SectionedCodeExtension extends StrictLogging:
             case _ => 0
       end contributionRanking
 
-      def assignContributionUsing(
-          contributionKindsByGroupId: Map[ParallelMatchesGroupId, Contribution[
-            Block
-          ]]
-      )(section: Section[Element]): Contribution[Section[Element]] =
-        val groupIds = groupIdsOf(section)
+      case class ThreeSidedClump[X](
+          base: IndexedSeq[X],
+          left: IndexedSeq[X],
+          right: IndexedSeq[X]
+      )
 
-        // @jules - this isn't quite right and is probably causing most of the
-        // test failures in `SectionedCodeExtensionTest`. The problem is that it
-        // considers the *group id* contribution to apply to a section that
-        // participates in that group to apply directly to the section. In
-        // reality the match that lead to the group id should also be consulted,
-        // so for example, if the overall group id maps to a
-        // `Contribution.Common`, but the section's match is a mere
-        // `BaseAndLeft`, then the contribution from the group id should be
-        // demoted to `Contribution.CommonToBaseAndLeftOnly`. On the other hand,
-        // if there is no match at all (and thus no group id either), the
-        // `getOrElse` below should assign a `Contribution.Difference` which is
-        // the right thing to do.
-        val contributions = groupIds.toSeq
-          .flatMap(contributionKindsByGroupId.get)
-          .sorted(
-            contributionRanking.reverse
+      type ThreeSidedClumps[X] = Vector[ThreeSidedClump[X]]
+
+      val blockLevelMergeAlgebra = new MergeAlgebra[ThreeSidedClumps, Block]:
+        override def empty: ThreeSidedClumps[Block] = Vector.empty
+
+        override def preservation(
+            result: ThreeSidedClumps[Block],
+            preservedBaseElement: Block,
+            preservedElementOnLeft: Block,
+            preservedElementOnRight: Block
+        ): ThreeSidedClumps[Block] = result.prepended(
+          ThreeSidedClump(
+            Vector(preservedBaseElement),
+            Vector(preservedElementOnLeft),
+            Vector(preservedElementOnRight)
           )
-
-        val bestRankedContribution =
-          contributions.headOption.getOrElse(Contribution.Difference(null))
-
-        val onePastTheBestRankedContributions = contributions.indexWhere(
-          0 > contributionRanking
-            .compare(_, bestRankedContribution)
         )
 
-        val moreThanOneBestRankedContribution =
-          1 < onePastTheBestRankedContributions
+        override def leftInsertion(
+            result: ThreeSidedClumps[Block],
+            insertedElement: Block
+        ): ThreeSidedClumps[Block] =
+          result.prepended(
+            ThreeSidedClump(Vector.empty, Vector(insertedElement), Vector.empty)
+          )
 
-        if moreThanOneBestRankedContribution then
-          Contribution.Difference(section)
-        else bestRankedContribution.constructLikeness(section)
-        end if
+        override def rightInsertion(
+            result: ThreeSidedClumps[Block],
+            insertedElement: Block
+        ): ThreeSidedClumps[Block] =
+          result.prepended(
+            ThreeSidedClump(Vector.empty, Vector.empty, Vector(insertedElement))
+          )
 
-      end assignContributionUsing
+        override def coincidentInsertion(
+            result: ThreeSidedClumps[Block],
+            insertedElementOnLeft: Block,
+            insertedElementOnRight: Block
+        ): ThreeSidedClumps[Block] = result.prepended(
+          ThreeSidedClump(
+            Vector.empty,
+            Vector(insertedElementOnLeft),
+            Vector(insertedElementOnRight)
+          )
+        )
 
-      val baseSectionContributions = baseSections.map(
-        assignContributionUsing(baseContributionKindsByGroupId)
-      )
+        override def leftDeletion(
+            result: ThreeSidedClumps[Block],
+            deletedBaseElement: Block,
+            deletedRightElement: Block
+        ): ThreeSidedClumps[Block] = result.prepended(
+          ThreeSidedClump(
+            Vector(deletedBaseElement),
+            Vector.empty,
+            Vector(deletedRightElement)
+          )
+        )
 
-      val leftSectionContributions = leftSections.map(
-        assignContributionUsing(leftContributionKindsByGroupId)
-      )
+        override def rightDeletion(
+            result: ThreeSidedClumps[Block],
+            deletedBaseElement: Block,
+            deletedLeftElement: Block
+        ): ThreeSidedClumps[Block] = result.prepended(
+          ThreeSidedClump(
+            Vector(deletedBaseElement),
+            Vector(deletedLeftElement),
+            Vector.empty
+          )
+        )
 
-      val rightSectionContributions = rightSections.map(
-        assignContributionUsing(rightContributionKindsByGroupId)
-      )
+        override def coincidentDeletion(
+            result: ThreeSidedClumps[Block],
+            deletedElement: Block
+        ): ThreeSidedClumps[Block] =
+          result.prepended(
+            ThreeSidedClump(Vector(deletedElement), Vector.empty, Vector.empty)
+          )
 
-      LongestCommonSubsequence.apply(
-        baseSectionContributions,
-        leftSectionContributions,
-        rightSectionContributions
+        override def leftEdit(
+            result: ThreeSidedClumps[Block],
+            editedBaseElement: Block,
+            editedRightElement: Block,
+            editElements: IndexedSeq[Block]
+        ): ThreeSidedClumps[Block] = result.prepended(
+          ThreeSidedClump(
+            Vector(editedBaseElement),
+            editElements,
+            Vector(editedRightElement)
+          )
+        )
+
+        override def rightEdit(
+            result: ThreeSidedClumps[Block],
+            editedBaseElement: Block,
+            editedLeftElement: Block,
+            editElements: IndexedSeq[Block]
+        ): ThreeSidedClumps[Block] = result.prepended(
+          ThreeSidedClump(
+            Vector(editedBaseElement),
+            Vector(editedLeftElement),
+            editElements
+          )
+        )
+
+        override def coincidentEdit(
+            result: ThreeSidedClumps[Block],
+            editedElement: Block,
+            editElements: IndexedSeq[(Block, Block)]
+        ): ThreeSidedClumps[Block] =
+          val (leftEditElements, rightEditElements) = editElements.unzip
+          result.prepended(
+            ThreeSidedClump(
+              Vector(editedElement),
+              leftEditElements,
+              rightEditElements
+            )
+          )
+        end coincidentEdit
+
+        override def conflict(
+            result: ThreeSidedClumps[Block],
+            editedElements: IndexedSeq[Block],
+            leftEditElements: IndexedSeq[Block],
+            rightEditElements: IndexedSeq[Block]
+        ): ThreeSidedClumps[Block] =
+          result.prepended(
+            ThreeSidedClump(editedElements, leftEditElements, rightEditElements)
+          )
+
+      val threeSidedClumps =
+        mergeOf(blockLevelMergeAlgebra)(baseBlocks, leftBlocks, rightBlocks)
+
+      def contributionsFromClump(
+          partialResult: Map[Section[Element], Contribution[Section[Element]]],
+          threeSidedClump: ThreeSidedClump[Block]
+      ): Map[Section[Element], Contribution[Section[Element]]] =
+        val sectionLevelLongestCommonSubsequenceInClump =
+          LongestCommonSubsequence.of(
+            threeSidedClump.base.flatMap(_.sectionsCoveredByGroup),
+            threeSidedClump.left.flatMap(_.sectionsCoveredByGroup),
+            threeSidedClump.right.flatMap(_.sectionsCoveredByGroup)
+          )
+
+        def foldInContributions(
+            partialResult: Map[Section[Element], Contribution[
+              Section[Element]
+            ]],
+            contributions: IndexedSeq[Contribution[Section[Element]]]
+        ): Map[Section[Element], Contribution[Section[Element]]] =
+          contributions.foldLeft(
+            partialResult
+          )((partial, contribution) =>
+            partial.updatedWith(contribution.element) {
+              case None =>
+                Some(contribution)
+              case Some(previousContribution) =>
+                Some(
+                  if contributionRanking.gt(contribution, previousContribution)
+                  then contribution
+                  else previousContribution
+                )
+            }
+          )
+
+        val incorporatingSectionsFromTheBase =
+          foldInContributions(
+            partialResult,
+            sectionLevelLongestCommonSubsequenceInClump.base
+          )
+
+        val incorporatingSectionsFromTheLeft =
+          foldInContributions(
+            incorporatingSectionsFromTheBase,
+            sectionLevelLongestCommonSubsequenceInClump.left
+          )
+
+        val incorporatingSectionsFromTheRight =
+          foldInContributions(
+            incorporatingSectionsFromTheLeft,
+            sectionLevelLongestCommonSubsequenceInClump.right
+          )
+
+        incorporatingSectionsFromTheRight
+      end contributionsFromClump
+
+      val contributionsFromSectionsInBlocksAcrossAllThreeSides
+          : Map[Section[Element], Contribution[Section[Element]]] =
+        threeSidedClumps.foldLeft(Map.empty)(contributionsFromClump)
+
+      def assignContributionsOnOneSide(
+          sections: IndexedSeq[Section[Element]]
+      ): IndexedSeq[Contribution[Section[Element]]] =
+        sections.map(section =>
+          contributionsFromSectionsInBlocksAcrossAllThreeSides
+            .get(section)
+            .getOrElse(Contribution.Difference(section))
+        )
+
+      LongestCommonSubsequence(
+        base = assignContributionsOnOneSide(baseSections),
+        left = assignContributionsOnOneSide(leftSections),
+        right = assignContributionsOnOneSide(rightSections)
       )
     end longestCommonSubsequenceOf
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -389,6 +389,20 @@ object SectionedCodeExtension extends StrictLogging:
           partialResult: Map[Section[Element], Contribution[Section[Element]]],
           threeSidedClump: ThreeSidedClump[Block]
       ): Map[Section[Element], Contribution[Section[Element]]] =
+        given Eq[Section[Element]] with
+          override def eqv(x: Section[Element], y: Section[Element]): Boolean =
+            // Check to see if either section has a previous common contribution
+            // that forbids equality. We still have to go ahead and make the
+            // comparison, but that's OK as the logic in `foldInContributions`
+            // will choose the best contribution in the end taking this into
+            // account.
+
+            (partialResult.get(x), partialResult.get(y)) match
+              case (Some(Contribution.Common(_)), _) => false
+              case (_, Some(Contribution.Common(_))) => false
+              case _                                 => sectionEq.eqv(x, y)
+        end given
+
         val sectionLevelLongestCommonSubsequenceInClump =
           LongestCommonSubsequence.of(
             threeSidedClump.base.flatMap(_.sectionsCoveredByGroup),

--- a/src/test/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequenceTest.scala
+++ b/src/test/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequenceTest.scala
@@ -303,6 +303,38 @@ class LongestCommonSubsequenceTest:
   end theLongestCommonSubsequenceUnderpinsAllThreeResults
 
   @TestFactory
+  def theApplyMethodIsConsistentWithTheOfMethod(): DynamicTests =
+    testCases
+      .withLimit(100)
+      .dynamicTests(
+        (
+          testCase: TestCase
+        ) =>
+          given Sized[Element] = defaultElementSize
+
+          val originalLongestCommonSubsequence @ LongestCommonSubsequence(
+            base,
+            left,
+            right,
+            _,
+            _,
+            _,
+            _
+          ) =
+            LongestCommonSubsequence
+              .of(testCase.base, testCase.left, testCase.right)
+
+          val reconstructedLongestCommonSubsequence =
+            LongestCommonSubsequence(base, left, right)
+
+          assert(
+            reconstructedLongestCommonSubsequence == originalLongestCommonSubsequence
+          )
+      )
+
+  end theApplyMethodIsConsistentWithTheOfMethod
+
+  @TestFactory
   def theLargestElementSizeSumIsTheTiebreakForLongestCommonSubsequencesOfTheSameLength()
       : DynamicTests =
     enum MissingSide:
@@ -413,8 +445,6 @@ class LongestCommonSubsequenceTest:
 end LongestCommonSubsequenceTest
 
 object LongestCommonSubsequenceTest:
-  given ProgressRecording = NoProgressRecording
-
   type Element = Char
   val coreElements: Trials[Element]       = trialsApi.choose('a' to 'z')
   val additionalElements: Trials[Element] = trialsApi.choose('A' to 'Z')
@@ -450,6 +480,8 @@ object LongestCommonSubsequenceTest:
     )
     if core != base || core != left || core != right
   yield TestCase(core, base, left, right)
+
+  given ProgressRecording = NoProgressRecording
 
   given Eq[Element] = _ == _
 

--- a/src/test/scala/com/sageserpent/kineticmerge/core/SectionedCodeTest.scala
+++ b/src/test/scala/com/sageserpent/kineticmerge/core/SectionedCodeTest.scala
@@ -780,23 +780,31 @@ class SectionedCodeTest:
 
     val baseSources = new FakeSources(
       Map(
-        1 -> (bigAllSidesContent ++ Vector(8, 4, 6, 7, 8,
-          2) ++ smallAmbiguousAllSidesContent)
+        1 -> (bigAllSidesContent ++ Vector(
+          8,
+          1,
+          7,
+          8
+        ) ++ smallAmbiguousAllSidesContent)
       ),
       "base"
     ) with SourcesContracts[Path, Element]
 
     val leftSources = new FakeSources(
       Map(
-        1 -> (bigAllSidesContent ++ Vector(2, 5, 9, 6,
-          3) ++ smallAmbiguousAllSidesContent)
+        1 -> (bigAllSidesContent ++ Vector(
+          2,
+          5,
+          9,
+          6
+        ) ++ smallAmbiguousAllSidesContent)
       ),
       "left"
     ) with SourcesContracts[Path, Element]
 
     val rightSources = new FakeSources(
       Map(
-        1 -> (bigAllSidesContent ++ Vector(0, 3, 4, 5, 6, 6,
+        1 -> (bigAllSidesContent ++ Vector(0, 3, 4, 3,
           4) ++ smallAmbiguousAllSidesContent)
       ),
       "right"
@@ -1071,8 +1079,8 @@ class SectionedCodeTest:
 
     val leftSources = new FakeSources(
       Map(
-        1 -> (equallyBigPairwiseContent ++ Vector(8, 7, 3, 4, 7, 8, 4, 5, 3, 8,
-          7, 3, 4) ++ bigAllSidesContent)
+        1 -> (equallyBigPairwiseContent ++ Vector(8, 7, 3, 4, 7, 8, 4, 3, 8, 7,
+          3, 4) ++ bigAllSidesContent)
       ),
       "left"
     ) with SourcesContracts[Path, Element]


### PR DESCRIPTION
This PR finishes the implementation of approximating per-file longest common subsequences using parallel match groups, as requested in issue #321.

Key changes:
1. **Tiny Matches Integration**: `SectionedCode` now includes tiny matches in its `parallelMatchesGroupIdsByMatch` mapping, ensuring they contribute to the block-level LCS alignment.
2. **LCS Refinement**: The mapping from block-level contributions back to section-level contributions in `SectionedCodeExtension` has been refined to handle filler sections and ambiguity (duplicated sections moved apart).
3. **Robust Merge Result**: `MergeResult.addConflicted` now delegates to `segmentFor`, which gracefully handles cases where an approximated LCS produces a "conflict" between sides that are actually equivalent according to the content-based `Eq[Section[Element]]`.
4. **API Enhancements**: `LongestCommonSubsequence` now supports manual construction via a public `apply` method, and `Contribution` has a `constructLikeness` helper.

These changes address the `IllegalArgumentException` seen in `SectionedCodeExtensionTest` and provide a faster, approximated LCS for large files while maintaining merge correctness.

---
*PR created automatically by Jules for task [15894848503637331019](https://jules.google.com/task/15894848503637331019) started by @sageserpent-open*