### PR TITLE
Performance Benchmarking and Timed Progress Reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,36 @@ Key goals include:
 - `CodeMotionAnalysisExtension.scala`: The global merge and migration logic.
 - `merge.scala`: The core three-way merge implementation.
 - `LongestCommonSubsequence.scala`: The alignment algorithm.
+
+## Performance Benchmarking
+
+It is strongly recommended to run the following benchmark when making changes to the core matching, LCS, merge, or block construction code.
+
+### Manual Benchmark Procedure
+
+1. **Build the CLI application** in the main project directory:
+   ```bash
+   sbt packageExecutable
+   ```
+   This produces `target/kinetic-merge`.
+
+2. **Setup a reproduction repository**: Create a separate clone of the Kinetic Merge repository in a temporary location (e.g., `/tmp/kinetic-merge-repro`):
+   ```bash
+   git clone https://github.com/sageserpent-open/kineticMerge.git /tmp/kinetic-merge-repro
+   cd /tmp/kinetic-merge-repro
+   git checkout 6e0b6821fa8fe53465c3355793b61ac425a10c1a
+   ```
+
+3. **Run the benchmark**: From within the repro repository, run the packaged executable from your development workspace:
+   ```bash
+   <PATH_TO_YOUR_WORKSPACE>/target/kinetic-merge \
+     --no-commit \
+     55fef2f785334b7bf99fc592dd101a462cbb2c6d
+   ```
+
+4. **Cleanup**:
+   ```bash
+   git merge --abort
+   ```
+
+The execution should be timed, aiming for "shortness" (ideally under one minute). At least one file is expected to have conflicts.

--- a/build.sbt
+++ b/build.sbt
@@ -102,6 +102,7 @@ lazy val root = (project in file("."))
     libraryDependencies += "de.sciss"        %% "fingertree" % "1.5.5",
     libraryDependencies += "com.github.ben-manes.caffeine" % "caffeine" % "3.2.4",
     libraryDependencies += "me.tongfei" % "progressbar" % "0.10.2",
+    libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.20.0",
     libraryDependencies +=
       "org.scala-lang.modules" %% "scala-parallel-collections" % "1.2.0",
     libraryDependencies += "com.sageserpent" %% "americium" % "2.1.0" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,6 @@ lazy val root = (project in file("."))
     libraryDependencies += "de.sciss"        %% "fingertree" % "1.5.5",
     libraryDependencies += "com.github.ben-manes.caffeine" % "caffeine" % "3.2.4",
     libraryDependencies += "me.tongfei" % "progressbar" % "0.10.2",
-    libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.20.0",
     libraryDependencies +=
       "org.scala-lang.modules" %% "scala-parallel-collections" % "1.2.0",
     libraryDependencies += "com.sageserpent" %% "americium" % "2.1.0" % Test,

--- a/src/main/scala/com/sageserpent/kineticmerge/Main.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/Main.scala
@@ -1784,7 +1784,7 @@ object Main extends StrictLogging:
         sectionedCode: SectionedCode[Path, Token] <- EitherT
           .fromEither[WorkflowLogWriter] {
             SectionedCode.of(baseSources, leftSources, rightSources)(
-              configuration
+              configuration.copy(label = "Primary match analysis")
             )
           }
           .leftMap(_.toString.taggedWith[Tags.ErrorMessage])

--- a/src/main/scala/com/sageserpent/kineticmerge/ProgressRecording.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/ProgressRecording.scala
@@ -1,24 +1,33 @@
 package com.sageserpent.kineticmerge
 
 import me.tongfei.progressbar.{ConsoleProgressBarConsumer, ProgressBarBuilder}
+import org.apache.commons.lang3.time.DurationFormatUtils
 import org.jline.utils.WriterOutputStream
 
 import java.io.PrintStream
 import java.nio.charset.Charset
-import java.time.{Duration as JavaDuration, Instant}
-
-import org.apache.commons.lang3.time.DurationFormatUtils
+import java.time.{Instant, Duration as JavaDuration}
 
 /** Records progress from zero up to some implied maximum set up by
   * [[ProgressRecording.newSession]]. Progress may be moved up or down; so it is
   * possible to use this to count progress up from zero to the maximum, or to
   * count progress down from the maximum to zero.
   */
-trait ProgressRecordingSession extends AutoCloseable:
+trait ProgressRecordingSession(val label: String, val maximumProgress: Int)
+    extends AutoCloseable:
+  private val startTime = Instant.now()
+
   /** @param amount
     *   Zero or positive amount of absolute progress.
     */
   def upTo(amount: Int): Unit
+
+  override def close(): Unit =
+    val duration = JavaDuration.between(startTime, Instant.now())
+    println(
+      s"$label $maximumProgress (Completed in: ${DurationFormatUtils.formatDurationHMS(duration.toMillis)})"
+    )
+  end close
 end ProgressRecordingSession
 
 trait ProgressRecording:
@@ -44,17 +53,8 @@ object NoProgressRecording extends ProgressRecording:
   override def newSession(label: String, maximumProgress: Int)(
       initialProgress: Int
   ): ProgressRecordingSession =
-    new ProgressRecordingSession:
-      private val startTime = Instant.now()
-
+    new ProgressRecordingSession(label, maximumProgress):
       override def upTo(amount: Int): Unit = {}
-
-      override def close(): Unit =
-        val duration = JavaDuration.between(startTime, Instant.now())
-        println(
-          s"$label $maximumProgress (Completed in: ${DurationFormatUtils.formatDurationHMS(duration.toMillis)})"
-        )
-      end close
     end new
   end newSession
 end NoProgressRecording
@@ -68,9 +68,7 @@ object ConsoleProgressRecording extends ProgressRecording:
   override def newSession(label: String, maximumProgress: Int)(
       initialProgress: Int
   ): ProgressRecordingSession =
-    new ProgressRecordingSession:
-      private val startTime = Instant.now()
-
+    new ProgressRecordingSession(label, maximumProgress):
       private val progressBar = Option(System.console()).map(console =>
         val progressBarConsumer = new ConsoleProgressBarConsumer(
           new PrintStream(
@@ -78,10 +76,10 @@ object ConsoleProgressRecording extends ProgressRecording:
           )
         )
         val builder = new ProgressBarBuilder
-        builder.setTaskName(label)
+        builder.setTaskName(this.label)
         builder.hideEta()
         builder.startsFrom(initialProgress, JavaDuration.ZERO)
-        builder.setInitialMax(maximumProgress)
+        builder.setInitialMax(this.maximumProgress)
         builder.clearDisplayOnFinish()
         builder.setConsumer(progressBarConsumer)
         builder.build()
@@ -91,9 +89,6 @@ object ConsoleProgressRecording extends ProgressRecording:
         progressBar.foreach(_.stepTo(amount))
       override def close(): Unit =
         progressBar.foreach(_.close())
-        val duration = JavaDuration.between(startTime, Instant.now())
-        println(
-          s"$label $maximumProgress (Completed in: ${DurationFormatUtils.formatDurationHMS(duration.toMillis)})"
-        )
+        super.close()
       end close
 end ConsoleProgressRecording

--- a/src/main/scala/com/sageserpent/kineticmerge/ProgressRecording.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/ProgressRecording.scala
@@ -7,6 +7,8 @@ import java.io.PrintStream
 import java.nio.charset.Charset
 import java.time.{Duration as JavaDuration, Instant}
 
+import org.apache.commons.lang3.time.DurationFormatUtils
+
 /** Records progress from zero up to some implied maximum set up by
   * [[ProgressRecording.newSession]]. Progress may be moved up or down; so it is
   * possible to use this to count progress up from zero to the maximum, or to
@@ -49,8 +51,12 @@ object NoProgressRecording extends ProgressRecording:
 
       override def close(): Unit =
         val duration = JavaDuration.between(startTime, Instant.now())
-        println(s"$label - took: $duration")
+        println(
+          s"$label $maximumProgress (Completed in: ${DurationFormatUtils.formatDurationHMS(duration.toMillis)})"
+        )
+      end close
     end new
+  end newSession
 end NoProgressRecording
 
 /** An instance of [[ProgressRecordingSession]] created by
@@ -86,5 +92,8 @@ object ConsoleProgressRecording extends ProgressRecording:
       override def close(): Unit =
         progressBar.foreach(_.close())
         val duration = JavaDuration.between(startTime, Instant.now())
-        println(s"$label - took: $duration")
+        println(
+          s"$label $maximumProgress (Completed in: ${DurationFormatUtils.formatDurationHMS(duration.toMillis)})"
+        )
+      end close
 end ConsoleProgressRecording

--- a/src/main/scala/com/sageserpent/kineticmerge/ProgressRecording.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/ProgressRecording.scala
@@ -1,20 +1,18 @@
 package com.sageserpent.kineticmerge
 
 import me.tongfei.progressbar.{ConsoleProgressBarConsumer, ProgressBarBuilder}
-import org.apache.commons.lang3.time.DurationFormatUtils
 import org.jline.utils.WriterOutputStream
 
 import java.io.PrintStream
 import java.nio.charset.Charset
-import java.time.{Instant, Duration as JavaDuration}
+import java.time.{Duration as JavaDuration, Instant}
 
 /** Records progress from zero up to some implied maximum set up by
   * [[ProgressRecording.newSession]]. Progress may be moved up or down; so it is
   * possible to use this to count progress up from zero to the maximum, or to
   * count progress down from the maximum to zero.
   */
-trait ProgressRecordingSession(val label: String, val maximumProgress: Int)
-    extends AutoCloseable:
+trait ProgressRecordingSession(val label: String) extends AutoCloseable:
   private val startTime = Instant.now()
 
   /** @param amount
@@ -24,10 +22,7 @@ trait ProgressRecordingSession(val label: String, val maximumProgress: Int)
 
   override def close(): Unit =
     val duration = JavaDuration.between(startTime, Instant.now())
-    println(
-      s"$label $maximumProgress (Completed in: ${DurationFormatUtils.formatDurationHMS(duration.toMillis)})"
-    )
-  end close
+    println(s"$label - took: $duration")
 end ProgressRecordingSession
 
 trait ProgressRecording:
@@ -53,10 +48,9 @@ object NoProgressRecording extends ProgressRecording:
   override def newSession(label: String, maximumProgress: Int)(
       initialProgress: Int
   ): ProgressRecordingSession =
-    new ProgressRecordingSession(label, maximumProgress):
+    new ProgressRecordingSession(label):
       override def upTo(amount: Int): Unit = {}
     end new
-  end newSession
 end NoProgressRecording
 
 /** An instance of [[ProgressRecordingSession]] created by
@@ -68,7 +62,7 @@ object ConsoleProgressRecording extends ProgressRecording:
   override def newSession(label: String, maximumProgress: Int)(
       initialProgress: Int
   ): ProgressRecordingSession =
-    new ProgressRecordingSession(label, maximumProgress):
+    new ProgressRecordingSession(label):
       private val progressBar = Option(System.console()).map(console =>
         val progressBarConsumer = new ConsoleProgressBarConsumer(
           new PrintStream(
@@ -79,7 +73,7 @@ object ConsoleProgressRecording extends ProgressRecording:
         builder.setTaskName(this.label)
         builder.hideEta()
         builder.startsFrom(initialProgress, JavaDuration.ZERO)
-        builder.setInitialMax(this.maximumProgress)
+        builder.setInitialMax(maximumProgress)
         builder.clearDisplayOnFinish()
         builder.setConsumer(progressBarConsumer)
         builder.build()
@@ -90,5 +84,4 @@ object ConsoleProgressRecording extends ProgressRecording:
       override def close(): Unit =
         progressBar.foreach(_.close())
         super.close()
-      end close
 end ConsoleProgressRecording

--- a/src/main/scala/com/sageserpent/kineticmerge/ProgressRecording.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/ProgressRecording.scala
@@ -5,7 +5,7 @@ import org.jline.utils.WriterOutputStream
 
 import java.io.PrintStream
 import java.nio.charset.Charset
-import java.time.Duration as JavaDuration
+import java.time.{Duration as JavaDuration, Instant}
 
 /** Records progress from zero up to some implied maximum set up by
   * [[ProgressRecording.newSession]]. Progress may be moved up or down; so it is
@@ -42,13 +42,15 @@ object NoProgressRecording extends ProgressRecording:
   override def newSession(label: String, maximumProgress: Int)(
       initialProgress: Int
   ): ProgressRecordingSession =
-    Session
+    new ProgressRecordingSession:
+      private val startTime = Instant.now()
 
-  private object Session extends ProgressRecordingSession:
-    override def upTo(amount: Int): Unit = {}
+      override def upTo(amount: Int): Unit = {}
 
-    override def close(): Unit = {}
-  end Session
+      override def close(): Unit =
+        val duration = JavaDuration.between(startTime, Instant.now())
+        println(s"$label - took: $duration")
+    end new
 end NoProgressRecording
 
 /** An instance of [[ProgressRecordingSession]] created by
@@ -61,6 +63,8 @@ object ConsoleProgressRecording extends ProgressRecording:
       initialProgress: Int
   ): ProgressRecordingSession =
     new ProgressRecordingSession:
+      private val startTime = Instant.now()
+
       private val progressBar = Option(System.console()).map(console =>
         val progressBarConsumer = new ConsoleProgressBarConsumer(
           new PrintStream(
@@ -79,5 +83,8 @@ object ConsoleProgressRecording extends ProgressRecording:
 
       override def upTo(amount: Int): Unit =
         progressBar.foreach(_.stepTo(amount))
-      override def close(): Unit = progressBar.foreach(_.close())
+      override def close(): Unit =
+        progressBar.foreach(_.close())
+        val duration = JavaDuration.between(startTime, Instant.now())
+        println(s"$label - took: $duration")
 end ConsoleProgressRecording

--- a/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
@@ -551,7 +551,8 @@ object LongestCommonSubsequence:
 
         Using(
           progressRecording.newSession(
-            label = s"Longest common subsequence swathes completed:",
+            label =
+              s"Longest common subsequence (part of block-level merging) swathes completed:",
             maximumProgress =
               /* NOTE: although the maximum swathe index is defined in terms of
                * the input *sizes*, we still need to add one as the LCS

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -217,10 +217,15 @@ object MatchAnalysis extends StrictLogging:
 
       def withAllMatchesOfAtLeastTheSureFireWindowSize()
           : MatchesAndTheirSections =
+        val sessionLabel =
+          if configuration.label.nonEmpty then
+            s"${configuration.label} - minimum match size considered:"
+          else "Minimum match size considered:"
+
         if 0 < maximumPossibleMatchSize then
           Using(
             progressRecording.newSession(
-              label = "Minimum match size considered:",
+              label = sessionLabel,
               maximumProgress = maximumPossibleMatchSize
             )(initialProgress = maximumPossibleMatchSize)
           ) { progressRecordingSession =>
@@ -1112,9 +1117,14 @@ object MatchAnalysis extends StrictLogging:
           val maximumSmallFryWindowSize =
             minimumSureFireWindowSizeAcrossAllFilesOverAllSides - 1
 
+          val sessionLabel =
+            if configuration.label.nonEmpty then
+              s"${configuration.label} - minimum match size considered:"
+            else "Minimum match size considered:"
+
           Using(
             progressRecording.newSession(
-              label = "Minimum match size considered:",
+              label = sessionLabel,
               maximumProgress = maximumSmallFryWindowSize
             )(initialProgress = maximumSmallFryWindowSize)
           ) { progressRecordingSession =>
@@ -1206,9 +1216,14 @@ object MatchAnalysis extends StrictLogging:
           }
         end withContentCoveredByNonTinyMatchesKnockedOut
 
+        val sessionLabel =
+          if configuration.label.nonEmpty then
+            s"${configuration.label} - minimum match size considered:"
+          else "Minimum match size considered:"
+
         val tinyMatches = Using(
           progressRecording.newSession(
-            label = "Minimum match size considered:",
+            label = sessionLabel,
             maximumProgress = minimumWindowSizeAcrossAllFilesOverAllSides
           )(initialProgress = minimumWindowSizeAcrossAllFilesOverAllSides)
         ) { progressRecordingSession =>
@@ -1286,10 +1301,15 @@ object MatchAnalysis extends StrictLogging:
       def reconcileMatches: MatchesAndTheirSections =
         val matches = sectionsAndTheirMatches.values.toSet
 
+        val sessionLabel =
+          if configuration.label.nonEmpty then
+            s"${configuration.label} - number of matches to reconcile:"
+          else "Number of matches to reconcile:"
+
         val Success(result) =
           Using(
             progressRecording.newSession(
-              label = "Number of matches to reconcile:",
+              label = sessionLabel,
               maximumProgress = matches.size
             )(initialProgress = matches.size)
           ) { progressRecordingSession =>
@@ -1570,6 +1590,7 @@ object MatchAnalysis extends StrictLogging:
           override val ambiguousMatchesThreshold: Int           = Int.MaxValue
           override val progressRecording: ProgressRecording     =
             configuration.progressRecording
+          override val label: String = "Meta-matching"
         end metaMatchConfiguration
 
         given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
@@ -3318,6 +3339,7 @@ object MatchAnalysis extends StrictLogging:
     val minimumAmbiguousMatchSize: Int
     val ambiguousMatchesThreshold: Int
     val progressRecording: ProgressRecording
+    val label: String = ""
   end AbstractConfiguration
 
   class AdmissibleFailure(message: String) extends RuntimeException(message)
@@ -3339,7 +3361,8 @@ object MatchAnalysis extends StrictLogging:
       thresholdSizeFractionForMatching: Double,
       minimumAmbiguousMatchSize: Int,
       ambiguousMatchesThreshold: Int,
-      progressRecording: ProgressRecording = NoProgressRecording
+      progressRecording: ProgressRecording = NoProgressRecording,
+      override val label: String = ""
   ) extends AbstractConfiguration:
     // TODO: why would `minimumMatchSize` be zero?
     require(0 <= minimumMatchSize)

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -239,20 +239,12 @@ object SectionedCodeExtension extends StrictLogging:
             )
 
       val threeSidedClumps =
-        Using(
-          progressRecording.newSession(
-            label = s"Block-level merge: $path",
-            maximumProgress = 1
-          )(initialProgress = 0)
-        ) { progressRecordingSession =>
-          val result = mergeOf(blockLevelMergeAlgebra)(
-            sectionedCode.baseBlocksFor(path),
-            sectionedCode.leftBlocksFor(path),
-            sectionedCode.rightBlocksFor(path)
-          )
-          progressRecordingSession.upTo(1)
-          result
-        }.get
+        mergeOf(blockLevelMergeAlgebra)(
+          sectionedCode.baseBlocksFor(path),
+          sectionedCode.leftBlocksFor(path),
+          sectionedCode.rightBlocksFor(path),
+          s"Block-level merge: $path"
+        )
 
       case class CollectedPairings(
           baseToLeft: MultiDict[Section[Element], Section[Element]] =
@@ -715,10 +707,12 @@ object SectionedCodeExtension extends StrictLogging:
                     baseSections = baseSections,
                     leftSections = IndexedSeq.empty,
                     rightSections = rightSections
-                  )(path).mergeUsing(mergeAlgebra =
-                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                      FileDeletionContext.Left
-                    )
+                  )(path).mergeUsing(
+                    mergeAlgebra =
+                      FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                        FileDeletionContext.Left
+                      ),
+                    label = s"Merge: $path"
                   )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
@@ -735,10 +729,12 @@ object SectionedCodeExtension extends StrictLogging:
                     baseSections = baseSections,
                     leftSections = leftSections,
                     rightSections = IndexedSeq.empty
-                  )(path).mergeUsing(mergeAlgebra =
-                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                      FileDeletionContext.Right
-                    )
+                  )(path).mergeUsing(
+                    mergeAlgebra =
+                      FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                        FileDeletionContext.Right
+                      ),
+                    label = s"Merge: $path"
                   )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
@@ -761,10 +757,12 @@ object SectionedCodeExtension extends StrictLogging:
                       optionalBaseSections.getOrElse(IndexedSeq.empty),
                     leftSections = leftSections,
                     rightSections = rightSections
-                  )(path).mergeUsing(mergeAlgebra =
-                    FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
-                      FileDeletionContext.None
-                    )
+                  )(path).mergeUsing(
+                    mergeAlgebra =
+                      FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
+                        FileDeletionContext.None
+                      ),
+                    label = s"Merge: $path"
                   )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -37,6 +37,7 @@ import scala.annotation.tailrec
 import scala.collection.immutable.MultiDict
 import scala.collection.{IndexedSeqView, Searching}
 import scala.math.Ordering.Implicits.seqOrdering
+import scala.util.Using
 
 object SectionedCodeExtension extends StrictLogging:
   /** Add merging capability to a [[SectionedCode]]. */
@@ -238,11 +239,20 @@ object SectionedCodeExtension extends StrictLogging:
             )
 
       val threeSidedClumps =
-        mergeOf(blockLevelMergeAlgebra)(
-          sectionedCode.baseBlocksFor(path),
-          sectionedCode.leftBlocksFor(path),
-          sectionedCode.rightBlocksFor(path)
-        )
+        Using(
+          progressRecording.newSession(
+            label = s"Block-level merge: $path",
+            maximumProgress = 1
+          )(initialProgress = 0)
+        ) { progressRecordingSession =>
+          val result = mergeOf(blockLevelMergeAlgebra)(
+            sectionedCode.baseBlocksFor(path),
+            sectionedCode.leftBlocksFor(path),
+            sectionedCode.rightBlocksFor(path)
+          )
+          progressRecordingSession.upTo(1)
+          result
+        }.get
 
       case class CollectedPairings(
           baseToLeft: MultiDict[Section[Element], Section[Element]] =
@@ -346,9 +356,21 @@ object SectionedCodeExtension extends StrictLogging:
         )
       end pairingsFromClump
 
-      val aggregatedPairings = threeSidedClumps
-        .map(pairingsFromClump)
-        .foldLeft(CollectedPairings())(_ union _)
+      val aggregatedPairings =
+        Using(
+          progressRecording.newSession(
+            label = s"Section-level LCS refinements: $path",
+            maximumProgress = threeSidedClumps.size
+          )(initialProgress = 0)
+        ) { progressRecordingSession =>
+          threeSidedClumps.zipWithIndex
+            .map((clump, index) =>
+              val result = pairingsFromClump(clump)
+              progressRecordingSession.upTo(1 + index)
+              result
+            )
+            .foldLeft(CollectedPairings())(_ union _)
+        }.get
 
       def uniquePartners(
           matches: MultiDict[Section[Element], Section[Element]]
@@ -1909,10 +1931,22 @@ object SectionedCodeExtension extends StrictLogging:
             )
         }
 
-      secondPassMergeResultsByPath
-        .map(applySplices)
-        .map(applySubstitutions)
-        .map(resolveSections) -> moveDestinationsReport
+      val result =
+        Using(
+          progressRecording.newSession(
+            label = "Post-alignment merge processing",
+            maximumProgress = 1
+          )(initialProgress = 0)
+        ) { progressRecordingSession =>
+          val result = secondPassMergeResultsByPath
+            .map(applySplices)
+            .map(applySubstitutions)
+            .map(resolveSections) -> moveDestinationsReport
+          progressRecordingSession.upTo(1)
+          result
+        }.get
+
+      result
     end merge
   end extension
 end SectionedCodeExtension

--- a/src/main/scala/com/sageserpent/kineticmerge/core/merge.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/merge.scala
@@ -10,6 +10,7 @@ import com.typesafe.scalalogging.StrictLogging
 import monocle.syntax.all.*
 
 import scala.annotation.tailrec
+import scala.util.Using
 
 object merge extends StrictLogging:
   /** Performs a three-way merge.
@@ -87,1436 +88,1576 @@ object merge extends StrictLogging:
   )(
       base: IndexedSeq[Element],
       left: IndexedSeq[Element],
-      right: IndexedSeq[Element]
-  )(using progressRecording: ProgressRecording): Result[Element] =
+      right: IndexedSeq[Element],
+      label: String = "Three-way merge"
+  )(using
+      progressRecording: ProgressRecording
+  ): Result[Element] =
     val longestCommonSubsequence =
       LongestCommonSubsequence.of(base, left, right)
 
-    longestCommonSubsequence.mergeUsing(mergeAlgebra)
+    longestCommonSubsequence.mergeUsing(mergeAlgebra, label)
   end of
 
   extension [Element: Eq: Sized](
       longestCommonSubsequence: LongestCommonSubsequence[Element]
   )
     def mergeUsing[Result[_]](
-        mergeAlgebra: MergeAlgebra[Result, Element]
-    )(using progressRecording: ProgressRecording): Result[Element] =
-      val session = progressRecording.newSession(
-        label = "Three-way merge",
-        maximumProgress = 1
-      )(initialProgress = 0)
+        mergeAlgebra: MergeAlgebra[Result, Element],
+        label: String = "Three-way merge"
+    )(using
+        progressRecording: ProgressRecording
+    ): Result[Element] =
+      Using(
+        progressRecording.newSession(
+          label = label,
+          maximumProgress =
+            longestCommonSubsequence.base.size + longestCommonSubsequence.left.size + longestCommonSubsequence.right.size
+        )(initialProgress = 0)
+      ) { session =>
+        var cumulativeProgress = 0
 
-      def rightEditNotMaroonedByPriorCoincidentInsertion(
-          leftTail: Seq[Contribution[Element]]
-      ) =
-        // Guard against a coincident insertion prior to the left side
-        // of a pending right edit or deletion; that would maroon the
-        // latter, so we *would* coalesce the following element on the
-        // right.
-        leftTail
-          .takeWhile {
-            case Contribution.CommonToBaseAndLeftOnly(_) => false
-            case _                                       => true
-          }
-          .forall {
-            case Contribution.CommonToLeftAndRightOnly(_) => false
-            case _                                        => true
-          }
+        def progress(amount: Int): Unit =
+          cumulativeProgress += amount
+          session.upTo(cumulativeProgress)
+        end progress
 
-      def leftEditNotMaroonedByPriorCoincidentInsertion(
-          rightTail: Seq[Contribution[Element]]
-      ) =
-        // Guard against a coincident insertion prior to the right side
-        // of a pending left edit or deletion; that would maroon the
-        // latter, so we *would* coalesce the following element on the
-        // left.
-        rightTail
-          .takeWhile {
-            case Contribution.CommonToBaseAndRightOnly(_) => false
-            case _                                        => true
-          }
-          .forall {
-            case Contribution.CommonToLeftAndRightOnly(_) => false
-            case _                                        => true
-          }
+        val reportingMergeAlgebra =
+          new MergeAlgebra[Result, Element]:
+            override def empty: Result[Element] = mergeAlgebra.empty
 
-      def rightEditNotMaroonedByPriorLeftDeletion(
-          baseTail: Seq[Contribution[Element]]
-      ) =
-        baseTail
-          .takeWhile {
-            case Contribution.CommonToBaseAndLeftOnly(_) => false
-            case _                                       => true
-          }
-          .forall {
-            case Contribution.CommonToBaseAndRightOnly(_) => false
-            case _                                        => true
-          }
+            override def preservation(
+                result: Result[Element],
+                preservedBaseElement: Element,
+                preservedElementOnLeft: Element,
+                preservedElementOnRight: Element
+            ): Result[Element] =
+              progress(3)
+              mergeAlgebra.preservation(
+                result,
+                preservedBaseElement,
+                preservedElementOnLeft,
+                preservedElementOnRight
+              )
+            end preservation
 
-      def leftEditNotMaroonedByPriorRightDeletion(
-          baseTail: Seq[Contribution[Element]]
-      ) =
-        baseTail
-          .takeWhile {
-            case Contribution.CommonToBaseAndRightOnly(_) => false
-            case _                                        => true
-          }
-          .forall {
-            case Contribution.CommonToBaseAndLeftOnly(_) => false
-            case _                                       => true
-          }
+            override def leftInsertion(
+                result: Result[Element],
+                insertedElement: Element
+            ): Result[Element] =
+              progress(1)
+              mergeAlgebra.leftInsertion(result, insertedElement)
 
-      trait LeftEditOperations:
-        def coalesceLeftInsertion(insertedElement: Element): LeftEdit
-        def finalLeftEdit(
-            result: Result[Element],
-            editedBaseElement: Element,
-            editedRightElement: Element,
-            insertedElement: Element
-        ): Result[Element]
-      end LeftEditOperations
+            override def rightInsertion(
+                result: Result[Element],
+                insertedElement: Element
+            ): Result[Element] =
+              progress(1)
+              mergeAlgebra.rightInsertion(result, insertedElement)
 
-      trait RightEditOperations:
-        def coalesceRightInsertion(insertedElement: Element): RightEdit
-        def finalRightEdit(
-            result: Result[Element],
-            editedBaseElement: Element,
-            editedLeftElement: Element,
-            insertedElement: Element
-        ): Result[Element]
-      end RightEditOperations
+            override def coincidentInsertion(
+                result: Result[Element],
+                insertedElementOnLeft: Element,
+                insertedElementOnRight: Element
+            ): Result[Element] =
+              progress(2)
+              mergeAlgebra.coincidentInsertion(
+                result,
+                insertedElementOnLeft,
+                insertedElementOnRight
+              )
 
-      trait CoincidentEditOperations:
-        def coalesceCoincidentInsertion(
-            insertedElementOnLeft: Element,
-            insertedElementOnRight: Element
-        ): CoincidentEdit
-        def finalCoincidentEdit(
-            result: Result[Element],
-            editedElement: Element,
-            insertedElementOnLeft: Element,
-            insertedElementOnRight: Element
-        ): Result[Element]
-      end CoincidentEditOperations
+            override def leftDeletion(
+                result: Result[Element],
+                deletedBaseElement: Element,
+                deletedRightElement: Element
+            ): Result[Element] =
+              progress(2)
+              mergeAlgebra.leftDeletion(
+                result,
+                deletedBaseElement,
+                deletedRightElement
+              )
 
-      trait ConflictOperations:
-        def coalesceConflict(
-            editedBaseElement: Option[Element],
-            leftElement: Option[Element],
-            rightElement: Option[Element]
-        ): Conflict
-        def finalConflict(
-            result: Result[Element],
-            editedElement: Option[Element],
-            leftElement: Option[Element],
-            rightElement: Option[Element]
-        ): Result[Element]
-      end ConflictOperations
+            override def rightDeletion(
+                result: Result[Element],
+                deletedBaseElement: Element,
+                deletedLeftElement: Element
+            ): Result[Element] =
+              progress(2)
+              mergeAlgebra.rightDeletion(
+                result,
+                deletedBaseElement,
+                deletedLeftElement
+              )
 
-      trait Coalescence:
-      end Coalescence
-      object NoCoalescence
-          extends Coalescence
-          with LeftEditOperations
-          with RightEditOperations
-          with CoincidentEditOperations
-          with ConflictOperations:
-        private val leftEdit = LeftEdit(
-          deferredLeftEdits = IndexedSeq.empty
-        )
-        private val rightEdit = RightEdit(
-          deferredRightEdits = IndexedSeq.empty
-        )
-        private val coincidentEdit = CoincidentEdit(
-          deferredCoincidentEdits = IndexedSeq.empty
-        )
-        private val conflict = Conflict(
-          deferredEdited = IndexedSeq.empty,
-          deferredLeftEdits = IndexedSeq.empty,
-          deferredRightEdits = IndexedSeq.empty
-        )
+            override def coincidentDeletion(
+                result: Result[Element],
+                deletedElement: Element
+            ): Result[Element] =
+              progress(1)
+              mergeAlgebra.coincidentDeletion(result, deletedElement)
 
-        // Export the union of the various APIs...
-        export leftEdit.{coalesceLeftInsertion, finalLeftEdit}
-        export rightEdit.{coalesceRightInsertion, finalRightEdit}
-        export coincidentEdit.{coalesceCoincidentInsertion, finalCoincidentEdit}
-        export conflict.{coalesceConflict, finalConflict}
-      end NoCoalescence
+            override def leftEdit(
+                result: Result[Element],
+                editedBaseElement: Element,
+                editedRightElement: Element,
+                editElements: IndexedSeq[Element]
+            ): Result[Element] =
+              progress(2 + editElements.size)
+              mergeAlgebra.leftEdit(
+                result,
+                editedBaseElement,
+                editedRightElement,
+                editElements
+              )
 
-      case class LeftEdit(
-          deferredLeftEdits: IndexedSeq[Element]
-      ) extends Coalescence
-          with LeftEditOperations:
-        override def coalesceLeftInsertion(insertedElement: Element): LeftEdit =
-          this.focus(_.deferredLeftEdits).modify(_ :+ insertedElement)
-        override def finalLeftEdit(
-            result: Result[Element],
-            editedBaseElement: Element,
-            editedRightElement: Element,
-            insertedElement: Element
-        ): Result[Element] = mergeAlgebra.leftEdit(
-          result,
-          editedBaseElement,
-          editedRightElement,
-          deferredLeftEdits :+ insertedElement
-        )
-      end LeftEdit
+            override def rightEdit(
+                result: Result[Element],
+                editedBaseElement: Element,
+                editedLeftElement: Element,
+                editElements: IndexedSeq[Element]
+            ): Result[Element] =
+              progress(2 + editElements.size)
+              mergeAlgebra.rightEdit(
+                result,
+                editedBaseElement,
+                editedLeftElement,
+                editElements
+              )
 
-      case class RightEdit(
-          deferredRightEdits: IndexedSeq[Element]
-      ) extends Coalescence
-          with RightEditOperations:
-        override def coalesceRightInsertion(
-            insertedElement: Element
-        ): RightEdit =
-          this.focus(_.deferredRightEdits).modify(_ :+ insertedElement)
+            override def coincidentEdit(
+                result: Result[Element],
+                editedElement: Element,
+                editElements: IndexedSeq[(Element, Element)]
+            ): Result[Element] =
+              progress(1 + 2 * editElements.size)
+              mergeAlgebra.coincidentEdit(result, editedElement, editElements)
 
-        override def finalRightEdit(
-            result: Result[Element],
-            editedBaseElement: Element,
-            editedLeftElement: Element,
-            insertedElement: Element
-        ): Result[Element] = mergeAlgebra.rightEdit(
-          result,
-          editedBaseElement,
-          editedLeftElement,
-          editElements = deferredRightEdits :+ insertedElement
-        )
-      end RightEdit
+            override def conflict(
+                result: Result[Element],
+                editedElements: IndexedSeq[Element],
+                leftEditElements: IndexedSeq[Element],
+                rightEditElements: IndexedSeq[Element]
+            ): Result[Element] =
+              progress(
+                editedElements.size + leftEditElements.size + rightEditElements.size
+              )
+              mergeAlgebra.conflict(
+                result,
+                editedElements,
+                leftEditElements,
+                rightEditElements
+              )
+        end reportingMergeAlgebra
 
-      case class CoincidentEdit(
-          deferredCoincidentEdits: IndexedSeq[(Element, Element)]
-      ) extends Coalescence
-          with CoincidentEditOperations:
-        override def coalesceCoincidentInsertion(
-            insertedElementOnLeft: Element,
-            insertedElementOnRight: Element
-        ): CoincidentEdit =
-          this
-            .focus(_.deferredCoincidentEdits)
-            .modify(_ :+ (insertedElementOnLeft -> insertedElementOnRight))
-        override def finalCoincidentEdit(
-            result: Result[Element],
-            editedElement: Element,
-            insertedElementOnLeft: Element,
-            insertedElementOnRight: Element
-        ): Result[Element] =
-          mergeAlgebra.coincidentEdit(
-            result,
-            editedElement,
-            editElements =
-              deferredCoincidentEdits :+ (insertedElementOnLeft -> insertedElementOnRight)
+        def rightEditNotMaroonedByPriorCoincidentInsertion(
+            leftTail: Seq[Contribution[Element]]
+        ) =
+          // Guard against a coincident insertion prior to the left side
+          // of a pending right edit or deletion; that would maroon the
+          // latter, so we *would* coalesce the following element on the
+          // right.
+          leftTail
+            .takeWhile {
+              case Contribution.CommonToBaseAndLeftOnly(_) => false
+              case _                                       => true
+            }
+            .forall {
+              case Contribution.CommonToLeftAndRightOnly(_) => false
+              case _                                        => true
+            }
+
+        def leftEditNotMaroonedByPriorCoincidentInsertion(
+            rightTail: Seq[Contribution[Element]]
+        ) =
+          // Guard against a coincident insertion prior to the right side
+          // of a pending left edit or deletion; that would maroon the
+          // latter, so we *would* coalesce the following element on the
+          // left.
+          rightTail
+            .takeWhile {
+              case Contribution.CommonToBaseAndRightOnly(_) => false
+              case _                                        => true
+            }
+            .forall {
+              case Contribution.CommonToLeftAndRightOnly(_) => false
+              case _                                        => true
+            }
+
+        def rightEditNotMaroonedByPriorLeftDeletion(
+            baseTail: Seq[Contribution[Element]]
+        ) =
+          baseTail
+            .takeWhile {
+              case Contribution.CommonToBaseAndLeftOnly(_) => false
+              case _                                       => true
+            }
+            .forall {
+              case Contribution.CommonToBaseAndRightOnly(_) => false
+              case _                                        => true
+            }
+
+        def leftEditNotMaroonedByPriorRightDeletion(
+            baseTail: Seq[Contribution[Element]]
+        ) =
+          baseTail
+            .takeWhile {
+              case Contribution.CommonToBaseAndRightOnly(_) => false
+              case _                                        => true
+            }
+            .forall {
+              case Contribution.CommonToBaseAndLeftOnly(_) => false
+              case _                                       => true
+            }
+
+        trait LeftEditOperations:
+          def coalesceLeftInsertion(insertedElement: Element): LeftEdit
+          def finalLeftEdit(
+              result: Result[Element],
+              editedBaseElement: Element,
+              editedRightElement: Element,
+              insertedElement: Element
+          ): Result[Element]
+        end LeftEditOperations
+
+        trait RightEditOperations:
+          def coalesceRightInsertion(insertedElement: Element): RightEdit
+          def finalRightEdit(
+              result: Result[Element],
+              editedBaseElement: Element,
+              editedLeftElement: Element,
+              insertedElement: Element
+          ): Result[Element]
+        end RightEditOperations
+
+        trait CoincidentEditOperations:
+          def coalesceCoincidentInsertion(
+              insertedElementOnLeft: Element,
+              insertedElementOnRight: Element
+          ): CoincidentEdit
+          def finalCoincidentEdit(
+              result: Result[Element],
+              editedElement: Element,
+              insertedElementOnLeft: Element,
+              insertedElementOnRight: Element
+          ): Result[Element]
+        end CoincidentEditOperations
+
+        trait ConflictOperations:
+          def coalesceConflict(
+              editedBaseElement: Option[Element],
+              leftElement: Option[Element],
+              rightElement: Option[Element]
+          ): Conflict
+          def finalConflict(
+              result: Result[Element],
+              editedElement: Option[Element],
+              leftElement: Option[Element],
+              rightElement: Option[Element]
+          ): Result[Element]
+        end ConflictOperations
+
+        trait Coalescence:
+        end Coalescence
+        object NoCoalescence
+            extends Coalescence
+            with LeftEditOperations
+            with RightEditOperations
+            with CoincidentEditOperations
+            with ConflictOperations:
+          private val leftEdit = LeftEdit(
+            deferredLeftEdits = IndexedSeq.empty
           )
-      end CoincidentEdit
+          private val rightEdit = RightEdit(
+            deferredRightEdits = IndexedSeq.empty
+          )
+          private val coincidentEdit = CoincidentEdit(
+            deferredCoincidentEdits = IndexedSeq.empty
+          )
+          private val conflict = Conflict(
+            deferredEdited = IndexedSeq.empty,
+            deferredLeftEdits = IndexedSeq.empty,
+            deferredRightEdits = IndexedSeq.empty
+          )
 
-      case class Conflict(
-          deferredEdited: IndexedSeq[Element],
-          deferredLeftEdits: IndexedSeq[Element],
-          deferredRightEdits: IndexedSeq[Element]
-      ) extends Coalescence
-          with ConflictOperations:
-        override def coalesceConflict(
-            editedBaseElement: Option[Element],
-            leftElement: Option[Element],
-            rightElement: Option[Element]
-        ): Conflict = this
-          .focus(_.deferredEdited)
-          .modify(_ ++ editedBaseElement)
-          .focus(_.deferredLeftEdits)
-          .modify(_ ++ leftElement)
-          .focus(_.deferredRightEdits)
-          .modify(_ ++ rightElement)
+          // Export the union of the various APIs...
+          export leftEdit.{coalesceLeftInsertion, finalLeftEdit}
+          export rightEdit.{coalesceRightInsertion, finalRightEdit}
+          export coincidentEdit.{coalesceCoincidentInsertion, finalCoincidentEdit}
+          export conflict.{coalesceConflict, finalConflict}
+        end NoCoalescence
 
-        override def finalConflict(
-            result: Result[Element],
-            editedElement: Option[Element],
-            leftElement: Option[Element],
-            rightElement: Option[Element]
-        ): Result[Element] = mergeAlgebra.conflict(
-          result,
-          editedElements = deferredEdited ++ editedElement,
-          leftEditElements = deferredLeftEdits ++ leftElement,
-          rightEditElements = deferredRightEdits ++ rightElement
-        )
-      end Conflict
+        case class LeftEdit(
+            deferredLeftEdits: IndexedSeq[Element]
+        ) extends Coalescence
+            with LeftEditOperations:
+          override def coalesceLeftInsertion(insertedElement: Element): LeftEdit =
+            this.focus(_.deferredLeftEdits).modify(_ :+ insertedElement)
+          override def finalLeftEdit(
+              result: Result[Element],
+              editedBaseElement: Element,
+              editedRightElement: Element,
+              insertedElement: Element
+          ): Result[Element] = mergeAlgebra.leftEdit(
+            result,
+            editedBaseElement,
+            editedRightElement,
+            deferredLeftEdits :+ insertedElement
+          )
+        end LeftEdit
 
-      inline def insertionConflict(
-          base: Seq[Contribution[Element]],
-          left: Seq[Contribution[Element]],
-          right: Seq[Contribution[Element]],
-          partialResult: Result[Element],
-          conflictOperations: ConflictOperations,
-          leftElement: Element,
-          leftTail: Seq[Contribution[Element]],
-          rightElement: Element,
-          rightTail: Seq[Contribution[Element]]
-      ) =
-        leftTail -> rightTail match
-          case (
-                Seq(Contribution.Difference(_), _*),
-                Seq(Contribution.Difference(_), _*)
-              ) =>
-            logger.debug(
-              s"Conflict between left insertion of ${pprintCustomised(leftElement)} and right insertion of ${pprintCustomised(rightElement)}, coalescing with following left insertion and right insertion conflict."
+        case class RightEdit(
+            deferredRightEdits: IndexedSeq[Element]
+        ) extends Coalescence
+            with RightEditOperations:
+          override def coalesceRightInsertion(
+              insertedElement: Element
+          ): RightEdit =
+            this.focus(_.deferredRightEdits).modify(_ :+ insertedElement)
+
+          override def finalRightEdit(
+              result: Result[Element],
+              editedBaseElement: Element,
+              editedLeftElement: Element,
+              insertedElement: Element
+          ): Result[Element] = mergeAlgebra.rightEdit(
+            result,
+            editedBaseElement,
+            editedLeftElement,
+            editElements = deferredRightEdits :+ insertedElement
+          )
+        end RightEdit
+
+        case class CoincidentEdit(
+            deferredCoincidentEdits: IndexedSeq[(Element, Element)]
+        ) extends Coalescence
+            with CoincidentEditOperations:
+          override def coalesceCoincidentInsertion(
+              insertedElementOnLeft: Element,
+              insertedElementOnRight: Element
+          ): CoincidentEdit =
+            this
+              .focus(_.deferredCoincidentEdits)
+              .modify(_ :+ (insertedElementOnLeft -> insertedElementOnRight))
+          override def finalCoincidentEdit(
+              result: Result[Element],
+              editedElement: Element,
+              insertedElementOnLeft: Element,
+              insertedElementOnRight: Element
+          ): Result[Element] =
+            mergeAlgebra.coincidentEdit(
+              result,
+              editedElement,
+              editElements =
+                deferredCoincidentEdits :+ (insertedElementOnLeft -> insertedElementOnRight)
             )
-            mergeBetweenRunsOfCommonElements(base, leftTail, rightTail)(
-              partialResult,
-              coalescence = conflictOperations.coalesceConflict(
-                None,
-                Some(leftElement),
-                Some(rightElement)
+        end CoincidentEdit
+
+        case class Conflict(
+            deferredEdited: IndexedSeq[Element],
+            deferredLeftEdits: IndexedSeq[Element],
+            deferredRightEdits: IndexedSeq[Element]
+        ) extends Coalescence
+            with ConflictOperations:
+          override def coalesceConflict(
+              editedBaseElement: Option[Element],
+              leftElement: Option[Element],
+              rightElement: Option[Element]
+          ): Conflict = this
+            .focus(_.deferredEdited)
+            .modify(_ ++ editedBaseElement)
+            .focus(_.deferredLeftEdits)
+            .modify(_ ++ leftElement)
+            .focus(_.deferredRightEdits)
+            .modify(_ ++ rightElement)
+
+          override def finalConflict(
+              result: Result[Element],
+              editedElement: Option[Element],
+              leftElement: Option[Element],
+              rightElement: Option[Element]
+          ): Result[Element] = mergeAlgebra.conflict(
+            result,
+            editedElements = deferredEdited ++ editedElement,
+            leftEditElements = deferredLeftEdits ++ leftElement,
+            rightEditElements = deferredRightEdits ++ rightElement
+          )
+        end Conflict
+
+        inline def insertionConflict(
+            base: Seq[Contribution[Element]],
+            left: Seq[Contribution[Element]],
+            right: Seq[Contribution[Element]],
+            partialResult: Result[Element],
+            conflictOperations: ConflictOperations,
+            leftElement: Element,
+            leftTail: Seq[Contribution[Element]],
+            rightElement: Element,
+            rightTail: Seq[Contribution[Element]]
+        ) =
+          leftTail -> rightTail match
+            case (
+                  Seq(Contribution.Difference(_), _*),
+                  Seq(Contribution.Difference(_), _*)
+                ) =>
+              logger.debug(
+                s"Conflict between left insertion of ${pprintCustomised(leftElement)} and right insertion of ${pprintCustomised(rightElement)}, coalescing with following left insertion and right insertion conflict."
               )
-            )
-
-          case (Seq(Contribution.Difference(_), _*), _) =>
-            logger.debug(
-              s"Conflict between left insertion of ${pprintCustomised(leftElement)} and right insertion of ${pprintCustomised(rightElement)}, coalescing with following left insertion."
-            )
-            mergeBetweenRunsOfCommonElements(base, leftTail, right)(
-              partialResult,
-              coalescence = conflictOperations.coalesceConflict(
-                None,
-                Some(leftElement),
-                None
-              )
-            )
-
-          case (_, Seq(Contribution.Difference(_), _*)) =>
-            logger.debug(
-              s"Conflict between left insertion of ${pprintCustomised(leftElement)} and right insertion of ${pprintCustomised(rightElement)}, coalescing with following right insertion."
-            )
-            mergeBetweenRunsOfCommonElements(base, left, rightTail)(
-              partialResult,
-              coalescence = conflictOperations.coalesceConflict(
-                None,
-                None,
-                Some(rightElement)
-              )
-            )
-
-          case _ =>
-            logger.debug(
-              s"Conflict between left insertion of ${pprintCustomised(leftElement)} and right insertion of ${pprintCustomised(rightElement)}."
-            )
-            mergeBetweenRunsOfCommonElements(base, leftTail, rightTail)(
-              partialResult = conflictOperations.finalConflict(
+              mergeBetweenRunsOfCommonElements(base, leftTail, rightTail)(
                 partialResult,
-                None,
-                Some(leftElement),
-                Some(rightElement)
-              ),
-              coalescence = NoCoalescence
-            )
-
-      inline def rightEditLeftDeletionConflict(
-          base: Seq[Contribution[Element]],
-          left: Seq[Contribution[Element]],
-          right: Seq[Contribution[Element]],
-          partialResult: Result[Element],
-          conflictOperations: ConflictOperations,
-          editedBaseElement: Element,
-          baseTail: Seq[Contribution[Element]],
-          rightElement: Element,
-          rightTail: Seq[Contribution[Element]]
-      ) =
-        baseTail -> rightTail match
-          case (
-                Seq(Contribution.Difference(_), _*),
-                Seq(Contribution.Difference(_), _*)
-              ) =>
-            logger.debug(
-              s"Conflict between left deletion of ${pprintCustomised(editedBaseElement)} and its edit on the right into ${pprintCustomised(rightElement)}, coalescing with following left deletion and right edit conflict."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, left, rightTail)(
-              partialResult,
-              coalescence = conflictOperations.coalesceConflict(
-                Some(editedBaseElement),
-                None,
-                Some(rightElement)
-              )
-            )
-
-          case (_, Seq(Contribution.Difference(followingRightElement), _*)) =>
-            logger.debug(
-              s"Conflict between left deletion of ${pprintCustomised(editedBaseElement)} and its edit on the right into ${pprintCustomised(rightElement)}, coalescing with following insertion of ${pprintCustomised(followingRightElement)} on the right."
-            )
-            mergeBetweenRunsOfCommonElements(base, left, rightTail)(
-              partialResult,
-              coalescence = conflictOperations.coalesceConflict(
-                None,
-                None,
-                Some(rightElement)
-              )
-            )
-
-          case (
-                Seq(Contribution.Difference(followingBaseElement), _*),
-                _
-              ) =>
-            logger.debug(
-              s"Conflict between left deletion of ${pprintCustomised(editedBaseElement)} and its edit on the right into ${pprintCustomised(rightElement)}, coalescing with following coincident deletion of ${pprintCustomised(followingBaseElement)}."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, left, right)(
-              partialResult,
-              coalescence = conflictOperations.coalesceConflict(
-                Some(editedBaseElement),
-                None,
-                None
-              )
-            )
-
-          case _ =>
-            logger.debug(
-              s"Conflict between left deletion of ${pprintCustomised(editedBaseElement)} and its edit on the right into ${pprintCustomised(rightElement)}."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, left, rightTail)(
-              partialResult = conflictOperations.finalConflict(
-                partialResult,
-                Some(editedBaseElement),
-                None,
-                Some(rightElement)
-              ),
-              coalescence = NoCoalescence
-            )
-
-      inline def leftEditRightDeletionConflict(
-          base: Seq[Contribution[Element]],
-          left: Seq[Contribution[Element]],
-          right: Seq[Contribution[Element]],
-          partialResult: Result[Element],
-          conflictOperations: ConflictOperations,
-          editedBaseElement: Element,
-          baseTail: Seq[Contribution[Element]],
-          leftElement: Element,
-          leftTail: Seq[Contribution[Element]]
-      ) =
-        baseTail -> leftTail match
-          case (
-                Seq(Contribution.Difference(_), _*),
-                Seq(Contribution.Difference(_), _*)
-              ) =>
-            logger.debug(
-              s"Conflict between right deletion of ${pprintCustomised(editedBaseElement)} and its edit on the left into ${pprintCustomised(leftElement)}, coalescing with following right deletion and left edit conflict."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, leftTail, right)(
-              partialResult,
-              coalescence = conflictOperations.coalesceConflict(
-                Some(editedBaseElement),
-                Some(leftElement),
-                None
-              )
-            )
-
-          case (_, Seq(Contribution.Difference(followingLeftElement), _*)) =>
-            logger.debug(
-              s"Conflict between right deletion of ${pprintCustomised(editedBaseElement)} and its edit on the left into ${pprintCustomised(leftElement)}, coalescing with following insertion of ${pprintCustomised(followingLeftElement)} on the left."
-            )
-            mergeBetweenRunsOfCommonElements(base, leftTail, right)(
-              partialResult,
-              coalescence = conflictOperations.coalesceConflict(
-                None,
-                Some(leftElement),
-                None
-              )
-            )
-
-          case (
-                Seq(Contribution.Difference(followingBaseElement), _*),
-                _
-              ) =>
-            logger.debug(
-              s"Conflict between right deletion of ${pprintCustomised(editedBaseElement)} and its edit on the left into ${pprintCustomised(leftElement)}, coalescing with following coincident deletion of ${pprintCustomised(followingBaseElement)}."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, left, right)(
-              partialResult,
-              coalescence = conflictOperations.coalesceConflict(
-                Some(editedBaseElement),
-                None,
-                None
-              )
-            )
-
-          case _ =>
-            logger.debug(
-              s"Conflict between right deletion of ${pprintCustomised(editedBaseElement)} and its edit on the left into ${pprintCustomised(leftElement)}."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, leftTail, right)(
-              partialResult = conflictOperations.finalConflict(
-                partialResult,
-                Some(editedBaseElement),
-                Some(leftElement),
-                None
-              ),
-              coalescence = NoCoalescence
-            )
-
-      inline def conflict(
-          base: Seq[Contribution[Element]],
-          left: Seq[Contribution[Element]],
-          right: Seq[Contribution[Element]],
-          partialResult: Result[Element],
-          conflictOperations: ConflictOperations,
-          editedBaseElement: Element,
-          baseTail: Seq[Contribution[Element]],
-          leftElement: Element,
-          leftTail: Seq[Contribution[Element]],
-          rightElement: Element,
-          rightTail: Seq[Contribution[Element]]
-      ) =
-        (baseTail, leftTail, rightTail) match
-          case (
-                Seq(Contribution.Difference(_), _*),
-                Seq(Contribution.Difference(_), _*),
-                Seq(Contribution.Difference(_), _*)
-              ) =>
-            // Edit conflict with another pending edit conflict.
-            logger.debug(
-              s"Edit conflict of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right, coalescing with following edit conflict."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
-              partialResult,
-              coalescence = conflictOperations.coalesceConflict(
-                Some(editedBaseElement),
-                Some(leftElement),
-                Some(rightElement)
-              )
-            )
-
-          case (
-                Seq(Contribution.Difference(_), _*),
-                Seq(Contribution.Difference(_), _*),
-                _
-              ) =>
-            // Edit conflict with a pending left edit versus right deletion
-            // conflict.
-            logger.debug(
-              s"Edit conflict of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right, coalescing with following left edit versus right deletion conflict."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, leftTail, right)(
-              partialResult,
-              coalescence = conflictOperations.coalesceConflict(
-                Some(editedBaseElement),
-                Some(leftElement),
-                None
-              )
-            )
-
-          case (
-                Seq(Contribution.Difference(_), _*),
-                _,
-                Seq(Contribution.Difference(_), _*)
-              ) =>
-            // Edit conflict with a pending right edit versus left deletion
-            // conflict.
-            logger.debug(
-              s"Edit conflict of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right, coalescing with following right edit versus left deletion conflict."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, left, rightTail)(
-              partialResult,
-              coalescence = conflictOperations.coalesceConflict(
-                Some(editedBaseElement),
-                None,
-                Some(rightElement)
-              )
-            )
-
-          case (
-                _,
-                Seq(Contribution.Difference(_), _*),
-                Seq(Contribution.Difference(_), _*)
-              ) =>
-            // Edit conflict with a pending left insertion versus right
-            // insertion conflict.
-            logger.debug(
-              s"Edit conflict of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right, coalescing with following left insertion versus right insertion conflict."
-            )
-            mergeBetweenRunsOfCommonElements(base, leftTail, rightTail)(
-              partialResult,
-              coalescence = conflictOperations.coalesceConflict(
-                None,
-                Some(leftElement),
-                Some(rightElement)
-              )
-            )
-
-          case (
-                Seq(
-                  Contribution.CommonToBaseAndLeftOnly(_),
-                  _*
-                ),
-                Seq(
-                  Contribution.Difference(followingLeftElement),
-                  _*
-                ),
-                _
-              ) if rightEditNotMaroonedByPriorCoincidentInsertion(leftTail) =>
-            // Left edit / right deletion conflict with pending left insertion
-            // and pending right edit.
-            logger.debug(
-              s"Conflict between right deletion of ${pprintCustomised(editedBaseElement)} and its edit on the left into ${pprintCustomised(leftElement)}, coalescing with following insertion of ${pprintCustomised(followingLeftElement)} on the left."
-            )
-            mergeBetweenRunsOfCommonElements(base, leftTail, right)(
-              partialResult,
-              coalescence = conflictOperations.coalesceConflict(
-                None,
-                Some(leftElement),
-                None
-              )
-            )
-
-          case (
-                Seq(
-                  Contribution.CommonToBaseAndLeftOnly(_),
-                  _*
-                ),
-                _,
-                _
-              ) if rightEditNotMaroonedByPriorCoincidentInsertion(leftTail) =>
-            // Left edit / right deletion conflict with pending right edit.
-            logger.debug(
-              s"Conflict between right deletion of ${pprintCustomised(editedBaseElement)} and its edit on the left into ${pprintCustomised(leftElement)} with following right edit."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, leftTail, right)(
-              partialResult = conflictOperations.finalConflict(
-                partialResult,
-                Some(editedBaseElement),
-                Some(leftElement),
-                None
-              ),
-              coalescence = NoCoalescence
-            )
-
-          case (
-                Seq(
-                  Contribution.CommonToBaseAndRightOnly(_),
-                  _*
-                ),
-                _,
-                Seq(Contribution.Difference(followingRightElement), _*)
-              ) if leftEditNotMaroonedByPriorCoincidentInsertion(rightTail) =>
-            // Right edit / left deletion conflict with pending right
-            // insertion and pending left edit.
-            logger.debug(
-              s"Conflict between left deletion of ${pprintCustomised(editedBaseElement)} and its edit on the right into ${pprintCustomised(rightElement)}, coalescing with following insertion of ${pprintCustomised(followingRightElement)} on the right."
-            )
-            mergeBetweenRunsOfCommonElements(base, left, rightTail)(
-              partialResult,
-              coalescence = conflictOperations.coalesceConflict(
-                None,
-                None,
-                Some(rightElement)
-              )
-            )
-
-          case (
-                Seq(
-                  Contribution.CommonToBaseAndRightOnly(_),
-                  _*
-                ),
-                _,
-                _
-              ) if leftEditNotMaroonedByPriorCoincidentInsertion(rightTail) =>
-            // Right edit / left deletion conflict with pending left edit.
-            logger.debug(
-              s"Conflict between left deletion of ${pprintCustomised(editedBaseElement)} and its edit on the right into ${pprintCustomised(rightElement)} with following left edit."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, left, rightTail)(
-              partialResult = conflictOperations.finalConflict(
-                partialResult,
-                Some(editedBaseElement),
-                None,
-                Some(rightElement)
-              ),
-              coalescence = NoCoalescence
-            )
-
-          case (
-                Seq(Contribution.Difference(followingBaseElement), _*),
-                Seq(Contribution.CommonToLeftAndRightOnly(_), _*),
-                Seq(Contribution.CommonToLeftAndRightOnly(_), _*)
-              ) =>
-            // Edit conflict with a pending coincident edit.
-            logger.debug(
-              s"Edit conflict of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right with following coincident edit of ${pprintCustomised(followingBaseElement)}."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
-              partialResult = conflictOperations.finalConflict(
-                partialResult,
-                Some(editedBaseElement),
-                Some(leftElement),
-                Some(rightElement)
-              ),
-              coalescence = NoCoalescence
-            )
-
-          case (
-                Seq(Contribution.Difference(followingBaseElement), _*),
-                _,
-                _
-              ) =>
-            // If the following element in the base would also be deleted on
-            // both sides, coalesce into a single edit conflict.
-            logger.debug(
-              s"Edit conflict of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right, coalescing with following coincident deletion of ${pprintCustomised(followingBaseElement)}."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, left, right)(
-              partialResult,
-              coalescence = conflictOperations.coalesceConflict(
-                Some(editedBaseElement),
-                None,
-                None
-              )
-            )
-
-          case (
-                _,
-                Seq(Contribution.Difference(followingLeftElement), _*),
-                _
-              ) =>
-            // Edit conflict with a pending left insertion.
-            logger.debug(
-              s"Edit conflict of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right, coalescing with following left insertion of ${pprintCustomised(followingLeftElement)}."
-            )
-            mergeBetweenRunsOfCommonElements(base, leftTail, right)(
-              partialResult,
-              coalescence = conflictOperations.coalesceConflict(
-                None,
-                Some(leftElement),
-                None
-              )
-            )
-
-          case (
-                _,
-                _,
-                Seq(Contribution.Difference(followingRightElement), _*)
-              ) =>
-            // Edit conflict with a pending right insertion.
-            logger.debug(
-              s"Edit conflict of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right, coalescing with following right insertion of ${pprintCustomised(followingRightElement)}."
-            )
-            mergeBetweenRunsOfCommonElements(base, left, rightTail)(
-              partialResult,
-              coalescence = conflictOperations.coalesceConflict(
-                None,
-                None,
-                Some(rightElement)
-              )
-            )
-
-          case _ =>
-            // Edit conflict.
-            logger.debug(
-              s"Edit conflict of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
-              partialResult = conflictOperations.finalConflict(
-                partialResult,
-                Some(editedBaseElement),
-                Some(leftElement),
-                Some(rightElement)
-              ),
-              coalescence = NoCoalescence
-            )
-        end match
-      end conflict
-
-      inline def leftEdit(
-          base: Seq[Contribution[Element]],
-          partialResult: Result[Element],
-          editedBaseElement: Element,
-          editedRightElement: Element,
-          baseTail: Seq[Contribution[Element]],
-          leftTail: Seq[Contribution[Element]],
-          rightTail: Seq[Contribution[Element]]
-      )(
-          leftEditOperations: LeftEditOperations,
-          leftElement: Element,
-          right: Seq[Contribution[Element]]
-      ) =
-        baseTail -> leftTail match
-          case (
-                Seq(
-                  Contribution.Difference(followingBaseElement),
-                  _*
-                ),
-                _
-              ) if leftEditNotMaroonedByPriorCoincidentInsertion(rightTail) =>
-            // There is a pending coincident deletion; handle this left edit
-            // in isolation without coalescing any following left insertion.
-            logger.debug(
-              s"Left edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} with following coincident deletion of ${pprintCustomised(followingBaseElement)}."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
-              partialResult = leftEditOperations
-                .finalLeftEdit(
-                  partialResult,
-                  editedBaseElement,
-                  editedRightElement,
-                  leftElement
-                ),
-              coalescence = NoCoalescence
-            )
-
-          case (
-                Seq(Contribution.CommonToBaseAndRightOnly(_), _*),
-                Seq(Contribution.Difference(_), _*)
-              ) if leftEditNotMaroonedByPriorCoincidentInsertion(rightTail) =>
-            // There is another pending left edit, but *don't* coalesce the
-            // following element on the left; that then respects any
-            // insertions that may be lurking on the right prior to the
-            // pending left edit claiming the following element on the left.
-            logger.debug(
-              s"Left edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)}, not coalescing with following left edit."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
-              partialResult = leftEditOperations
-                .finalLeftEdit(
-                  partialResult,
-                  editedBaseElement,
-                  editedRightElement,
-                  leftElement
-                ),
-              coalescence = NoCoalescence
-            )
-
-          case (_, Seq(Contribution.Difference(followingLeftElement), _*)) =>
-            // If the following element on the left would also be inserted,
-            // coalesce into a single edit.
-            logger.debug(
-              s"Left edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)}, coalescing with following insertion of ${pprintCustomised(followingLeftElement)} on the left."
-            )
-            mergeBetweenRunsOfCommonElements(base, leftTail, right)(
-              partialResult,
-              coalescence =
-                leftEditOperations.coalesceLeftInsertion(leftElement)
-            )
-
-          case _ =>
-            logger.debug(
-              s"Left edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)}."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
-              partialResult = leftEditOperations
-                .finalLeftEdit(
-                  partialResult,
-                  editedBaseElement,
-                  editedRightElement,
-                  leftElement
-                ),
-              coalescence = NoCoalescence
-            )
-        end match
-      end leftEdit
-
-      inline def rightEdit(
-          base: Seq[Contribution[Element]],
-          partialResult: Result[Element],
-          editedBaseElement: Element,
-          editedLeftElement: Element,
-          baseTail: Seq[Contribution[Element]],
-          leftTail: Seq[Contribution[Element]],
-          rightTail: Seq[Contribution[Element]]
-      )(
-          rightEditOperations: RightEditOperations,
-          rightElement: Element,
-          left: Seq[Contribution[Element]]
-      ) =
-        baseTail -> rightTail match
-          case (
-                Seq(
-                  Contribution.Difference(followingBaseElement),
-                  _*
-                ),
-                _
-              ) if rightEditNotMaroonedByPriorCoincidentInsertion(leftTail) =>
-            // There is a pending coincident deletion; handle this right edit
-            // in isolation without coalescing any following right insertion.
-            logger.debug(
-              s"Right edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(rightElement)} with following coincident deletion of ${pprintCustomised(followingBaseElement)}."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
-              partialResult = rightEditOperations.finalRightEdit(
-                partialResult,
-                editedBaseElement,
-                editedLeftElement,
-                rightElement
-              ),
-              coalescence = NoCoalescence
-            )
-
-          case (
-                Seq(Contribution.CommonToBaseAndLeftOnly(_), _*),
-                Seq(Contribution.Difference(_), _*)
-              ) if rightEditNotMaroonedByPriorCoincidentInsertion(leftTail) =>
-            // There is another pending right edit, but *don't* coalesce the
-            // following element on the right; that then respects any
-            // insertions that may be lurking on the left prior to the pending
-            // right edit claiming the following element on the right.
-            logger.debug(
-              s"Right edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(rightElement)}, not coalescing with following right edit."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
-              partialResult = rightEditOperations.finalRightEdit(
-                partialResult,
-                editedBaseElement,
-                editedLeftElement,
-                rightElement
-              ),
-              coalescence = NoCoalescence
-            )
-
-          case (_, Seq(Contribution.Difference(followingRightElement), _*)) =>
-            // If the following element on the right would also be inserted,
-            // coalesce into a single edit.
-            logger.debug(
-              s"Right edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(rightElement)}, coalescing with following insertion of ${pprintCustomised(followingRightElement)} on the right."
-            )
-            mergeBetweenRunsOfCommonElements(base, left, rightTail)(
-              partialResult,
-              coalescence =
-                rightEditOperations.coalesceRightInsertion(rightElement)
-            )
-
-          case _ =>
-            logger.debug(
-              s"Right edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(rightElement)}."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
-              rightEditOperations.finalRightEdit(
-                partialResult,
-                editedBaseElement,
-                editedLeftElement,
-                rightElement
-              ),
-              coalescence = NoCoalescence
-            )
-        end match
-      end rightEdit
-
-      inline def coincidentEdit(
-          base: Seq[Contribution[Element]],
-          partialResult: Result[Element],
-          editedBaseElement: Element,
-          baseTail: Seq[Contribution[Element]],
-          leftTail: Seq[Contribution[Element]],
-          rightTail: Seq[Contribution[Element]]
-      )(
-          coincidentEditOperations: CoincidentEditOperations,
-          coincidentElementOnLeft: Element,
-          coincidentElementOnRight: Element
-      ) =
-        (baseTail, leftTail, rightTail) match
-          case (
-                Seq(Contribution.Difference(_), _*),
-                Seq(Contribution.CommonToLeftAndRightOnly(_), _*),
-                Seq(Contribution.CommonToLeftAndRightOnly(_), _*)
-              ) =>
-            logger.debug(
-              s"Coincident edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(coincidentElementOnLeft)} on the left and ${pprintCustomised(coincidentElementOnRight)} on the right, not coalescing with following coincident edit."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
-              partialResult = coincidentEditOperations.finalCoincidentEdit(
-                partialResult,
-                editedBaseElement,
-                coincidentElementOnLeft,
-                coincidentElementOnRight
-              ),
-              coalescence = NoCoalescence
-            )
-
-          case (
-                _,
-                Seq(
-                  Contribution.CommonToLeftAndRightOnly(followingLeftElement),
-                  _*
-                ),
-                Seq(
-                  Contribution.CommonToLeftAndRightOnly(followingRightElement),
-                  _*
+                coalescence = conflictOperations.coalesceConflict(
+                  None,
+                  Some(leftElement),
+                  Some(rightElement)
                 )
-              ) =>
-            logger.debug(
-              s"Coincident edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(coincidentElementOnLeft)} on the left and ${pprintCustomised(coincidentElementOnRight)} on the right, coalescing with following coincident insertion of ${pprintCustomised(followingLeftElement)} on the left and ${pprintCustomised(followingRightElement)} on the right."
-            )
-            mergeBetweenRunsOfCommonElements(base, leftTail, rightTail)(
-              partialResult,
-              coalescence =
-                coincidentEditOperations.coalesceCoincidentInsertion(
+              )
+
+            case (Seq(Contribution.Difference(_), _*), _) =>
+              logger.debug(
+                s"Conflict between left insertion of ${pprintCustomised(leftElement)} and right insertion of ${pprintCustomised(rightElement)}, coalescing with following left insertion."
+              )
+              mergeBetweenRunsOfCommonElements(base, leftTail, right)(
+                partialResult,
+                coalescence = conflictOperations.coalesceConflict(
+                  None,
+                  Some(leftElement),
+                  None
+                )
+              )
+
+            case (_, Seq(Contribution.Difference(_), _*)) =>
+              logger.debug(
+                s"Conflict between left insertion of ${pprintCustomised(leftElement)} and right insertion of ${pprintCustomised(rightElement)}, coalescing with following right insertion."
+              )
+              mergeBetweenRunsOfCommonElements(base, left, rightTail)(
+                partialResult,
+                coalescence = conflictOperations.coalesceConflict(
+                  None,
+                  None,
+                  Some(rightElement)
+                )
+              )
+
+            case _ =>
+              logger.debug(
+                s"Conflict between left insertion of ${pprintCustomised(leftElement)} and right insertion of ${pprintCustomised(rightElement)}."
+              )
+              mergeBetweenRunsOfCommonElements(base, leftTail, rightTail)(
+                partialResult = conflictOperations.finalConflict(
+                  partialResult,
+                  None,
+                  Some(leftElement),
+                  Some(rightElement)
+                ),
+                coalescence = NoCoalescence
+              )
+
+        inline def rightEditLeftDeletionConflict(
+            base: Seq[Contribution[Element]],
+            left: Seq[Contribution[Element]],
+            right: Seq[Contribution[Element]],
+            partialResult: Result[Element],
+            conflictOperations: ConflictOperations,
+            editedBaseElement: Element,
+            baseTail: Seq[Contribution[Element]],
+            rightElement: Element,
+            rightTail: Seq[Contribution[Element]]
+        ) =
+          baseTail -> rightTail match
+            case (
+                  Seq(Contribution.Difference(_), _*),
+                  Seq(Contribution.Difference(_), _*)
+                ) =>
+              logger.debug(
+                s"Conflict between left deletion of ${pprintCustomised(editedBaseElement)} and its edit on the right into ${pprintCustomised(rightElement)}, coalescing with following left deletion and right edit conflict."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, left, rightTail)(
+                partialResult,
+                coalescence = conflictOperations.coalesceConflict(
+                  Some(editedBaseElement),
+                  None,
+                  Some(rightElement)
+                )
+              )
+
+            case (_, Seq(Contribution.Difference(followingRightElement), _*)) =>
+              logger.debug(
+                s"Conflict between left deletion of ${pprintCustomised(editedBaseElement)} and its edit on the right into ${pprintCustomised(rightElement)}, coalescing with following insertion of ${pprintCustomised(followingRightElement)} on the right."
+              )
+              mergeBetweenRunsOfCommonElements(base, left, rightTail)(
+                partialResult,
+                coalescence = conflictOperations.coalesceConflict(
+                  None,
+                  None,
+                  Some(rightElement)
+                )
+              )
+
+            case (
+                  Seq(Contribution.Difference(followingBaseElement), _*),
+                  _
+                ) =>
+              logger.debug(
+                s"Conflict between left deletion of ${pprintCustomised(editedBaseElement)} and its edit on the right into ${pprintCustomised(rightElement)}, coalescing with following coincident deletion of ${pprintCustomised(followingBaseElement)}."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, left, right)(
+                partialResult,
+                coalescence = conflictOperations.coalesceConflict(
+                  Some(editedBaseElement),
+                  None,
+                  None
+                )
+              )
+
+            case _ =>
+              logger.debug(
+                s"Conflict between left deletion of ${pprintCustomised(editedBaseElement)} and its edit on the right into ${pprintCustomised(rightElement)}."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, left, rightTail)(
+                partialResult = conflictOperations.finalConflict(
+                  partialResult,
+                  Some(editedBaseElement),
+                  None,
+                  Some(rightElement)
+                ),
+                coalescence = NoCoalescence
+              )
+
+        inline def leftEditRightDeletionConflict(
+            base: Seq[Contribution[Element]],
+            left: Seq[Contribution[Element]],
+            right: Seq[Contribution[Element]],
+            partialResult: Result[Element],
+            conflictOperations: ConflictOperations,
+            editedBaseElement: Element,
+            baseTail: Seq[Contribution[Element]],
+            leftElement: Element,
+            leftTail: Seq[Contribution[Element]]
+        ) =
+          baseTail -> leftTail match
+            case (
+                  Seq(Contribution.Difference(_), _*),
+                  Seq(Contribution.Difference(_), _*)
+                ) =>
+              logger.debug(
+                s"Conflict between right deletion of ${pprintCustomised(editedBaseElement)} and its edit on the left into ${pprintCustomised(leftElement)}, coalescing with following right deletion and left edit conflict."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, leftTail, right)(
+                partialResult,
+                coalescence = conflictOperations.coalesceConflict(
+                  Some(editedBaseElement),
+                  Some(leftElement),
+                  None
+                )
+              )
+
+            case (_, Seq(Contribution.Difference(followingLeftElement), _*)) =>
+              logger.debug(
+                s"Conflict between right deletion of ${pprintCustomised(editedBaseElement)} and its edit on the left into ${pprintCustomised(leftElement)}, coalescing with following insertion of ${pprintCustomised(followingLeftElement)} on the left."
+              )
+              mergeBetweenRunsOfCommonElements(base, leftTail, right)(
+                partialResult,
+                coalescence = conflictOperations.coalesceConflict(
+                  None,
+                  Some(leftElement),
+                  None
+                )
+              )
+
+            case (
+                  Seq(Contribution.Difference(followingBaseElement), _*),
+                  _
+                ) =>
+              logger.debug(
+                s"Conflict between right deletion of ${pprintCustomised(editedBaseElement)} and its edit on the left into ${pprintCustomised(leftElement)}, coalescing with following coincident deletion of ${pprintCustomised(followingBaseElement)}."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, left, right)(
+                partialResult,
+                coalescence = conflictOperations.coalesceConflict(
+                  Some(editedBaseElement),
+                  None,
+                  None
+                )
+              )
+
+            case _ =>
+              logger.debug(
+                s"Conflict between right deletion of ${pprintCustomised(editedBaseElement)} and its edit on the left into ${pprintCustomised(leftElement)}."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, leftTail, right)(
+                partialResult = conflictOperations.finalConflict(
+                  partialResult,
+                  Some(editedBaseElement),
+                  Some(leftElement),
+                  None
+                ),
+                coalescence = NoCoalescence
+              )
+
+        inline def conflict(
+            base: Seq[Contribution[Element]],
+            left: Seq[Contribution[Element]],
+            right: Seq[Contribution[Element]],
+            partialResult: Result[Element],
+            conflictOperations: ConflictOperations,
+            editedBaseElement: Element,
+            baseTail: Seq[Contribution[Element]],
+            leftElement: Element,
+            leftTail: Seq[Contribution[Element]],
+            rightElement: Element,
+            rightTail: Seq[Contribution[Element]]
+        ) =
+          (baseTail, leftTail, rightTail) match
+            case (
+                  Seq(Contribution.Difference(_), _*),
+                  Seq(Contribution.Difference(_), _*),
+                  Seq(Contribution.Difference(_), _*)
+                ) =>
+              // Edit conflict with another pending edit conflict.
+              logger.debug(
+                s"Edit conflict of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right, coalescing with following edit conflict."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
+                partialResult,
+                coalescence = conflictOperations.coalesceConflict(
+                  Some(editedBaseElement),
+                  Some(leftElement),
+                  Some(rightElement)
+                )
+              )
+
+            case (
+                  Seq(Contribution.Difference(_), _*),
+                  Seq(Contribution.Difference(_), _*),
+                  _
+                ) =>
+              // Edit conflict with a pending left edit versus right deletion
+              // conflict.
+              logger.debug(
+                s"Edit conflict of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right, coalescing with following left edit versus right deletion conflict."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, leftTail, right)(
+                partialResult,
+                coalescence = conflictOperations.coalesceConflict(
+                  Some(editedBaseElement),
+                  Some(leftElement),
+                  None
+                )
+              )
+
+            case (
+                  Seq(Contribution.Difference(_), _*),
+                  _,
+                  Seq(Contribution.Difference(_), _*)
+                ) =>
+              // Edit conflict with a pending right edit versus left deletion
+              // conflict.
+              logger.debug(
+                s"Edit conflict of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right, coalescing with following right edit versus left deletion conflict."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, left, rightTail)(
+                partialResult,
+                coalescence = conflictOperations.coalesceConflict(
+                  Some(editedBaseElement),
+                  None,
+                  Some(rightElement)
+                )
+              )
+
+            case (
+                  _,
+                  Seq(Contribution.Difference(_), _*),
+                  Seq(Contribution.Difference(_), _*)
+                ) =>
+              // Edit conflict with a pending left insertion versus right
+              // insertion conflict.
+              logger.debug(
+                s"Edit conflict of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right, coalescing with following left insertion versus right insertion conflict."
+              )
+              mergeBetweenRunsOfCommonElements(base, leftTail, rightTail)(
+                partialResult,
+                coalescence = conflictOperations.coalesceConflict(
+                  None,
+                  Some(leftElement),
+                  Some(rightElement)
+                )
+              )
+
+            case (
+                  Seq(
+                    Contribution.CommonToBaseAndLeftOnly(_),
+                    _*
+                  ),
+                  Seq(
+                    Contribution.Difference(followingLeftElement),
+                    _*
+                  ),
+                  _
+                ) if rightEditNotMaroonedByPriorCoincidentInsertion(leftTail) =>
+              // Left edit / right deletion conflict with pending left insertion
+              // and pending right edit.
+              logger.debug(
+                s"Conflict between right deletion of ${pprintCustomised(editedBaseElement)} and its edit on the left into ${pprintCustomised(leftElement)}, coalescing with following insertion of ${pprintCustomised(followingLeftElement)} on the left."
+              )
+              mergeBetweenRunsOfCommonElements(base, leftTail, right)(
+                partialResult,
+                coalescence = conflictOperations.coalesceConflict(
+                  None,
+                  Some(leftElement),
+                  None
+                )
+              )
+
+            case (
+                  Seq(
+                    Contribution.CommonToBaseAndLeftOnly(_),
+                    _*
+                  ),
+                  _,
+                  _
+                ) if rightEditNotMaroonedByPriorCoincidentInsertion(leftTail) =>
+              // Left edit / right deletion conflict with pending right edit.
+              logger.debug(
+                s"Conflict between right deletion of ${pprintCustomised(editedBaseElement)} and its edit on the left into ${pprintCustomised(leftElement)} with following right edit."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, leftTail, right)(
+                partialResult = conflictOperations.finalConflict(
+                  partialResult,
+                  Some(editedBaseElement),
+                  Some(leftElement),
+                  None
+                ),
+                coalescence = NoCoalescence
+              )
+
+            case (
+                  Seq(
+                    Contribution.CommonToBaseAndRightOnly(_),
+                    _*
+                  ),
+                  _,
+                  Seq(Contribution.Difference(followingRightElement), _*)
+                ) if leftEditNotMaroonedByPriorCoincidentInsertion(rightTail) =>
+              // Right edit / left deletion conflict with pending right
+              // insertion and pending left edit.
+              logger.debug(
+                s"Conflict between left deletion of ${pprintCustomised(editedBaseElement)} and its edit on the right into ${pprintCustomised(rightElement)}, coalescing with following insertion of ${pprintCustomised(followingRightElement)} on the right."
+              )
+              mergeBetweenRunsOfCommonElements(base, left, rightTail)(
+                partialResult,
+                coalescence = conflictOperations.coalesceConflict(
+                  None,
+                  None,
+                  Some(rightElement)
+                )
+              )
+
+            case (
+                  Seq(
+                    Contribution.CommonToBaseAndRightOnly(_),
+                    _*
+                  ),
+                  _,
+                  _
+                ) if leftEditNotMaroonedByPriorCoincidentInsertion(rightTail) =>
+              // Right edit / left deletion conflict with pending left edit.
+              logger.debug(
+                s"Conflict between left deletion of ${pprintCustomised(editedBaseElement)} and its edit on the right into ${pprintCustomised(rightElement)} with following left edit."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, left, rightTail)(
+                partialResult = conflictOperations.finalConflict(
+                  partialResult,
+                  Some(editedBaseElement),
+                  None,
+                  Some(rightElement)
+                ),
+                coalescence = NoCoalescence
+              )
+
+            case (
+                  Seq(Contribution.Difference(followingBaseElement), _*),
+                  Seq(Contribution.CommonToLeftAndRightOnly(_), _*),
+                  Seq(Contribution.CommonToLeftAndRightOnly(_), _*)
+                ) =>
+              // Edit conflict with a pending coincident edit.
+              logger.debug(
+                s"Edit conflict of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right with following coincident edit of ${pprintCustomised(followingBaseElement)}."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
+                partialResult = conflictOperations.finalConflict(
+                  partialResult,
+                  Some(editedBaseElement),
+                  Some(leftElement),
+                  Some(rightElement)
+                ),
+                coalescence = NoCoalescence
+              )
+
+            case (
+                  Seq(Contribution.Difference(followingBaseElement), _*),
+                  _,
+                  _
+                ) =>
+              // If the following element in the base would also be deleted on
+              // both sides, coalesce into a single edit conflict.
+              logger.debug(
+                s"Edit conflict of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right, coalescing with following coincident deletion of ${pprintCustomised(followingBaseElement)}."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, left, right)(
+                partialResult,
+                coalescence = conflictOperations.coalesceConflict(
+                  Some(editedBaseElement),
+                  None,
+                  None
+                )
+              )
+
+            case (
+                  _,
+                  Seq(Contribution.Difference(followingLeftElement), _*),
+                  _
+                ) =>
+              // Edit conflict with a pending left insertion.
+              logger.debug(
+                s"Edit conflict of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right, coalescing with following left insertion of ${pprintCustomised(followingLeftElement)}."
+              )
+              mergeBetweenRunsOfCommonElements(base, leftTail, right)(
+                partialResult,
+                coalescence = conflictOperations.coalesceConflict(
+                  None,
+                  Some(leftElement),
+                  None
+                )
+              )
+
+            case (
+                  _,
+                  _,
+                  Seq(Contribution.Difference(followingRightElement), _*)
+                ) =>
+              // Edit conflict with a pending right insertion.
+              logger.debug(
+                s"Edit conflict of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right, coalescing with following right insertion of ${pprintCustomised(followingRightElement)}."
+              )
+              mergeBetweenRunsOfCommonElements(base, left, rightTail)(
+                partialResult,
+                coalescence = conflictOperations.coalesceConflict(
+                  None,
+                  None,
+                  Some(rightElement)
+                )
+              )
+
+            case _ =>
+              // Edit conflict.
+              logger.debug(
+                s"Edit conflict of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
+                partialResult = conflictOperations.finalConflict(
+                  partialResult,
+                  Some(editedBaseElement),
+                  Some(leftElement),
+                  Some(rightElement)
+                ),
+                coalescence = NoCoalescence
+              )
+          end match
+        end conflict
+
+        inline def leftEdit(
+            base: Seq[Contribution[Element]],
+            partialResult: Result[Element],
+            editedBaseElement: Element,
+            editedRightElement: Element,
+            baseTail: Seq[Contribution[Element]],
+            leftTail: Seq[Contribution[Element]],
+            rightTail: Seq[Contribution[Element]]
+        )(
+            leftEditOperations: LeftEditOperations,
+            leftElement: Element,
+            right: Seq[Contribution[Element]]
+        ) =
+          baseTail -> leftTail match
+            case (
+                  Seq(
+                    Contribution.Difference(followingBaseElement),
+                    _*
+                  ),
+                  _
+                ) if leftEditNotMaroonedByPriorCoincidentInsertion(rightTail) =>
+              // There is a pending coincident deletion; handle this left edit
+              // in isolation without coalescing any following left insertion.
+              logger.debug(
+                s"Left edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)} with following coincident deletion of ${pprintCustomised(followingBaseElement)}."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
+                partialResult = leftEditOperations
+                  .finalLeftEdit(
+                    partialResult,
+                    editedBaseElement,
+                    editedRightElement,
+                    leftElement
+                  ),
+                coalescence = NoCoalescence
+              )
+
+            case (
+                  Seq(Contribution.CommonToBaseAndRightOnly(_), _*),
+                  Seq(Contribution.Difference(_), _*)
+                ) if leftEditNotMaroonedByPriorCoincidentInsertion(rightTail) =>
+              // There is another pending left edit, but *don't* coalesce the
+              // following element on the left; that then respects any
+              // insertions that may be lurking on the right prior to the
+              // pending left edit claiming the following element on the left.
+              logger.debug(
+                s"Left edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)}, not coalescing with following left edit."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
+                partialResult = leftEditOperations
+                  .finalLeftEdit(
+                    partialResult,
+                    editedBaseElement,
+                    editedRightElement,
+                    leftElement
+                  ),
+                coalescence = NoCoalescence
+              )
+
+            case (_, Seq(Contribution.Difference(followingLeftElement), _*)) =>
+              // If the following element on the left would also be inserted,
+              // coalesce into a single edit.
+              logger.debug(
+                s"Left edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)}, coalescing with following insertion of ${pprintCustomised(followingLeftElement)} on the left."
+              )
+              mergeBetweenRunsOfCommonElements(base, leftTail, right)(
+                partialResult,
+                coalescence =
+                  leftEditOperations.coalesceLeftInsertion(leftElement)
+              )
+
+            case _ =>
+              logger.debug(
+                s"Left edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(leftElement)}."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
+                partialResult = leftEditOperations
+                  .finalLeftEdit(
+                    partialResult,
+                    editedBaseElement,
+                    editedRightElement,
+                    leftElement
+                  ),
+                coalescence = NoCoalescence
+              )
+          end match
+        end leftEdit
+
+        inline def rightEdit(
+            base: Seq[Contribution[Element]],
+            partialResult: Result[Element],
+            editedBaseElement: Element,
+            editedLeftElement: Element,
+            baseTail: Seq[Contribution[Element]],
+            leftTail: Seq[Contribution[Element]],
+            rightTail: Seq[Contribution[Element]]
+        )(
+            rightEditOperations: RightEditOperations,
+            rightElement: Element,
+            left: Seq[Contribution[Element]]
+        ) =
+          baseTail -> rightTail match
+            case (
+                  Seq(
+                    Contribution.Difference(followingBaseElement),
+                    _*
+                  ),
+                  _
+                ) if rightEditNotMaroonedByPriorCoincidentInsertion(leftTail) =>
+              // There is a pending coincident deletion; handle this right edit
+              // in isolation without coalescing any following right insertion.
+              logger.debug(
+                s"Right edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(rightElement)} with following coincident deletion of ${pprintCustomised(followingBaseElement)}."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
+                partialResult = rightEditOperations.finalRightEdit(
+                  partialResult,
+                  editedBaseElement,
+                  editedLeftElement,
+                  rightElement
+                ),
+                coalescence = NoCoalescence
+              )
+
+            case (
+                  Seq(Contribution.CommonToBaseAndLeftOnly(_), _*),
+                  Seq(Contribution.Difference(_), _*)
+                ) if rightEditNotMaroonedByPriorCoincidentInsertion(leftTail) =>
+              // There is another pending right edit, but *don't* coalesce the
+              // following element on the right; that then respects any
+              // insertions that may be lurking on the left prior to the pending
+              // right edit claiming the following element on the right.
+              logger.debug(
+                s"Right edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(rightElement)}, not coalescing with following right edit."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
+                partialResult = rightEditOperations.finalRightEdit(
+                  partialResult,
+                  editedBaseElement,
+                  editedLeftElement,
+                  rightElement
+                ),
+                coalescence = NoCoalescence
+              )
+
+            case (_, Seq(Contribution.Difference(followingRightElement), _*)) =>
+              // If the following element on the right would also be inserted,
+              // coalesce into a single edit.
+              logger.debug(
+                s"Right edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(rightElement)}, coalescing with following insertion of ${pprintCustomised(followingRightElement)} on the right."
+              )
+              mergeBetweenRunsOfCommonElements(base, left, rightTail)(
+                partialResult,
+                coalescence =
+                  rightEditOperations.coalesceRightInsertion(rightElement)
+              )
+
+            case _ =>
+              logger.debug(
+                s"Right edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(rightElement)}."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
+                rightEditOperations.finalRightEdit(
+                  partialResult,
+                  editedBaseElement,
+                  editedLeftElement,
+                  rightElement
+                ),
+                coalescence = NoCoalescence
+              )
+          end match
+        end rightEdit
+
+        inline def coincidentEdit(
+            base: Seq[Contribution[Element]],
+            partialResult: Result[Element],
+            editedBaseElement: Element,
+            baseTail: Seq[Contribution[Element]],
+            leftTail: Seq[Contribution[Element]],
+            rightTail: Seq[Contribution[Element]]
+        )(
+            coincidentEditOperations: CoincidentEditOperations,
+            coincidentElementOnLeft: Element,
+            coincidentElementOnRight: Element
+        ) =
+          (baseTail, leftTail, rightTail) match
+            case (
+                  Seq(Contribution.Difference(_), _*),
+                  Seq(Contribution.CommonToLeftAndRightOnly(_), _*),
+                  Seq(Contribution.CommonToLeftAndRightOnly(_), _*)
+                ) =>
+              logger.debug(
+                s"Coincident edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(coincidentElementOnLeft)} on the left and ${pprintCustomised(coincidentElementOnRight)} on the right, not coalescing with following coincident edit."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
+                partialResult = coincidentEditOperations.finalCoincidentEdit(
+                  partialResult,
+                  editedBaseElement,
                   coincidentElementOnLeft,
                   coincidentElementOnRight
-                )
-            )
+                ),
+                coalescence = NoCoalescence
+              )
 
-          case _ =>
-            logger.debug(
-              s"Coincident edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(coincidentElementOnLeft)} on the left and ${pprintCustomised(coincidentElementOnRight)} on the right."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
-              coincidentEditOperations.finalCoincidentEdit(
+            case (
+                  _,
+                  Seq(
+                    Contribution.CommonToLeftAndRightOnly(followingLeftElement),
+                    _*
+                  ),
+                  Seq(
+                    Contribution.CommonToLeftAndRightOnly(followingRightElement),
+                    _*
+                  )
+                ) =>
+              logger.debug(
+                s"Coincident edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(coincidentElementOnLeft)} on the left and ${pprintCustomised(coincidentElementOnRight)} on the right, coalescing with following coincident insertion of ${pprintCustomised(followingLeftElement)} on the left and ${pprintCustomised(followingRightElement)} on the right."
+              )
+              mergeBetweenRunsOfCommonElements(base, leftTail, rightTail)(
+                partialResult,
+                coalescence =
+                  coincidentEditOperations.coalesceCoincidentInsertion(
+                    coincidentElementOnLeft,
+                    coincidentElementOnRight
+                  )
+              )
+
+            case _ =>
+              logger.debug(
+                s"Coincident edit of ${pprintCustomised(editedBaseElement)} into ${pprintCustomised(coincidentElementOnLeft)} on the left and ${pprintCustomised(coincidentElementOnRight)} on the right."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
+                coincidentEditOperations.finalCoincidentEdit(
+                  partialResult,
+                  editedBaseElement,
+                  coincidentElementOnLeft,
+                  coincidentElementOnRight
+                ),
+                coalescence = NoCoalescence
+              )
+          end match
+        end coincidentEdit
+
+        @tailrec
+        def mergeBetweenRunsOfCommonElements(
+            base: Seq[Contribution[Element]],
+            left: Seq[Contribution[Element]],
+            right: Seq[Contribution[Element]]
+        )(
+            partialResult: Result[Element],
+            coalescence: Coalescence
+        ): Result[Element] =
+          (coalescence, base, left, right) match
+            // SYMMETRIC...
+            case (
+                  NoCoalescence,
+                  Seq(Contribution.Common(baseElement), baseTail*),
+                  Seq(Contribution.Common(leftElement), leftTail*),
+                  Seq(Contribution.Common(rightElement), rightTail*)
+                ) => // Preservation.
+              logger.debug(
+                s"Preservation of ${pprintCustomised(baseElement)} as it is common to all three sides."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
+                partialResult = mergeAlgebra.preservation(
+                  partialResult,
+                  preservedBaseElement = baseElement,
+                  preservedElementOnLeft = leftElement,
+                  preservedElementOnRight = rightElement
+                ),
+                coalescence = NoCoalescence
+              )
+
+            // SYMMETRIC...
+            case (
+                  coincidentEditOperations: CoincidentEditOperations,
+                  Seq(Contribution.Difference(editedBaseElement), baseTail*),
+                  Seq(
+                    Contribution.CommonToLeftAndRightOnly(leftElement),
+                    leftTail*
+                  ),
+                  Seq(
+                    Contribution.CommonToLeftAndRightOnly(rightElement),
+                    rightTail*
+                  )
+                ) => // Coincident edit.
+              coincidentEdit(
+                base,
                 partialResult,
                 editedBaseElement,
-                coincidentElementOnLeft,
-                coincidentElementOnRight
-              ),
-              coalescence = NoCoalescence
-            )
-        end match
-      end coincidentEdit
-
-      @tailrec
-      def mergeBetweenRunsOfCommonElements(
-          base: Seq[Contribution[Element]],
-          left: Seq[Contribution[Element]],
-          right: Seq[Contribution[Element]]
-      )(
-          partialResult: Result[Element],
-          coalescence: Coalescence
-      ): Result[Element] =
-        (coalescence, base, left, right) match
-          // SYMMETRIC...
-          case (
-                NoCoalescence,
-                Seq(Contribution.Common(baseElement), baseTail*),
-                Seq(Contribution.Common(leftElement), leftTail*),
-                Seq(Contribution.Common(rightElement), rightTail*)
-              ) => // Preservation.
-            logger.debug(
-              s"Preservation of ${pprintCustomised(baseElement)} as it is common to all three sides."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, leftTail, rightTail)(
-              partialResult = mergeAlgebra.preservation(
-                partialResult,
-                preservedBaseElement = baseElement,
-                preservedElementOnLeft = leftElement,
-                preservedElementOnRight = rightElement
-              ),
-              coalescence = NoCoalescence
-            )
-
-          // SYMMETRIC...
-          case (
-                coincidentEditOperations: CoincidentEditOperations,
-                Seq(Contribution.Difference(editedBaseElement), baseTail*),
-                Seq(
-                  Contribution.CommonToLeftAndRightOnly(leftElement),
-                  leftTail*
-                ),
-                Seq(
-                  Contribution.CommonToLeftAndRightOnly(rightElement),
-                  rightTail*
-                )
-              ) => // Coincident edit.
-            coincidentEdit(
-              base,
-              partialResult,
-              editedBaseElement,
-              baseTail,
-              leftTail,
-              rightTail
-            )(
-              coincidentEditOperations,
-              coincidentElementOnLeft = leftElement,
-              coincidentElementOnRight = rightElement
-            )
-
-          // SYMMETRIC...
-          case (
-                NoCoalescence,
-                _,
-                Seq(
-                  Contribution.CommonToLeftAndRightOnly(leftElement),
-                  leftTail*
-                ),
-                Seq(
-                  Contribution.CommonToLeftAndRightOnly(rightElement),
-                  rightTail*
-                )
-              ) => // Coincident insertion.
-            logger.debug(
-              s"Coincident insertion of ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right."
-            )
-            mergeBetweenRunsOfCommonElements(base, leftTail, rightTail)(
-              partialResult = mergeAlgebra.coincidentInsertion(
-                partialResult,
-                insertedElementOnLeft = leftElement,
-                insertedElementOnRight = rightElement
-              ),
-              coalescence = NoCoalescence
-            )
-
-          // LEFT...
-          case (
-                leftEditOperations: LeftEditOperations,
-                Seq(
-                  Contribution.CommonToBaseAndRightOnly(editedBaseElement),
-                  baseTail*
-                ),
-                Seq(Contribution.Difference(leftElement), leftTail*),
-                Seq(
-                  Contribution.CommonToBaseAndRightOnly(editedRightElement),
-                  rightTail*
-                )
-              ) => // Left edit.
-            leftEdit(
-              base,
-              partialResult,
-              editedBaseElement,
-              editedRightElement,
-              baseTail,
-              leftTail,
-              rightTail
-            )(leftEditOperations, leftElement, right)
-
-          // RIGHT...
-          case (
-                rightEditOperations: RightEditOperations,
-                Seq(
-                  Contribution.CommonToBaseAndLeftOnly(editedBaseElement),
-                  baseTail*
-                ),
-                Seq(
-                  Contribution.CommonToBaseAndLeftOnly(editedLeftElement),
-                  leftTail*
-                ),
-                Seq(Contribution.Difference(rightElement), rightTail*)
-              ) => // Right edit.
-            rightEdit(
-              base,
-              partialResult,
-              editedBaseElement,
-              editedLeftElement,
-              baseTail,
-              leftTail,
-              rightTail
-            )(rightEditOperations, rightElement, left)
-
-          // LEFT...
-          case (
-                NoCoalescence,
-                Seq(
-                  Contribution.CommonToBaseAndRightOnly(deletedBaseElement),
-                  baseTail*
-                ),
-                _,
-                Seq(
-                  Contribution.CommonToBaseAndRightOnly(deletedRightElement),
-                  rightTail*
-                )
-              ) => // Left deletion.
-            logger.debug(
-              s"Left deletion of ${pprintCustomised(deletedBaseElement)}."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, left, rightTail)(
-              mergeAlgebra.leftDeletion(
-                partialResult,
-                deletedBaseElement = deletedBaseElement,
-                deletedRightElement = deletedRightElement
-              ),
-              coalescence = NoCoalescence
-            )
-
-          // RIGHT...
-          case (
-                NoCoalescence,
-                Seq(
-                  Contribution.CommonToBaseAndLeftOnly(deletedBaseElement),
-                  baseTail*
-                ),
-                Seq(
-                  Contribution.CommonToBaseAndLeftOnly(deletedLeftElement),
-                  leftTail*
-                ),
-                _
-              ) => // Right deletion.
-            logger.debug(
-              s"Right deletion of ${pprintCustomised(deletedBaseElement)}."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, leftTail, right)(
-              mergeAlgebra.rightDeletion(
-                partialResult,
-                deletedBaseElement = deletedBaseElement,
-                deletedLeftElement = deletedLeftElement
-              ),
-              coalescence = NoCoalescence
-            )
-
-          // SYMMETRIC...
-          case (
-                conflictOperations: ConflictOperations,
-                Seq(Contribution.Difference(editedBaseElement), baseTail*),
-                Seq(Contribution.Difference(leftElement), leftTail*),
-                Seq(Contribution.Difference(rightElement), rightTail*)
-              ) => // Conflict, multiple possibilities.
-            conflict(
-              base,
-              left,
-              right,
-              partialResult,
-              conflictOperations,
-              editedBaseElement,
-              baseTail,
-              leftElement,
-              leftTail,
-              rightElement,
-              rightTail
-            )
-
-          // LEFT...
-          case (
-                NoCoalescence,
-                Seq(Contribution.Difference(_), _*),
-                Seq(Contribution.Difference(leftElement), leftTail*),
-                Seq(Contribution.CommonToLeftAndRightOnly(_), _*)
-              ) => // Left insertion with pending coincident edit.
-            logger.debug(
-              s"Left insertion of ${pprintCustomised(leftElement)} with following coincident edit."
-            )
-            mergeBetweenRunsOfCommonElements(base, leftTail, right)(
-              mergeAlgebra.leftInsertion(
-                partialResult,
-                insertedElement = leftElement
-              ),
-              coalescence = NoCoalescence
-            )
-
-          // RIGHT...
-          case (
-                NoCoalescence,
-                Seq(Contribution.Difference(_), _*),
-                Seq(Contribution.CommonToLeftAndRightOnly(_), _*),
-                Seq(Contribution.Difference(rightElement), rightTail*)
-              ) => // Right insertion with pending coincident edit.
-            logger.debug(
-              s"Right insertion of ${pprintCustomised(rightElement)} with following coincident edit."
-            )
-            mergeBetweenRunsOfCommonElements(base, left, rightTail)(
-              mergeAlgebra.rightInsertion(
-                partialResult,
-                insertedElement = rightElement
-              ),
-              coalescence = NoCoalescence
-            )
-
-          // LEFT...
-          case (
-                NoCoalescence,
-                Seq(Contribution.Difference(deletedBaseElement), baseTail*),
-                Seq(Contribution.Difference(_), _*),
-                Seq(Contribution.CommonToBaseAndRightOnly(_), _*)
+                baseTail,
+                leftTail,
+                rightTail
+              )(
+                coincidentEditOperations,
+                coincidentElementOnLeft = leftElement,
+                coincidentElementOnRight = rightElement
               )
-              if leftEditNotMaroonedByPriorRightDeletion(
-                baseTail
-              ) => // Coincident deletion with pending left edit.
-            logger.debug(
-              s"Coincident deletion of ${pprintCustomised(deletedBaseElement)} with following left edit."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, left, right)(
-              mergeAlgebra.coincidentDeletion(
-                partialResult,
-                deletedElement = deletedBaseElement
-              ),
-              coalescence = NoCoalescence
-            )
 
-          // RIGHT...
-          case (
-                NoCoalescence,
-                Seq(Contribution.Difference(deletedBaseElement), baseTail*),
-                Seq(Contribution.CommonToBaseAndLeftOnly(_), _*),
-                Seq(Contribution.Difference(_), _*)
+            // SYMMETRIC...
+            case (
+                  NoCoalescence,
+                  _,
+                  Seq(
+                    Contribution.CommonToLeftAndRightOnly(leftElement),
+                    leftTail*
+                  ),
+                  Seq(
+                    Contribution.CommonToLeftAndRightOnly(rightElement),
+                    rightTail*
+                  )
+                ) => // Coincident insertion.
+              logger.debug(
+                s"Coincident insertion of ${pprintCustomised(leftElement)} on the left and ${pprintCustomised(rightElement)} on the right."
               )
-              if rightEditNotMaroonedByPriorLeftDeletion(
-                baseTail
-              ) => // Coincident deletion with pending right edit.
-            logger.debug(
-              s"Coincident deletion of ${pprintCustomised(deletedBaseElement)} with following right edit."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, left, right)(
-              mergeAlgebra.coincidentDeletion(
+              mergeBetweenRunsOfCommonElements(base, leftTail, rightTail)(
+                partialResult = mergeAlgebra.coincidentInsertion(
+                  partialResult,
+                  insertedElementOnLeft = leftElement,
+                  insertedElementOnRight = rightElement
+                ),
+                coalescence = NoCoalescence
+              )
+
+            // LEFT...
+            case (
+                  leftEditOperations: LeftEditOperations,
+                  Seq(
+                    Contribution.CommonToBaseAndRightOnly(editedBaseElement),
+                    baseTail*
+                  ),
+                  Seq(Contribution.Difference(leftElement), leftTail*),
+                  Seq(
+                    Contribution.CommonToBaseAndRightOnly(editedRightElement),
+                    rightTail*
+                  )
+                ) => // Left edit.
+              leftEdit(
+                base,
                 partialResult,
-                deletedElement = deletedBaseElement
-              ),
-              coalescence = NoCoalescence
-            )
+                editedBaseElement,
+                editedRightElement,
+                baseTail,
+                leftTail,
+                rightTail
+              )(leftEditOperations, leftElement, right)
 
-          // LEFT...
-          case (
-                conflictOperations: ConflictOperations,
-                Seq(Contribution.Difference(editedBaseElement), baseTail*),
-                Seq(Contribution.Difference(leftElement), leftTail*),
-                _
-              ) => // Left edit / right deletion conflict.
-            leftEditRightDeletionConflict(
-              base,
-              left,
-              right,
-              partialResult,
-              conflictOperations,
-              editedBaseElement,
-              baseTail,
-              leftElement,
-              leftTail
-            )
-
-          // RIGHT...
-          case (
-                conflictOperations: ConflictOperations,
-                Seq(Contribution.Difference(editedBaseElement), baseTail*),
-                _,
-                Seq(Contribution.Difference(rightElement), rightTail*)
-              ) => // Right edit / left deletion conflict.
-            rightEditLeftDeletionConflict(
-              base,
-              left,
-              right,
-              partialResult,
-              conflictOperations,
-              editedBaseElement,
-              baseTail,
-              rightElement,
-              rightTail
-            )
-
-          // SYMMETRIC...
-          case (
-                NoCoalescence,
-                Seq(Contribution.Difference(deletedBaseElement), baseTail*),
-                _,
-                _
-              ) => // Coincident deletion.
-            logger.debug(
-              s"Coincident deletion of ${pprintCustomised(deletedBaseElement)}."
-            )
-            mergeBetweenRunsOfCommonElements(baseTail, left, right)(
-              mergeAlgebra.coincidentDeletion(
+            // RIGHT...
+            case (
+                  rightEditOperations: RightEditOperations,
+                  Seq(
+                    Contribution.CommonToBaseAndLeftOnly(editedBaseElement),
+                    baseTail*
+                  ),
+                  Seq(
+                    Contribution.CommonToBaseAndLeftOnly(editedLeftElement),
+                    leftTail*
+                  ),
+                  Seq(Contribution.Difference(rightElement), rightTail*)
+                ) => // Right edit.
+              rightEdit(
+                base,
                 partialResult,
-                deletedElement = deletedBaseElement
-              ),
-              coalescence = NoCoalescence
-            )
+                editedBaseElement,
+                editedLeftElement,
+                baseTail,
+                leftTail,
+                rightTail
+              )(rightEditOperations, rightElement, left)
 
-          // LEFT...
-          case (
-                NoCoalescence,
-                Seq(Contribution.CommonToBaseAndLeftOnly(_), _*),
-                Seq(Contribution.Difference(leftElement), leftTail*),
-                Seq(Contribution.Difference(_), _*)
-              ) => // Left insertion with pending right edit.
-            logger.debug(
-              s"Left insertion of ${pprintCustomised(leftElement)} with following right edit."
-            )
-            mergeBetweenRunsOfCommonElements(base, leftTail, right)(
-              mergeAlgebra.leftInsertion(
+            // LEFT...
+            case (
+                  NoCoalescence,
+                  Seq(
+                    Contribution.CommonToBaseAndRightOnly(deletedBaseElement),
+                    baseTail*
+                  ),
+                  _,
+                  Seq(
+                    Contribution.CommonToBaseAndRightOnly(deletedRightElement),
+                    rightTail*
+                  )
+                ) => // Left deletion.
+              logger.debug(
+                s"Left deletion of ${pprintCustomised(deletedBaseElement)}."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, left, rightTail)(
+                mergeAlgebra.leftDeletion(
+                  partialResult,
+                  deletedBaseElement = deletedBaseElement,
+                  deletedRightElement = deletedRightElement
+                ),
+                coalescence = NoCoalescence
+              )
+
+            // RIGHT...
+            case (
+                  NoCoalescence,
+                  Seq(
+                    Contribution.CommonToBaseAndLeftOnly(deletedBaseElement),
+                    baseTail*
+                  ),
+                  Seq(
+                    Contribution.CommonToBaseAndLeftOnly(deletedLeftElement),
+                    leftTail*
+                  ),
+                  _
+                ) => // Right deletion.
+              logger.debug(
+                s"Right deletion of ${pprintCustomised(deletedBaseElement)}."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, leftTail, right)(
+                mergeAlgebra.rightDeletion(
+                  partialResult,
+                  deletedBaseElement = deletedBaseElement,
+                  deletedLeftElement = deletedLeftElement
+                ),
+                coalescence = NoCoalescence
+              )
+
+            // SYMMETRIC...
+            case (
+                  conflictOperations: ConflictOperations,
+                  Seq(Contribution.Difference(editedBaseElement), baseTail*),
+                  Seq(Contribution.Difference(leftElement), leftTail*),
+                  Seq(Contribution.Difference(rightElement), rightTail*)
+                ) => // Conflict, multiple possibilities.
+              conflict(
+                base,
+                left,
+                right,
                 partialResult,
-                insertedElement = leftElement
-              ),
-              coalescence = NoCoalescence
-            )
+                conflictOperations,
+                editedBaseElement,
+                baseTail,
+                leftElement,
+                leftTail,
+                rightElement,
+                rightTail
+              )
 
-          // RIGHT...
-          case (
-                NoCoalescence,
-                Seq(Contribution.CommonToBaseAndRightOnly(_), _*),
-                Seq(Contribution.Difference(_), _*),
-                Seq(Contribution.Difference(rightElement), rightTail*)
-              ) => // Right insertion with pending left edit.
-            logger.debug(
-              s"Right insertion of ${pprintCustomised(rightElement)} with following left edit."
-            )
-            mergeBetweenRunsOfCommonElements(base, left, rightTail)(
-              mergeAlgebra.rightInsertion(
+            // LEFT...
+            case (
+                  NoCoalescence,
+                  Seq(Contribution.Difference(_), _*),
+                  Seq(Contribution.Difference(leftElement), leftTail*),
+                  Seq(Contribution.CommonToLeftAndRightOnly(_), _*)
+                ) => // Left insertion with pending coincident edit.
+              logger.debug(
+                s"Left insertion of ${pprintCustomised(leftElement)} with following coincident edit."
+              )
+              mergeBetweenRunsOfCommonElements(base, leftTail, right)(
+                mergeAlgebra.leftInsertion(
+                  partialResult,
+                  insertedElement = leftElement
+                ),
+                coalescence = NoCoalescence
+              )
+
+            // RIGHT...
+            case (
+                  NoCoalescence,
+                  Seq(Contribution.Difference(_), _*),
+                  Seq(Contribution.CommonToLeftAndRightOnly(_), _*),
+                  Seq(Contribution.Difference(rightElement), rightTail*)
+                ) => // Right insertion with pending coincident edit.
+              logger.debug(
+                s"Right insertion of ${pprintCustomised(rightElement)} with following coincident edit."
+              )
+              mergeBetweenRunsOfCommonElements(base, left, rightTail)(
+                mergeAlgebra.rightInsertion(
+                  partialResult,
+                  insertedElement = rightElement
+                ),
+                coalescence = NoCoalescence
+              )
+
+            // LEFT...
+            case (
+                  NoCoalescence,
+                  Seq(Contribution.Difference(deletedBaseElement), baseTail*),
+                  Seq(Contribution.Difference(_), _*),
+                  Seq(Contribution.CommonToBaseAndRightOnly(_), _*)
+                )
+                if leftEditNotMaroonedByPriorRightDeletion(
+                  baseTail
+                ) => // Coincident deletion with pending left edit.
+              logger.debug(
+                s"Coincident deletion of ${pprintCustomised(deletedBaseElement)} with following left edit."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, left, right)(
+                mergeAlgebra.coincidentDeletion(
+                  partialResult,
+                  deletedElement = deletedBaseElement
+                ),
+                coalescence = NoCoalescence
+              )
+
+            // RIGHT...
+            case (
+                  NoCoalescence,
+                  Seq(Contribution.Difference(deletedBaseElement), baseTail*),
+                  Seq(Contribution.CommonToBaseAndLeftOnly(_), _*),
+                  Seq(Contribution.Difference(_), _*)
+                )
+                if rightEditNotMaroonedByPriorLeftDeletion(
+                  baseTail
+                ) => // Coincident deletion with pending right edit.
+              logger.debug(
+                s"Coincident deletion of ${pprintCustomised(deletedBaseElement)} with following right edit."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, left, right)(
+                mergeAlgebra.coincidentDeletion(
+                  partialResult,
+                  deletedElement = deletedBaseElement
+                ),
+                coalescence = NoCoalescence
+              )
+
+            // LEFT...
+            case (
+                  conflictOperations: ConflictOperations,
+                  Seq(Contribution.Difference(editedBaseElement), baseTail*),
+                  Seq(Contribution.Difference(leftElement), leftTail*),
+                  _
+                ) => // Left edit / right deletion conflict.
+              leftEditRightDeletionConflict(
+                base,
+                left,
+                right,
                 partialResult,
-                insertedElement = rightElement
-              ),
-              coalescence = NoCoalescence
-            )
+                conflictOperations,
+                editedBaseElement,
+                baseTail,
+                leftElement,
+                leftTail
+              )
 
-          // SYMMETRIC...
-          case (
-                conflictOperations: ConflictOperations,
-                _,
-                Seq(Contribution.Difference(leftElement), leftTail*),
-                Seq(Contribution.Difference(rightElement), rightTail*)
-              ) => // Insertion conflict.
-            insertionConflict(
-              base,
-              left,
-              right,
-              partialResult,
-              conflictOperations,
-              leftElement,
-              leftTail,
-              rightElement,
-              rightTail
-            )
-
-          // LEFT...
-          case (
-                NoCoalescence,
-                Seq(
-                  Contribution.Common(_) |
-                  Contribution.CommonToBaseAndLeftOnly(_) |
-                  Contribution.CommonToLeftAndRightOnly(_) |
-                  Contribution.CommonToBaseAndRightOnly(_),
-                  _*
-                ) | Seq(),
-                Seq(Contribution.Difference(leftElement), leftTail*),
-                _
-              ) => // Left insertion.
-            logger.debug(s"Left insertion of ${pprintCustomised(leftElement)}.")
-            mergeBetweenRunsOfCommonElements(base, leftTail, right)(
-              mergeAlgebra.leftInsertion(
+            // RIGHT...
+            case (
+                  conflictOperations: ConflictOperations,
+                  Seq(Contribution.Difference(editedBaseElement), baseTail*),
+                  _,
+                  Seq(Contribution.Difference(rightElement), rightTail*)
+                ) => // Right edit / left deletion conflict.
+              rightEditLeftDeletionConflict(
+                base,
+                left,
+                right,
                 partialResult,
-                insertedElement = leftElement
-              ),
-              coalescence = NoCoalescence
-            )
+                conflictOperations,
+                editedBaseElement,
+                baseTail,
+                rightElement,
+                rightTail
+              )
 
-          // RIGHT...
-          case (
-                NoCoalescence,
-                Seq(
-                  Contribution.Common(_) |
-                  Contribution.CommonToBaseAndRightOnly(_) |
-                  Contribution.CommonToLeftAndRightOnly(_) |
-                  Contribution.CommonToBaseAndLeftOnly(_),
-                  _*
-                ) | Seq(),
-                _,
-                Seq(Contribution.Difference(rightElement), rightTail*)
-              ) => // Right insertion.
-            logger.debug(
-              s"Right insertion of ${pprintCustomised(rightElement)}."
-            )
-            mergeBetweenRunsOfCommonElements(base, left, rightTail)(
-              mergeAlgebra.rightInsertion(
+            // SYMMETRIC...
+            case (
+                  NoCoalescence,
+                  Seq(Contribution.Difference(deletedBaseElement), baseTail*),
+                  _,
+                  _
+                ) => // Coincident deletion.
+              logger.debug(
+                s"Coincident deletion of ${pprintCustomised(deletedBaseElement)}."
+              )
+              mergeBetweenRunsOfCommonElements(baseTail, left, right)(
+                mergeAlgebra.coincidentDeletion(
+                  partialResult,
+                  deletedElement = deletedBaseElement
+                ),
+                coalescence = NoCoalescence
+              )
+
+            // LEFT...
+            case (
+                  NoCoalescence,
+                  Seq(Contribution.CommonToBaseAndLeftOnly(_), _*),
+                  Seq(Contribution.Difference(leftElement), leftTail*),
+                  Seq(Contribution.Difference(_), _*)
+                ) => // Left insertion with pending right edit.
+              logger.debug(
+                s"Left insertion of ${pprintCustomised(leftElement)} with following right edit."
+              )
+              mergeBetweenRunsOfCommonElements(base, leftTail, right)(
+                mergeAlgebra.leftInsertion(
+                  partialResult,
+                  insertedElement = leftElement
+                ),
+                coalescence = NoCoalescence
+              )
+
+            // RIGHT...
+            case (
+                  NoCoalescence,
+                  Seq(Contribution.CommonToBaseAndRightOnly(_), _*),
+                  Seq(Contribution.Difference(_), _*),
+                  Seq(Contribution.Difference(rightElement), rightTail*)
+                ) => // Right insertion with pending left edit.
+              logger.debug(
+                s"Right insertion of ${pprintCustomised(rightElement)} with following left edit."
+              )
+              mergeBetweenRunsOfCommonElements(base, left, rightTail)(
+                mergeAlgebra.rightInsertion(
+                  partialResult,
+                  insertedElement = rightElement
+                ),
+                coalescence = NoCoalescence
+              )
+
+            // SYMMETRIC...
+            case (
+                  conflictOperations: ConflictOperations,
+                  _,
+                  Seq(Contribution.Difference(leftElement), leftTail*),
+                  Seq(Contribution.Difference(rightElement), rightTail*)
+                ) => // Insertion conflict.
+              insertionConflict(
+                base,
+                left,
+                right,
                 partialResult,
-                insertedElement = rightElement
-              ),
-              coalescence = NoCoalescence
-            )
+                conflictOperations,
+                leftElement,
+                leftTail,
+                rightElement,
+                rightTail
+              )
 
-          // SYMMETRIC...
-          case (NoCoalescence, Seq(), Seq(), Seq()) => // Terminating case!
-            logger.debug(s"Merge yielded:\n${pprintCustomised(partialResult)}")
-            partialResult
-        end match
-      end mergeBetweenRunsOfCommonElements
+            // LEFT...
+            case (
+                  NoCoalescence,
+                  Seq(
+                    Contribution.Common(_) |
+                    Contribution.CommonToBaseAndLeftOnly(_) |
+                    Contribution.CommonToLeftAndRightOnly(_) |
+                    Contribution.CommonToBaseAndRightOnly(_),
+                    _*
+                  ) | Seq(),
+                  Seq(Contribution.Difference(leftElement), leftTail*),
+                  _
+                ) => // Left insertion.
+              logger.debug(s"Left insertion of ${pprintCustomised(leftElement)}.")
+              mergeBetweenRunsOfCommonElements(base, leftTail, right)(
+                mergeAlgebra.leftInsertion(
+                  partialResult,
+                  insertedElement = leftElement
+                ),
+                coalescence = NoCoalescence
+              )
 
-      val result = mergeBetweenRunsOfCommonElements(
-        longestCommonSubsequence.base,
-        longestCommonSubsequence.left,
-        longestCommonSubsequence.right
-      )(
-        partialResult = mergeAlgebra.empty,
-        coalescence = NoCoalescence
-      )
+            // RIGHT...
+            case (
+                  NoCoalescence,
+                  Seq(
+                    Contribution.Common(_) |
+                    Contribution.CommonToBaseAndRightOnly(_) |
+                    Contribution.CommonToLeftAndRightOnly(_) |
+                    Contribution.CommonToBaseAndLeftOnly(_),
+                    _*
+                  ) | Seq(),
+                  _,
+                  Seq(Contribution.Difference(rightElement), rightTail*)
+                ) => // Right insertion.
+              logger.debug(
+                s"Right insertion of ${pprintCustomised(rightElement)}."
+              )
+              mergeBetweenRunsOfCommonElements(base, left, rightTail)(
+                mergeAlgebra.rightInsertion(
+                  partialResult,
+                  insertedElement = rightElement
+                ),
+                coalescence = NoCoalescence
+              )
 
-      session.upTo(1)
-      session.close()
+            // SYMMETRIC...
+            case (NoCoalescence, Seq(), Seq(), Seq()) => // Terminating case!
+              logger.debug(s"Merge yielded:\n${pprintCustomised(partialResult)}")
+              partialResult
+          end match
+        end mergeBetweenRunsOfCommonElements
 
-      result
+          mergeBetweenRunsOfCommonElements(
+            longestCommonSubsequence.base,
+            longestCommonSubsequence.left,
+            longestCommonSubsequence.right
+          )(
+            partialResult = reportingMergeAlgebra.empty,
+            coalescence = NoCoalescence
+          )
+      }.get
     end mergeUsing
   end extension
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/merge.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/merge.scala
@@ -101,6 +101,11 @@ object merge extends StrictLogging:
     def mergeUsing[Result[_]](
         mergeAlgebra: MergeAlgebra[Result, Element]
     )(using progressRecording: ProgressRecording): Result[Element] =
+      val session = progressRecording.newSession(
+        label = "Three-way merge",
+        maximumProgress = 1
+      )(initialProgress = 0)
+
       def rightEditNotMaroonedByPriorCoincidentInsertion(
           leftTail: Seq[Contribution[Element]]
       ) =
@@ -1499,7 +1504,7 @@ object merge extends StrictLogging:
         end match
       end mergeBetweenRunsOfCommonElements
 
-      mergeBetweenRunsOfCommonElements(
+      val result = mergeBetweenRunsOfCommonElements(
         longestCommonSubsequence.base,
         longestCommonSubsequence.left,
         longestCommonSubsequence.right
@@ -1507,6 +1512,11 @@ object merge extends StrictLogging:
         partialResult = mergeAlgebra.empty,
         coalescence = NoCoalescence
       )
+
+      session.upTo(1)
+      session.close()
+
+      result
     end mergeUsing
   end extension
 


### PR DESCRIPTION
This PR introduces a standardized manual benchmark procedure to `AGENTS.md` and significantly improves the application's observability regarding performance.

Key changes:
1.  **Benchmarking Documentation**: Added a "Performance Benchmarking" section to `AGENTS.md` with clear steps for establishing a performance baseline.
2.  **Activity Timing**: The `ProgressRecording` utility now automatically records the start time of every session and prints a timed summary (e.g., "Meta-matching - took: PT1.534S") when the session is closed. This provides fine-grained performance data directly in the console output.
3.  **Improved Coverage and Labeling**:
    *   Primary and internal (meta-matching) analyses are now explicitly labeled.
    *   New progress tracking added for:
        *   Per-file block-level merges.
        *   Section-level LCS refinements (aggregated to reduce noise).
        *   The core three-way merge process.
        *   Post-alignment merge processing (splices and substitutions).
    *   Clarified existing labels to provide better context (e.g., linking LCS swathes to block-level merging).

These changes ensure that both developers and automated agents have better visibility into the engine's performance and can more easily identify bottlenecks during development.

---
*PR created automatically by Jules for task [7210390203909390655](https://jules.google.com/task/7210390203909390655) started by @sageserpent-open*