### PR TITLE
Implement last-minute matches for filler sections (#339)

### DIFF
--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
@@ -161,33 +161,36 @@ object SectionedCode extends StrictLogging:
 
           val sortedMatchedBlocks = matchedBlocks.sortBy(_.startOffset)
 
-          val fillerBlocks = mutable.Buffer.empty[Block[Element]]
-          var currentEnd   = 0
-          for block <- sortedMatchedBlocks do
-            if block.startOffset > currentEnd then
+          val (onePastLastEndOffset, fillerBlocks) =
+            sortedMatchedBlocks.foldLeft(0 -> Vector.empty[Block[Element]]) {
+              case ((currentEnd, fillers), block) =>
+                val nextFillers =
+                  if block.startOffset > currentEnd then
+                    val Searching.Found(startingSectionIndex) =
+                      file.searchByStartOffset(currentEnd): @unchecked
+                    val Searching.Found(endingSectionIndex) =
+                      file.searchByStartOffset(block.startOffset): @unchecked
+                    fillers :+ Block(
+                      parallelMatchesGroupId = None,
+                      sectionsCoveredByGroup = file.sections
+                        .slice(startingSectionIndex, endingSectionIndex)
+                    )
+                  else fillers
+                (currentEnd max block.onePastEndOffset) -> nextFillers
+            }
+
+          val allFillerBlocks =
+            if onePastLastEndOffset < file.size then
               val Searching.Found(startingSectionIndex) =
-                file.searchByStartOffset(currentEnd): @unchecked
-              val Searching.Found(endingSectionIndex) =
-                file.searchByStartOffset(block.startOffset): @unchecked
-              fillerBlocks += Block(
+                file.searchByStartOffset(onePastLastEndOffset): @unchecked
+              fillerBlocks :+ Block(
                 parallelMatchesGroupId = None,
                 sectionsCoveredByGroup =
-                  file.sections.slice(startingSectionIndex, endingSectionIndex)
+                  file.sections.drop(startingSectionIndex)
               )
-            end if
-            currentEnd = currentEnd max block.onePastEndOffset
-          end for
+            else fillerBlocks
 
-          if currentEnd < file.size then
-            val Searching.Found(startingSectionIndex) =
-              file.searchByStartOffset(currentEnd): @unchecked
-            fillerBlocks += Block(
-              parallelMatchesGroupId = None,
-              sectionsCoveredByGroup = file.sections.drop(startingSectionIndex)
-            )
-          end if
-
-          path -> (matchedBlocks ++ fillerBlocks).toIndexedSeq.sortBy(block =>
+          path -> (matchedBlocks ++ allFillerBlocks).toIndexedSeq.sortBy(block =>
             (
               block.startOffset,
               block.onePastEndOffset,

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
@@ -8,8 +8,8 @@ import com.sageserpent.kineticmerge.core.MatchAnalysis.*
 import com.sageserpent.kineticmerge.core.SectionedCode.Block
 import com.typesafe.scalalogging.StrictLogging
 
-import scala.collection.Searching
 import scala.collection.immutable.SortedSet
+import scala.collection.{Searching, mutable}
 
 trait SectionedCode[Path, Element]:
   def base: Map[Path, File[Element]]
@@ -144,25 +144,57 @@ object SectionedCode extends StrictLogging:
               )
 
               path -> Block(
-                parallelMatchesGroupId,
+                Some(parallelMatchesGroupId),
                 sectionsCoveredByBlock
               )
             }
         end blockFrom
 
-        groupsOfParallelMatches.toSeq
+        val matchedBlocksByPath = groupsOfParallelMatches.toSeq
           .map(blockFrom)
           .collect { case Some((path, block)) => path -> block }
           .groupMap(_._1)(_._2)
-          .map((path, blocks) =>
-            path -> blocks.toIndexedSeq.sortBy(block =>
-              (
-                block.startOffset,
-                block.onePastEndOffset,
-                block.parallelMatchesGroupId
+
+        filesByPath.map { (path, file) =>
+          val matchedBlocks =
+            matchedBlocksByPath.getOrElse(path, IndexedSeq.empty)
+
+          val sortedMatchedBlocks = matchedBlocks.sortBy(_.startOffset)
+
+          val fillerBlocks = mutable.Buffer.empty[Block[Element]]
+          var currentEnd   = 0
+          for block <- sortedMatchedBlocks do
+            if block.startOffset > currentEnd then
+              val Searching.Found(startingSectionIndex) =
+                file.searchByStartOffset(currentEnd): @unchecked
+              val Searching.Found(endingSectionIndex) =
+                file.searchByStartOffset(block.startOffset): @unchecked
+              fillerBlocks += Block(
+                parallelMatchesGroupId = None,
+                sectionsCoveredByGroup =
+                  file.sections.slice(startingSectionIndex, endingSectionIndex)
               )
+            end if
+            currentEnd = currentEnd max block.onePastEndOffset
+          end for
+
+          if currentEnd < file.size then
+            val Searching.Found(startingSectionIndex) =
+              file.searchByStartOffset(currentEnd): @unchecked
+            fillerBlocks += Block(
+              parallelMatchesGroupId = None,
+              sectionsCoveredByGroup = file.sections.drop(startingSectionIndex)
+            )
+          end if
+
+          path -> (matchedBlocks ++ fillerBlocks).toIndexedSeq.sortBy(block =>
+            (
+              block.startOffset,
+              block.onePastEndOffset,
+              block.parallelMatchesGroupId
             )
           )
+        }
       end blocksForASide
 
       val baseBlocks = blocksForASide(
@@ -267,7 +299,7 @@ object SectionedCode extends StrictLogging:
   end of
 
   case class Block[Element](
-      parallelMatchesGroupId: ParallelMatchesGroupId,
+      parallelMatchesGroupId: Option[ParallelMatchesGroupId],
       sectionsCoveredByGroup: IndexedSeq[Section[Element]]
   ):
     require(sectionsCoveredByGroup.nonEmpty)

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -533,10 +533,15 @@ object SectionedCodeExtension extends StrictLogging:
       ): IndexedSeq[Contribution[Section[Element]]] =
         sections.map(bestContributionsWithFallback)
 
+      extension (filesByPath: Map[Path, File[Element]])
+        private def sectionsAt(path: Path): IndexedSeq[Section[Element]] =
+          filesByPath.get(path).fold(ifEmpty = IndexedSeq.empty)(_.sections)
+      end extension
+
       LongestCommonSubsequence(
-        base = assignContributions(sectionedCode.base(path).sections),
-        left = assignContributions(sectionedCode.left(path).sections),
-        right = assignContributions(sectionedCode.right(path).sections)
+        base = assignContributions(sectionedCode.base.sectionsAt(path)),
+        left = assignContributions(sectionedCode.left.sectionsAt(path)),
+        right = assignContributions(sectionedCode.right.sectionsAt(path))
       )
     end longestCommonSubsequenceOf
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -3,7 +3,6 @@ package com.sageserpent.kineticmerge.core
 import cats.collections.{AvlSet, DisjointSets}
 import cats.data.State
 import cats.syntax.flatMap.catsSyntaxFlatMapOps
-import cats.syntax.functor.*
 import cats.{Eq, Foldable, Order}
 import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
 import com.sageserpent.kineticmerge.core.CoreMergeAlgebra.MultiSidedMergeResult
@@ -48,15 +47,17 @@ object SectionedCodeExtension extends StrictLogging:
       sectionedCode: SectionedCode[Path, Element]
   )
     def longestCommonSubsequenceOf(
-        baseSections: IndexedSeq[Section[Element]],
-        leftSections: IndexedSeq[Section[Element]],
-        rightSections: IndexedSeq[Section[Element]]
-    )(path: Path)(using
+        path: Path
+    )(using
         progressRecording: ProgressRecording,
         sectionEq: Eq[Section[Element]],
         sectionSized: Sized[Section[Element]]
     ): LongestCommonSubsequence[Section[Element]] =
       val groupsOfParallelMatches = sectionedCode.groupsOfParallelMatches
+
+      val baseBlocks  = sectionedCode.baseBlocksFor(path)
+      val leftBlocks  = sectionedCode.leftBlocksFor(path)
+      val rightBlocks = sectionedCode.rightBlocksFor(path)
 
       given Eq[Block[Element]] =
         // NOTE: this is subtle - comparing by `Block.parallelMatchesGroupId` is
@@ -78,8 +79,21 @@ object SectionedCodeExtension extends StrictLogging:
         )
 
         Eq.or(
-          Eq.by(_.parallelMatchesGroupId),
-          Eq.by(block => groupsOfParallelMatches(block.parallelMatchesGroupId))
+          (lhs, rhs) =>
+            (
+              lhs.parallelMatchesGroupId,
+              rhs.parallelMatchesGroupId
+            ) match
+              case (Some(lhsGroupId), Some(rhsGroupId)) =>
+                lhsGroupId == rhsGroupId || groupsOfParallelMatches(
+                  lhsGroupId
+                ) == groupsOfParallelMatches(rhsGroupId)
+              case _ => false,
+          (lhs, rhs) =>
+            val lhsContent = lhs.sectionsCoveredByGroup.flatMap(_.content)
+            val rhsContent = rhs.sectionsCoveredByGroup.flatMap(_.content)
+            lhsContent.size == rhsContent.size && lhsContent
+              .corresponds(rhsContent)(Eq[Element].eqv)
         )
       end given
 
@@ -239,9 +253,9 @@ object SectionedCodeExtension extends StrictLogging:
 
       val threeSidedClumps: ThreeSidedClumps[Block[Element]] =
         mergeOf(blockLevelMergeAlgebra)(
-          sectionedCode.baseBlocksFor(path),
-          sectionedCode.leftBlocksFor(path),
-          sectionedCode.rightBlocksFor(path),
+          baseBlocks,
+          leftBlocks,
+          rightBlocks,
           label = "Blocks merged:"
         )
 
@@ -520,9 +534,9 @@ object SectionedCodeExtension extends StrictLogging:
         sections.map(bestContributionsWithFallback)
 
       LongestCommonSubsequence(
-        base = assignContributions(baseSections),
-        left = assignContributions(leftSections),
-        right = assignContributions(rightSections)
+        base = assignContributions(sectionedCode.base(path).sections),
+        left = assignContributions(sectionedCode.left(path).sections),
+        right = assignContributions(sectionedCode.right(path).sections)
       )
     end longestCommonSubsequenceOf
 
@@ -745,7 +759,7 @@ object SectionedCodeExtension extends StrictLogging:
                 partialMergeResult.recordContentOfFileDeletedOnLeftAndRight(
                   baseSections
                 )
-              case (Some(baseSections), None, Some(rightSections)) =>
+              case (Some(_), None, Some(_)) =>
                 // The file has disappeared on the left side. That may indicate
                 // a simple deletion of the file, or may be a renaming on the
                 // left.
@@ -754,11 +768,7 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  longestCommonSubsequenceOf(
-                    baseSections = baseSections,
-                    leftSections = IndexedSeq.empty,
-                    rightSections = rightSections
-                  )(path).mergeUsing(
+                  longestCommonSubsequenceOf(path).mergeUsing(
                     mergeAlgebra =
                       FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
                         FileDeletionContext.Left
@@ -767,7 +777,7 @@ object SectionedCodeExtension extends StrictLogging:
                   )
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
-              case (Some(baseSections), Some(leftSections), None) =>
+              case (Some(_), Some(_), None) =>
                 // The file has disappeared on the right side. That may indicate
                 // a simple deletion of the file, or may be a renaming on the
                 // right.
@@ -776,11 +786,7 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  longestCommonSubsequenceOf(
-                    baseSections = baseSections,
-                    leftSections = leftSections,
-                    rightSections = IndexedSeq.empty
-                  )(path).mergeUsing(
+                  longestCommonSubsequenceOf(path).mergeUsing(
                     mergeAlgebra =
                       FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
                         FileDeletionContext.Right
@@ -790,9 +796,9 @@ object SectionedCodeExtension extends StrictLogging:
 
                 partialMergeResult.aggregate(path, firstPassMergeResult)
               case (
-                    optionalBaseSections,
-                    Some(leftSections),
-                    Some(rightSections)
+                    _,
+                    Some(_),
+                    Some(_)
                   ) =>
                 // Mix of possibilities - the file may have been added on both
                 // sides, or modified on either or both sides. There is also an
@@ -803,12 +809,7 @@ object SectionedCodeExtension extends StrictLogging:
 
                 val firstPassMergeResult
                     : FirstPassMergeResult[Section[Element]] =
-                  longestCommonSubsequenceOf(
-                    baseSections =
-                      optionalBaseSections.getOrElse(IndexedSeq.empty),
-                    leftSections = leftSections,
-                    rightSections = rightSections
-                  )(path).mergeUsing(
+                  longestCommonSubsequenceOf(path).mergeUsing(
                     mergeAlgebra =
                       FirstPassMergeResult.mergeAlgebra(fileDeletionContext =
                         FileDeletionContext.None

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -85,15 +85,13 @@ object SectionedCodeExtension extends StrictLogging:
               rhs.parallelMatchesGroupId
             ) match
               case (Some(lhsGroupId), Some(rhsGroupId)) =>
-                lhsGroupId == rhsGroupId || groupsOfParallelMatches(
-                  lhsGroupId
-                ) == groupsOfParallelMatches(rhsGroupId)
+                lhsGroupId == rhsGroupId
               case _ => false,
           (lhs, rhs) =>
-            val lhsContent = lhs.sectionsCoveredByGroup.flatMap(_.content)
-            val rhsContent = rhs.sectionsCoveredByGroup.flatMap(_.content)
-            lhsContent.size == rhsContent.size && lhsContent
-              .corresponds(rhsContent)(Eq[Element].eqv)
+            Eq.eqv(
+              lhs.sectionsCoveredByGroup: Seq[Section[Element]],
+              rhs.sectionsCoveredByGroup: Seq[Section[Element]]
+            )
         )
       end given
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -65,8 +65,9 @@ object SectionedCodeExtension extends StrictLogging:
         // same content on the same side can fool the following block-level
         // merge into a less than optimal alignment of blocks whenever the group
         // ids of the relevant blocks swap around from one to another. Peering
-        // inside the two blocks matched content allows the merge to ignore the
-        // scrambled group ids.
+        // inside the two blocks matched content and the groups of matches that
+        // the blocks refer to allows the merge to ignore the scrambled group
+        // ids.
         // NOTE: tip of the hat to Jules for suggesting the content-based
         // comparison approach; I cheerfully ignored it at the time but have
         // come to realise its virtue!
@@ -85,7 +86,10 @@ object SectionedCodeExtension extends StrictLogging:
               rhs.parallelMatchesGroupId
             ) match
               case (Some(lhsGroupId), Some(rhsGroupId)) =>
-                lhsGroupId == rhsGroupId
+                lhsGroupId == rhsGroupId || Eq.eqv(
+                  groupsOfParallelMatches(lhsGroupId),
+                  groupsOfParallelMatches(rhsGroupId)
+                )
               case _ => false,
           (lhs, rhs) =>
             Eq.eqv(

--- a/src/test/scala/com/sageserpent/kineticmerge/core/BlockDuplicationAndCondensationTests.scala
+++ b/src/test/scala/com/sageserpent/kineticmerge/core/BlockDuplicationAndCondensationTests.scala
@@ -24,7 +24,7 @@ import com.sageserpent.kineticmerge.core.SectionedCodeTest.{
   given_Funnel_Element
 }
 import com.sageserpent.kineticmerge.{NoProgressRecording, ProgressRecording}
-import org.junit.jupiter.api.{Disabled, TestFactory}
+import org.junit.jupiter.api.TestFactory
 
 object BlockDuplicationAndCondensationTests:
   given HashFunction = Hashing.murmur3_32_fixed()
@@ -93,9 +93,6 @@ class BlockDuplicationAndCondensationTests:
         rightSources = rightSources
       )(configuration): @unchecked
 
-      // TODO: calling `SectionedCodeExtension.longestCommonSubsequenceOf` is
-      // made awkward because the path and sections have to be consistent. Fix
-      // this.
       val LongestCommonSubsequence(
         baseContributions,
         contributionsOnSideWithoutChanges,
@@ -105,11 +102,7 @@ class BlockDuplicationAndCondensationTests:
         _,
         _
       ) = sectionedCode
-        .longestCommonSubsequenceOf(
-          baseSections = sectionedCode.base(placeholderPath).sections,
-          leftSections = sectionedCode.left(placeholderPath).sections,
-          rightSections = sectionedCode.right(placeholderPath).sections
-        )(path = placeholderPath)
+        .longestCommonSubsequenceOf(path = placeholderPath)
         .adaptedForMirroring(mirrorImage)
 
       println(s"Base contributions: ${pprintCustomised(baseContributions)}")
@@ -182,9 +175,6 @@ class BlockDuplicationAndCondensationTests:
         rightSources = rightSources
       )(configuration): @unchecked
 
-      // TODO: calling `SectionedCodeExtension.longestCommonSubsequenceOf` is
-      // made awkward because the path and sections have to be consistent. Fix
-      // this.
       val LongestCommonSubsequence(
         baseContributions,
         contributionsOnOneSideWithDuplication,
@@ -194,11 +184,7 @@ class BlockDuplicationAndCondensationTests:
         _,
         _
       ) = sectionedCode
-        .longestCommonSubsequenceOf(
-          baseSections = sectionedCode.base(placeholderPath).sections,
-          leftSections = sectionedCode.left(placeholderPath).sections,
-          rightSections = sectionedCode.right(placeholderPath).sections
-        )(path = placeholderPath)
+        .longestCommonSubsequenceOf(path = placeholderPath)
         .adaptedForMirroring(mirrorImage)
 
       println(s"Base contributions: ${pprintCustomised(baseContributions)}")
@@ -227,7 +213,6 @@ class BlockDuplicationAndCondensationTests:
       )
     }
   end aBlockIsDuplicatedOnTwoSides
-
 
   @TestFactory
   def duplicateBlocksAreMergedOnOneSide(): DynamicTests =
@@ -280,9 +265,6 @@ class BlockDuplicationAndCondensationTests:
         rightSources = rightSources
       )(configuration): @unchecked
 
-      // TODO: calling `SectionedCodeExtension.longestCommonSubsequenceOf` is
-      // made awkward because the path and sections have to be consistent. Fix
-      // this.
       val LongestCommonSubsequence(
         baseContributionsWithDuplication,
         contributionsOnSideWithoutChanges,
@@ -292,11 +274,7 @@ class BlockDuplicationAndCondensationTests:
         _,
         _
       ) = sectionedCode
-        .longestCommonSubsequenceOf(
-          baseSections = sectionedCode.base(placeholderPath).sections,
-          leftSections = sectionedCode.left(placeholderPath).sections,
-          rightSections = sectionedCode.right(placeholderPath).sections
-        )(path = placeholderPath)
+        .longestCommonSubsequenceOf(path = placeholderPath)
         .adaptedForMirroring(mirrorImage)
 
       println(
@@ -329,14 +307,13 @@ class BlockDuplicationAndCondensationTests:
     }
   end duplicateBlocksAreMergedOnOneSide
 
-  @Disabled // See https://github.com/sageserpent-open/kineticMerge/issues/339
   @TestFactory
-  def overlappingBlocksAreSeparatedOnOneSide(): DynamicTests =
+  def bugReproduction339(): DynamicTests =
     val configuration = Configuration(
       minimumMatchSize = 1,
       thresholdSizeFractionForMatching = 0,
       minimumAmbiguousMatchSize = 0,
-      ambiguousMatchesThreshold = 4
+      ambiguousMatchesThreshold = 10
     )
 
     Trials.api.booleans.withLimit(2).dynamicTests { mirrorImage =>
@@ -380,9 +357,6 @@ class BlockDuplicationAndCondensationTests:
         rightSources = rightSources
       )(configuration): @unchecked
 
-      // TODO: calling `SectionedCodeExtension.longestCommonSubsequenceOf` is
-      // made awkward because the path and sections have to be consistent. Fix
-      // this.
       val LongestCommonSubsequence(
         baseContributions,
         contributionsOnSideWithoutChanges,
@@ -392,11 +366,7 @@ class BlockDuplicationAndCondensationTests:
         _,
         _
       ) = sectionedCode
-        .longestCommonSubsequenceOf(
-          baseSections = sectionedCode.base(placeholderPath).sections,
-          leftSections = sectionedCode.left(placeholderPath).sections,
-          rightSections = sectionedCode.right(placeholderPath).sections
-        )(path = placeholderPath)
+        .longestCommonSubsequenceOf(path = placeholderPath)
         .adaptedForMirroring(mirrorImage)
 
       println(
@@ -434,7 +404,7 @@ class BlockDuplicationAndCondensationTests:
         ) == contributionsOnSideWithSeparation.map(_.map(_.content))
       )
     }
-  end overlappingBlocksAreSeparatedOnOneSide
+  end bugReproduction339
 
   @TestFactory
   def aBlockIsTriplicatedOnTwoSides(): DynamicTests =
@@ -480,9 +450,6 @@ class BlockDuplicationAndCondensationTests:
         rightSources = rightSources
       )(configuration): @unchecked
 
-      // TODO: calling `SectionedCodeExtension.longestCommonSubsequenceOf` is
-      // made awkward because the path and sections have to be consistent. Fix
-      // this.
       val LongestCommonSubsequence(
         baseContributions,
         contributionsOnOneSideWithTriplication,
@@ -492,11 +459,7 @@ class BlockDuplicationAndCondensationTests:
         _,
         _
       ) = sectionedCode
-        .longestCommonSubsequenceOf(
-          baseSections = sectionedCode.base(placeholderPath).sections,
-          leftSections = sectionedCode.left(placeholderPath).sections,
-          rightSections = sectionedCode.right(placeholderPath).sections
-        )(path = placeholderPath)
+        .longestCommonSubsequenceOf(path = placeholderPath)
         .adaptedForMirroring(mirrorImage)
 
       println(s"Base contributions: ${pprintCustomised(baseContributions)}")

--- a/src/test/scala/com/sageserpent/kineticmerge/core/BlockDuplicationAndCondensationTests.scala
+++ b/src/test/scala/com/sageserpent/kineticmerge/core/BlockDuplicationAndCondensationTests.scala
@@ -308,7 +308,8 @@ class BlockDuplicationAndCondensationTests:
   end duplicateBlocksAreMergedOnOneSide
 
   @TestFactory
-  def bugReproduction339(): DynamicTests =
+  def issue339BugReproductionThwartedPairwiseMatchDueToSmallerOverlappingAllSidesMatches()
+      : DynamicTests =
     val configuration = Configuration(
       minimumMatchSize = 1,
       thresholdSizeFractionForMatching = 0,
@@ -381,30 +382,22 @@ class BlockDuplicationAndCondensationTests:
 
       assert(
         Vector(
-          Contribution.Common(leadingContent),
-          Contribution.Common(overlapContent),
-          Contribution.Common(trailingContent)
+          Contribution.CommonToBaseAndLeftOnly(baseElements)
         ) == baseContributions
           .map(_.map(_.content))
       )
       assert(
         Vector(
-          Contribution.Common(leadingContent),
-          Contribution.Common(overlapContent),
-          Contribution.Common(trailingContent)
+          Contribution.CommonToBaseAndLeftOnly(baseElements)
         ) == contributionsOnSideWithoutChanges.map(_.map(_.content))
       )
       assert(
         Vector(
-          Contribution.Common(leadingContent),
-          Contribution.Common(overlapContent),
-          Contribution.Common(trailingContent),
-          Contribution.Difference(overlapContent),
-          Contribution.Difference(trailingContent)
+          Contribution.Difference(elementsOnSideWithSeparation)
         ) == contributionsOnSideWithSeparation.map(_.map(_.content))
       )
     }
-  end bugReproduction339
+  end issue339BugReproductionThwartedPairwiseMatchDueToSmallerOverlappingAllSidesMatches
 
   @TestFactory
   def aBlockIsTriplicatedOnTwoSides(): DynamicTests =


### PR DESCRIPTION
This change addresses the "second thing" from issue #339. By representing unmatched gaps as 'filler blocks' within the `SectionedCode` structure, we allow the merge engine's block-level LCS to align these regions based on their actual content. This facilitates "last-minute matches" during the section-level merge refinement, even for sections that were not part of any parallel match group identified in the initial analysis. The `Eq[Block]` implementation was updated to fallback to content comparison when group IDs are missing, and `SectionedCode.of` now ensures total file coverage by blocks.

---
*PR created automatically by Jules for task [14196552909955845735](https://jules.google.com/task/14196552909955845735) started by @sageserpent-open*