### PR TITLE
Bolster SectionsSeen fidelity tests

### DIFF
--- a/src/test/scala/com/sageserpent/kineticmerge/core/SectionsSeenTest.scala
+++ b/src/test/scala/com/sageserpent/kineticmerge/core/SectionsSeenTest.scala
@@ -11,47 +11,87 @@ case class FakeSection(startOffset: Int, size: Int, id: Int = 0) extends Section
   override def render: pprint.Tree = pprint.Tree.Literal(s"Section($startOffset, $size, $id)")
 
 class SectionsSeenTest:
-  val sections: Trials[FakeSection] = for
+  private val sectionGen: Trials[FakeSection] = for
     start <- Trials.api.integers(0, 1000)
     size <- Trials.api.integers(1, 100)
     id <- Trials.api.integers(0, 10)
   yield FakeSection(start, size, id)
 
-  val operations: Trials[Operation] = Trials.api.alternate(
-    sections.map(Operation.Add.apply),
-    sections.map(Operation.Remove.apply),
-    for
-      start <- Trials.api.integers(0, 1000)
-      size <- Trials.api.integers(1, 100)
-    yield Operation.QueryIncludes(start, start + size),
-    for
-      start <- Trials.api.integers(0, 1000)
-      size <- Trials.api.integers(1, 100)
-    yield Operation.QueryOverlaps(start, start + size)
-  )
+  private def sequences: Trials[Vector[Operation]] =
+    Trials.api.integers(1, 100).flatMap { numberOfOperations =>
+      def rangeGen(sectionsSeen: Set[FakeSection]): Trials[(Int, Int)] =
+        for
+          useExisting <- Trials.api.booleans
+          range <- if (useExisting && sectionsSeen.nonEmpty) {
+            Trials.api.choose(sectionsSeen).flatMap { s =>
+              val start = s.startOffset
+              val end = s.onePastEndOffset
+              Trials.api.alternate(
+                Trials.api.only((start, end)), // Exact match
+                Trials.api.only(if (end - 1 > start + 1) (start + 1, end - 1) else (start, end)), // Nested inside
+                Trials.api.only((start - 1, end + 1)), // Nested outside
+                Trials.api.only((start - 5, start + 5)), // Partial overlap start
+                Trials.api.only((end - 5, end + 5)) // Partial overlap end
+              )
+            }
+          } else {
+            for
+              start <- Trials.api.integers(0, 1000)
+              size <- Trials.api.integers(1, 100)
+            yield (start, start + size)
+          }
+        yield range
+
+      def generate(opsSoFar: Vector[Operation], sectionsSeen: Set[FakeSection]): Trials[Vector[Operation]] =
+        if (opsSoFar.size >= numberOfOperations) Trials.api.only(opsSoFar)
+        else
+          val operationGen: Trials[Operation] = Trials.api.alternate(
+            sectionGen.map(Operation.Add.apply),
+            if (sectionsSeen.isEmpty) sectionGen.map(Operation.Remove.apply)
+            else Trials.api.choose(sectionsSeen).map(Operation.Remove.apply),
+            rangeGen(sectionsSeen).map(Operation.QueryIncludes.apply),
+            rangeGen(sectionsSeen).map(Operation.QueryOverlaps.apply)
+          )
+
+          operationGen.flatMap { op =>
+            val nextSectionsSeen = op match
+              case Operation.Add(s) => sectionsSeen + s
+              case Operation.Remove(s) => sectionsSeen - s
+              case _ => sectionsSeen
+            generate(opsSoFar :+ op, nextSectionsSeen)
+          }
+
+      generate(Vector.empty, Set.empty)
+    }
 
   @TestFactory
-  def tests(): DynamicTests =
-    operations.several[Vector[Operation]].withLimit(100).dynamicTests { ops =>
+  def fidelityAgainstReferenceImplementation(): DynamicTests =
+    sequences.withLimit(500).dynamicTests { ops =>
       var sectionsSeen = SectionsSeen.empty[Int]
       var reference = RangedSeq.empty[FakeSection, Int](_.closedOpenInterval, Ordering.Int)
+      var hitSeen = false
 
       ops.foreach {
         case Operation.Add(s) =>
           sectionsSeen = sectionsSeen + s
           reference = reference + s
         case Operation.Remove(s) =>
+          if (reference.iterator.contains(s)) hitSeen = true
           sectionsSeen = sectionsSeen - s
           reference = reference - s
         case Operation.QueryIncludes(start, end) =>
           val result = sectionsSeen.filterIncludes((start, end)).toSet
           val expected = reference.filterIncludes((start, end)).toSet
+          if (expected.nonEmpty) hitSeen = true
           assertEquals(expected, result, s"Operation: QueryIncludes($start, $end)")
         case Operation.QueryOverlaps(start, end) =>
           val result = sectionsSeen.filterOverlaps((start, end)).toSet
           val expected = reference.filterOverlaps((start, end)).toSet
+          if (expected.nonEmpty) hitSeen = true
           assertEquals(expected, result, s"Operation: QueryOverlaps($start, $end)")
       }
+
+      if (!hitSeen) Trials.reject()
 
       assertEquals(reference.iterator.toSet, sectionsSeen.iterator.toSet, "Final contents mismatch")
     }

--- a/src/test/scala/com/sageserpent/kineticmerge/core/SectionsSeenTest.scala
+++ b/src/test/scala/com/sageserpent/kineticmerge/core/SectionsSeenTest.scala
@@ -2,98 +2,166 @@ package com.sageserpent.kineticmerge.core
 
 import com.sageserpent.americium.Trials
 import com.sageserpent.americium.junit5.*
-import org.junit.jupiter.api.TestFactory
-import org.junit.jupiter.api.Assertions.*
+import com.sageserpent.kineticmerge.core.ExpectyFlavouredAssert.assert
 import de.sciss.fingertree.RangedSeq
+import org.junit.jupiter.api.TestFactory
 
-case class FakeSection(startOffset: Int, size: Int, id: Int = 0) extends Section[Int]:
+case class FakeSection(startOffset: Int, size: Int, id: Int = 0)
+    extends Section[Int]:
   override def content: IndexedSeq[Int] = IndexedSeq.empty
-  override def render: pprint.Tree = pprint.Tree.Literal(s"Section($startOffset, $size, $id)")
+  override def render: pprint.Tree      =
+    pprint.Tree.Literal(s"Section($startOffset, $size, $id)")
+end FakeSection
 
 class SectionsSeenTest:
-  private val sectionGen: Trials[FakeSection] = for
+  private val sections: Trials[FakeSection] = for
     start <- Trials.api.integers(0, 1000)
-    size <- Trials.api.integers(1, 100)
-    id <- Trials.api.integers(0, 10)
+    size  <- Trials.api.integers(1, 100)
+    id    <- Trials.api.integers(0, 10)
   yield FakeSection(start, size, id)
-
-  private def sequences: Trials[Vector[Operation]] =
-    Trials.api.integers(1, 100).flatMap { numberOfOperations =>
-      def rangeGen(sectionsSeen: Set[FakeSection]): Trials[(Int, Int)] =
-        for
-          useExisting <- Trials.api.booleans
-          range <- if (useExisting && sectionsSeen.nonEmpty) {
-            Trials.api.choose(sectionsSeen).flatMap { s =>
-              val start = s.startOffset
-              val end = s.onePastEndOffset
-              Trials.api.alternate(
-                Trials.api.only((start, end)), // Exact match
-                Trials.api.only(if (end - 1 > start + 1) (start + 1, end - 1) else (start, end)), // Nested inside
-                Trials.api.only((start - 1, end + 1)), // Nested outside
-                Trials.api.only((start - 5, start + 5)), // Partial overlap start
-                Trials.api.only((end - 5, end + 5)) // Partial overlap end
-              )
-            }
-          } else {
-            for
-              start <- Trials.api.integers(0, 1000)
-              size <- Trials.api.integers(1, 100)
-            yield (start, start + size)
-          }
-        yield range
-
-      def generate(opsSoFar: Vector[Operation], sectionsSeen: Set[FakeSection]): Trials[Vector[Operation]] =
-        if (opsSoFar.size >= numberOfOperations) Trials.api.only(opsSoFar)
-        else
-          val operationGen: Trials[Operation] = Trials.api.alternate(
-            sectionGen.map(Operation.Add.apply),
-            if (sectionsSeen.isEmpty) sectionGen.map(Operation.Remove.apply)
-            else Trials.api.choose(sectionsSeen).map(Operation.Remove.apply),
-            rangeGen(sectionsSeen).map(Operation.QueryIncludes.apply),
-            rangeGen(sectionsSeen).map(Operation.QueryOverlaps.apply)
-          )
-
-          operationGen.flatMap { op =>
-            val nextSectionsSeen = op match
-              case Operation.Add(s) => sectionsSeen + s
-              case Operation.Remove(s) => sectionsSeen - s
-              case _ => sectionsSeen
-            generate(opsSoFar :+ op, nextSectionsSeen)
-          }
-
-      generate(Vector.empty, Set.empty)
-    }
 
   @TestFactory
   def fidelityAgainstReferenceImplementation(): DynamicTests =
     sequences.withLimit(500).dynamicTests { ops =>
       var sectionsSeen = SectionsSeen.empty[Int]
-      var reference = RangedSeq.empty[FakeSection, Int](_.closedOpenInterval, Ordering.Int)
-      var hitSeen = false
+      var reference    =
+        RangedSeq.empty[FakeSection, Int](_.closedOpenInterval, Ordering.Int)
+      var referenceWasHit = false
 
       ops.foreach {
         case Operation.Add(s) =>
           sectionsSeen = sectionsSeen + s
           reference = reference + s
         case Operation.Remove(s) =>
-          if (reference.iterator.contains(s)) hitSeen = true
+          if reference.iterator.contains(s) then referenceWasHit = true
           sectionsSeen = sectionsSeen - s
           reference = reference - s
         case Operation.QueryIncludes(start, end) =>
-          val result = sectionsSeen.filterIncludes((start, end)).toSet
+          val result   = sectionsSeen.filterIncludes((start, end)).toSet
           val expected = reference.filterIncludes((start, end)).toSet
-          if (expected.nonEmpty) hitSeen = true
-          assertEquals(expected, result, s"Operation: QueryIncludes($start, $end)")
+          if expected.nonEmpty then referenceWasHit = true
+          assert(
+            expected == result,
+            s"Operation: QueryIncludes($start, $end)"
+          )
         case Operation.QueryOverlaps(start, end) =>
-          val result = sectionsSeen.filterOverlaps((start, end)).toSet
+          val result   = sectionsSeen.filterOverlaps((start, end)).toSet
           val expected = reference.filterOverlaps((start, end)).toSet
-          if (expected.nonEmpty) hitSeen = true
-          assertEquals(expected, result, s"Operation: QueryOverlaps($start, $end)")
+          if expected.nonEmpty then referenceWasHit = true
+          assert(
+            expected == result,
+            s"Operation: QueryOverlaps($start, $end)"
+          )
       }
 
-      if (!hitSeen) Trials.reject()
+      if !referenceWasHit then Trials.reject()
 
-      assertEquals(reference.iterator.toSet, sectionsSeen.iterator.toSet, "Final contents mismatch")
+      assert(
+        reference.iterator.toSet == sectionsSeen.iterator.toSet,
+        "Final contents mismatch"
+      )
+    }
+
+  private def sequences: Trials[Vector[Operation]] =
+    Trials.api.integers(1, 100).flatMap { numberOfOperations =>
+      def ranges(sectionsSeen: Set[FakeSection]): Trials[(Int, Int)] =
+        for
+          useExisting <- Trials.api.booleans
+          range       <-
+            if useExisting && sectionsSeen.nonEmpty then
+              Trials.api.choose(sectionsSeen).flatMap { sectionSeen =>
+                val start = sectionSeen.startOffset
+                val end   = sectionSeen.onePastEndOffset
+
+                val nestedInsidePossibility =
+                  val nudgedEnd   = end - 1
+                  val nudgedStart = start + 1
+
+                  Option.when(nudgedEnd > nudgedStart)((nudgedStart, nudgedEnd))
+                end nestedInsidePossibility
+
+                val overlapWithStartPossibility =
+                  val nudgedStart = start - 5
+                  val nudgedEnd   = start + 5
+
+                  Option.when(end >= nudgedEnd)((nudgedStart, nudgedEnd))
+                end overlapWithStartPossibility
+
+                val overlapWithEndPossibility =
+                  val nudgedStart = end - 5
+                  val nudgedEnd   = end + 5
+
+                  Option.when(start <= nudgedStart)((nudgedStart, nudgedEnd))
+                end overlapWithEndPossibility
+
+                val vettedAlternatives = Seq(
+                  nestedInsidePossibility,
+                  overlapWithStartPossibility,
+                  overlapWithEndPossibility
+                ).flatMap(_.map(Trials.api.only))
+
+                val exactMatchAlternative     = Trials.api.only((start, end))
+                val nestingOutsideAlternative =
+                  Trials.api.only((start - 1, end + 1))
+
+                Trials.api.alternate(
+                  vettedAlternatives :+ exactMatchAlternative :+ nestingOutsideAlternative
+                )
+              }
+            else
+              for
+                start <- Trials.api.integers(0, 1000)
+                size  <- Trials.api.integers(1, 100)
+              yield (start, start + size)
+        yield range
+
+      def operationSequences(
+          partialResult: Vector[Operation],
+          sectionsSeen: Set[FakeSection]
+      ): Trials[Vector[Operation]] =
+        if partialResult.size >= numberOfOperations then
+          Trials.api.only(partialResult)
+        else
+          val operations: Trials[Operation] = Trials.api.alternate(
+            if sectionsSeen.isEmpty then sections.map(Operation.Add.apply)
+            else
+              Trials.api.alternateWithWeights(
+                3 -> sections.map(Operation.Add.apply),
+                1 -> Trials.api
+                  .choose(sectionsSeen)
+                  .map(
+                    Operation.Add.apply
+                  ) // Add some duplicates in occasionally.
+              )
+            ,
+            if sectionsSeen.isEmpty then sections.map(Operation.Remove.apply)
+            else
+              Trials.api.alternateWithWeights(
+                3 -> Trials.api
+                  .choose(sectionsSeen)
+                  .map(
+                    Operation.Remove.apply
+                  ),
+                1 -> sections
+                  .filter(!sectionsSeen.contains(_))
+                  .map(
+                    Operation.Remove.apply
+                  ) // Attempt to remove a section that isn't present occasionally.
+              )
+            ,
+            ranges(sectionsSeen).map(Operation.QueryIncludes.apply),
+            ranges(sectionsSeen).map(Operation.QueryOverlaps.apply)
+          )
+
+          operations.flatMap { op =>
+            val nextSectionsSeen = op match
+              case Operation.Add(s)    => sectionsSeen + s
+              case Operation.Remove(s) => sectionsSeen - s
+              case _                   => sectionsSeen
+            operationSequences(partialResult :+ op, nextSectionsSeen)
+          }
+
+      operationSequences(Vector.empty, Set.empty)
     }
 
   enum Operation:
@@ -101,3 +169,5 @@ class SectionsSeenTest:
     case Remove(section: FakeSection)
     case QueryIncludes(start: Int, end: Int)
     case QueryOverlaps(start: Int, end: Int)
+  end Operation
+end SectionsSeenTest


### PR DESCRIPTION
Renamed the test method to `fidelityAgainstReferenceImplementation` and significantly bolstered the test suite's robustness. The updated test uses a stateful generator to ensure that sequences of operations frequently interact with existing data (hits), exercising edge cases like exact matches, nested intervals, and partial overlaps. It also now rejects trial sequences that don't produce any hits, ensuring a high-quality test set with a 500-trial budget.

---
*PR created automatically by Jules for task [981967881945295864](https://jules.google.com/task/981967881945295864) started by @sageserpent-open*