### PR TITLE
Fragment overlapping matches in Match Analysis

### DIFF
--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1357,14 +1357,13 @@ object MatchAnalysis extends StrictLogging:
             looseExclusiveUpperBoundOnMaximumMatchSize =
               minimumWindowSizeAcrossAllFilesOverAllSides
           )(using progressRecordingSession)
-        }.get.purgedOfMatchesWithOverlappingSections(enabled = true).matches
+        }.get.purgedOfMatchesWithOverlappingSections.matches
 
         tinyMatches.foldLeft(this)(_ withMatch _)
       end withTinyMatches
 
-      private def purgedOfMatchesWithOverlappingSections(
-          enabled: Boolean
-      ): MatchesAndTheirSections =
+      private def purgedOfMatchesWithOverlappingSections
+          : MatchesAndTheirSections =
         def overlapsWithSomethingElse(aMatch: GenericMatch[Element]): Boolean =
           // NOTE: this is loose: it also considers subsumed matches to be
           // overlapping. In practise this method should only be called
@@ -1396,323 +1395,10 @@ object MatchAnalysis extends StrictLogging:
           matches.filter(overlapsWithSomethingElse)
 
         if overlappingMatches.nonEmpty then
-          if enabled then
-            logger.debug(
-              s"Reconciling overlapping matches:\n${pprintCustomised(overlappingMatches)}"
-            )
-
-            val sessionLabel =
-              if configuration.label.nonEmpty then
-                s"${configuration.label} - number of overlapping matches to reconcile:"
-              else "Number of overlapping matches to reconcile:"
-
-            val Success(reconciled) =
-              Using(
-                progressRecording.newSession(
-                  label = sessionLabel,
-                  maximumProgress = overlappingMatches.size
-                )(initialProgress = overlappingMatches.size)
-              ) { progressRecordingSession =>
-                case class RecursionState(
-                    remainingMatchesAndTheirSections: MatchesAndTheirSections,
-                    remainingContestedMatches: Set[GenericMatch[Element]]
-                )
-
-                def reconcileUsing(
-                    recursionState: RecursionState
-                ): ParallelMatchesGroupIdTracking[
-                  Either[RecursionState, MatchesAndTheirSections]
-                ] =
-                  val RecursionState(
-                    remainingMatchesAndTheirSections,
-                    remainingContestedMatches
-                  ) = recursionState
-
-                  val (matchesThatAreSubsumed, matchesThatAreNotSubsumed) =
-                    remainingContestedMatches.partition(aMatch =>
-                      aMatch.baseContribution.fold(ifEmpty = false)(
-                        remainingMatchesAndTheirSections.baseSubsumes(_)
-                      ) || aMatch.leftContribution.fold(ifEmpty = false)(
-                        remainingMatchesAndTheirSections.leftSubsumes(_)
-                      ) || aMatch.rightContribution.fold(ifEmpty = false)(
-                        remainingMatchesAndTheirSections.rightSubsumes(_)
-                      )
-                    )
-
-                  val remainingMatchesAndTheirSectionsWithoutSubsumedMatches =
-                    remainingMatchesAndTheirSections
-                      .withoutTheseMatches(matchesThatAreSubsumed)
-
-                  val (unsplitMatchesWithoutOverlaps, splits) =
-                    matchesThatAreNotSubsumed
-                      .map(
-                        remainingMatchesAndTheirSectionsWithoutSubsumedMatches.hiveOffNonOverlappedMatchFrom
-                      )
-                      .partitionMap(identity)
-
-                  progressRecordingSession.upTo(splits.size)
-
-                  if splits.isEmpty then
-                    for updatedParallelMatchesGroupIdsByMatch <- State.get
-                    yield
-                      val fullyReconciledMatches =
-                        remainingMatchesAndTheirSectionsWithoutSubsumedMatches.matches
-
-                      val parallelMatchesGroupIdsByMatch =
-                        updatedParallelMatchesGroupIdsByMatch
-                          .filter((key, _) =>
-                            fullyReconciledMatches.contains(key)
-                          )
-
-                      Right(
-                        remainingMatchesAndTheirSectionsWithoutSubsumedMatches
-                          .copy(parallelMatchesGroupIdsByMatch =
-                            parallelMatchesGroupIdsByMatch
-                          )
-                      )
-                  else
-                    for splitResults <- splits.sequence
-                    yield
-                      val hivedOffMatches =
-                        splitResults.flatMap(_.hivedOffNonOverlappedMatch)
-                      val remainingContestedMatches =
-                        splitResults.flatMap(_.remainingContestedMatches)
-
-                      Left(
-                        RecursionState(
-                          remainingMatchesAndTheirSections =
-                            // TODO: this is clumsy.
-                            (hivedOffMatches union remainingContestedMatches)
-                              .foldLeft(
-                                remainingMatchesAndTheirSectionsWithoutSubsumedMatches
-                                  .withoutTheseMatches(
-                                    matchesThatAreNotSubsumed diff unsplitMatchesWithoutOverlaps
-                                  )
-                              )(
-                                _ withMatch _
-                              )
-                              .withoutRedundantPairwiseMatches,
-                          remainingContestedMatches =
-                            // TODO: this is also clumsy.
-                            hivedOffMatches union remainingContestedMatches
-                        )
-                      )
-                    end for
-                  end if
-                end reconcileUsing
-
-                FlatMap[ParallelMatchesGroupIdTracking]
-                  .tailRecM(
-                    RecursionState(
-                      remainingMatchesAndTheirSections = this,
-                      remainingContestedMatches = overlappingMatches
-                    )
-                  )(reconcileUsing)
-                  .runA(parallelMatchesGroupIdsByMatch)
-                  .value
-              }: @unchecked
-
-            reconciled
-          else
-            throw new AdmissibleFailure(
-              s"""Overlapping matches found: ${pprintCustomised(
-                  overlappingMatches
-                )}.
-                 |Consider setting the command line parameter `--minimum-match-size` to something larger than ${overlappingMatches.map {
-                  case Match.AllSides(baseSection, _, _)  => baseSection.size
-                  case Match.BaseAndLeft(baseSection, _)  => baseSection.size
-                  case Match.BaseAndRight(baseSection, _) => baseSection.size
-                  case Match.LeftAndRight(leftSection, _) => leftSection.size
-                }.min}.
-                 |""".stripMargin
-            )
+          this.withoutTheseMatches(overlappingMatches)
         else this
         end if
       end purgedOfMatchesWithOverlappingSections
-
-      private def hiveOffNonOverlappedMatchFrom(
-          aMatch: GenericMatch[Element]
-      ): Either[
-        GenericMatch[Element], /* Original match if not split. */
-        ParallelMatchesGroupIdTracking[HivedOffNonOverlappedMatchResult]
-      ] =
-        enum Encroachment:
-          def startToLeftAndEndToRight: Either[Int, Int] =
-            this match
-              case OnTheStart(advancingRelativeStartOffset) =>
-                Left(advancingRelativeStartOffset)
-              case OnTheEnd(limitingRelativeEndOffset) =>
-                Right(limitingRelativeEndOffset)
-
-          case OnTheStart(advancingRelativeStartOffset: Int)
-          case OnTheEnd(limitingRelativeEndOffset: Int)
-        end Encroachment
-
-        def encroachments(
-            side: Sources[Path, Element],
-            sectionsByPath: Map[Path, SectionsSeen]
-        )(
-            section: Section[Element]
-        ): Iterable[Encroachment] =
-
-          sectionsByPath
-            .get(side.pathFor(section))
-            .fold(ifEmpty = Set.empty)(
-              _.filterOverlaps(section.closedOpenInterval)
-                // Subsuming sections are considered to be overlapping by the
-                // implementation of `SectionSeen.filterOverlaps`, so collect
-                // with a nuanced predicate.
-                // NOTE: this is a strict overlap, so if the candidate section
-                // is equivalent to `section`, it isn't considered to be a
-                // degenerate overlap. This is important, because the calling
-                // logic in `purgedOfMatchesWithOverlappingSections` needs to
-                // both completely hive off matches from overlaps *and* trim the
-                // overlaps down to ambiguous matches, so we expect to see
-                // equivalent sections belonging to multiple ambiguous matches.
-                .collect {
-                  case candidateSection
-                      if candidateSection.startOffset > section.startOffset && candidateSection.onePastEndOffset < section.onePastEndOffset =>
-                    throw new IllegalArgumentException(
-                      s"Precondition failure: match ${pprintCustomised(aMatch)} subsumes another match on at least one side."
-                    )
-                  case candidateSection
-                      if candidateSection.startOffset < section.startOffset && candidateSection.onePastEndOffset > section.onePastEndOffset =>
-                    throw new IllegalArgumentException(
-                      s"Precondition failure: match ${pprintCustomised(aMatch)} is subsumed by another match on at least one side."
-                    )
-                  case candidateSection
-                      if candidateSection.startOffset > section.startOffset =>
-                    // The overlapping `candidateSection` extends up to or past
-                    // the end of `section`, so this encroaches on the end. We
-                    // do allow a special case subsumption here where
-                    // `candidateSection` aligns with the end.
-                    Encroachment.OnTheEnd(
-                      candidateSection.startOffset - section.startOffset
-                    )
-                  case candidateSection
-                      if candidateSection.onePastEndOffset < section.onePastEndOffset =>
-                    // The overlapping `candidateSection` extends back to or
-                    // before the start of `section`, so this encroaches on the
-                    // start. We do allow a special case subsumption here where
-                    // `candidateSection` aligns with the start.
-                    Encroachment.OnTheStart(
-                      candidateSection.onePastEndOffset - section.startOffset
-                    )
-                }
-            )
-        end encroachments
-
-        val baseEncroachments =
-          aMatch.baseContribution.fold(ifEmpty = Seq.empty)(
-            encroachments(
-              baseSources,
-              baseSectionsByPath
-            )
-          )
-        val leftEncroachments =
-          aMatch.leftContribution.fold(ifEmpty = Seq.empty)(
-            encroachments(
-              leftSources,
-              leftSectionsByPath
-            )
-          )
-        val rightEncroachments =
-          aMatch.rightContribution.fold(ifEmpty = Seq.empty)(
-            encroachments(
-              rightSources,
-              rightSectionsByPath
-            )
-          )
-
-        val overallEncroachments =
-          baseEncroachments ++ leftEncroachments ++ rightEncroachments
-
-        val (
-          advancingRelativeStartOffsets,
-          advancingRelativeOnePastEndOffsets
-        ) =
-          overallEncroachments.partitionMap(_.startToLeftAndEndToRight)
-
-        val relativeStartOffsetToHiveOffFrom =
-          advancingRelativeStartOffsets.maxOption
-
-        val relativeOnePastEndOffsetToHiveOffTo =
-          advancingRelativeOnePastEndOffsets.minOption
-
-        (
-          relativeStartOffsetToHiveOffFrom,
-          relativeOnePastEndOffsetToHiveOffTo
-        ) match
-          case (None, None)                      => Left(aMatch)
-          case (Some(relativeStartOffset), None) =>
-            val remainingContestedMatch =
-              aMatch.slice(relativeStartOffset = 0, size = relativeStartOffset)
-            val hivedOffMatch = aMatch.slice(
-              relativeStartOffset = relativeStartOffset,
-              size = aMatch.size - relativeStartOffset
-            )
-
-            Right(
-              for
-                _ <- propagateGroupId(aMatch, remainingContestedMatch)
-                _ <- propagateGroupId(aMatch, hivedOffMatch)
-              yield new HivedOffNonOverlappedMatchResult:
-                def hivedOffNonOverlappedMatch: Option[GenericMatch[Element]] =
-                  Some(hivedOffMatch)
-                def remainingContestedMatches: Seq[GenericMatch[Element]] =
-                  Seq(remainingContestedMatch)
-            )
-          case (None, Some(relativeOnePastEndOffset)) =>
-            val hivedOffMatch = aMatch.slice(
-              relativeStartOffset = 0,
-              size = relativeOnePastEndOffset
-            )
-            val remainingContestedMatch = aMatch.slice(
-              relativeStartOffset = relativeOnePastEndOffset,
-              size = aMatch.size - relativeOnePastEndOffset
-            )
-
-            Right(
-              for
-                _ <- propagateGroupId(aMatch, hivedOffMatch)
-                _ <- propagateGroupId(aMatch, remainingContestedMatch)
-              yield new HivedOffNonOverlappedMatchResult:
-                def hivedOffNonOverlappedMatch: Option[GenericMatch[Element]] =
-                  Some(hivedOffMatch)
-                def remainingContestedMatches: Seq[GenericMatch[Element]] =
-                  Seq(remainingContestedMatch)
-            )
-          case (Some(relativeStartOffset), Some(relativeOnePastEndOffset)) =>
-            val leadingRemainingContestedMatch =
-              aMatch.slice(relativeStartOffset = 0, size = relativeStartOffset)
-            val hivedOffMatch =
-              Option.when(relativeStartOffset < relativeOnePastEndOffset)(
-                aMatch.slice(
-                  relativeStartOffset = relativeStartOffset,
-                  size = relativeOnePastEndOffset - relativeStartOffset
-                )
-              )
-            val trailingRemainingContestedMatch = aMatch.slice(
-              relativeStartOffset = relativeOnePastEndOffset,
-              size = aMatch.size - relativeOnePastEndOffset
-            )
-
-            Right(
-              for
-                _ <- propagateGroupId(aMatch, leadingRemainingContestedMatch)
-                _ <- hivedOffMatch.traverse(propagateGroupId(aMatch, _))
-                _ <- propagateGroupId(aMatch, trailingRemainingContestedMatch)
-              yield new HivedOffNonOverlappedMatchResult:
-                def hivedOffNonOverlappedMatch: Option[GenericMatch[Element]] =
-                  hivedOffMatch
-                def remainingContestedMatches: Seq[GenericMatch[Element]] =
-                  Seq(
-                    leadingRemainingContestedMatch,
-                    trailingRemainingContestedMatch
-                  )
-            )
-        end match
-      end hiveOffNonOverlappedMatchFrom
 
       def reconcileMatches(
           suppressMatchesInvolvingOverlappingSections: Boolean
@@ -1852,9 +1538,10 @@ object MatchAnalysis extends StrictLogging:
               .value
           }: @unchecked
 
-        val result = reconciled.purgedOfMatchesWithOverlappingSections(enabled =
-          suppressMatchesInvolvingOverlappingSections
-        )
+        val result =
+          reconciled.reconcileMatchesWithOverlappingSections(enabled =
+            suppressMatchesInvolvingOverlappingSections
+          )
 
         result.reconciliationPostcondition()
 
@@ -2524,6 +2211,358 @@ object MatchAnalysis extends StrictLogging:
             )
         end match
       end withMatch
+
+      private def reconcileMatchesWithOverlappingSections(
+          enabled: Boolean
+      ): MatchesAndTheirSections =
+        def overlapsWithSomethingElse(aMatch: GenericMatch[Element]): Boolean =
+          // NOTE: this is loose: it also considers subsumed matches to be
+          // overlapping. In practise this method should only be called
+          // post-reconciliation, so that's OK. Otherwise, any subsumed matches
+          // will cause a precondition failure later on.
+          aMatch match
+            case Match.AllSides(baseSection, leftSection, rightSection) =>
+              baseOverlapsOrIsSubsumedBy(baseSection) ||
+              leftOverlapsOrIsSubsumedBy(
+                leftSection
+              ) || rightOverlapsOrIsSubsumedBy(rightSection)
+            case Match.BaseAndLeft(baseSection, leftSection) =>
+              baseOverlapsOrIsSubsumedBy(baseSection) ||
+              leftOverlapsOrIsSubsumedBy(
+                leftSection
+              )
+            case Match.BaseAndRight(baseSection, rightSection) =>
+              baseOverlapsOrIsSubsumedBy(
+                baseSection
+              ) || rightOverlapsOrIsSubsumedBy(rightSection)
+            case Match.LeftAndRight(leftSection, rightSection) =>
+              leftOverlapsOrIsSubsumedBy(
+                leftSection
+              ) || rightOverlapsOrIsSubsumedBy(rightSection)
+
+        val matches = this.matches
+
+        val overlappingMatches =
+          matches.filter(overlapsWithSomethingElse)
+
+        if overlappingMatches.nonEmpty then
+          if enabled then
+            logger.debug(
+              s"Reconciling overlapping matches:\n${pprintCustomised(overlappingMatches)}"
+            )
+
+            val sessionLabel =
+              if configuration.label.nonEmpty then
+                s"${configuration.label} - number of overlapping matches to reconcile:"
+              else "Number of overlapping matches to reconcile:"
+
+            val Success(reconciled) =
+              Using(
+                progressRecording.newSession(
+                  label = sessionLabel,
+                  maximumProgress = overlappingMatches.size
+                )(initialProgress = overlappingMatches.size)
+              ) { progressRecordingSession =>
+                case class RecursionState(
+                    remainingMatchesAndTheirSections: MatchesAndTheirSections,
+                    remainingContestedMatches: Set[GenericMatch[Element]]
+                )
+
+                def reconcileUsing(
+                    recursionState: RecursionState
+                ): ParallelMatchesGroupIdTracking[
+                  Either[RecursionState, MatchesAndTheirSections]
+                ] =
+                  val RecursionState(
+                    remainingMatchesAndTheirSections,
+                    remainingContestedMatches
+                  ) = recursionState
+
+                  val (matchesThatAreSubsumed, matchesThatAreNotSubsumed) =
+                    remainingContestedMatches.partition(aMatch =>
+                      aMatch.baseContribution.fold(ifEmpty = false)(
+                        remainingMatchesAndTheirSections.baseSubsumes(_)
+                      ) || aMatch.leftContribution.fold(ifEmpty = false)(
+                        remainingMatchesAndTheirSections.leftSubsumes(_)
+                      ) || aMatch.rightContribution.fold(ifEmpty = false)(
+                        remainingMatchesAndTheirSections.rightSubsumes(_)
+                      )
+                    )
+
+                  val remainingMatchesAndTheirSectionsWithoutSubsumedMatches =
+                    remainingMatchesAndTheirSections
+                      .withoutTheseMatches(matchesThatAreSubsumed)
+
+                  val (unsplitMatchesWithoutOverlaps, splits) =
+                    matchesThatAreNotSubsumed
+                      .map(
+                        remainingMatchesAndTheirSectionsWithoutSubsumedMatches.hiveOffNonOverlappedMatchFrom
+                      )
+                      .partitionMap(identity)
+
+                  progressRecordingSession.upTo(splits.size)
+
+                  if splits.isEmpty then
+                    for updatedParallelMatchesGroupIdsByMatch <- State.get
+                    yield
+                      val fullyReconciledMatches =
+                        remainingMatchesAndTheirSectionsWithoutSubsumedMatches.matches
+
+                      val parallelMatchesGroupIdsByMatch =
+                        updatedParallelMatchesGroupIdsByMatch
+                          .filter((key, _) =>
+                            fullyReconciledMatches.contains(key)
+                          )
+
+                      Right(
+                        remainingMatchesAndTheirSectionsWithoutSubsumedMatches
+                          .copy(parallelMatchesGroupIdsByMatch =
+                            parallelMatchesGroupIdsByMatch
+                          )
+                      )
+                  else
+                    for splitResults <- splits.sequence
+                    yield
+                      val hivedOffMatches =
+                        splitResults.flatMap(_.hivedOffNonOverlappedMatch)
+                      val remainingContestedMatches =
+                        splitResults.flatMap(_.remainingContestedMatches)
+
+                      Left(
+                        RecursionState(
+                          remainingMatchesAndTheirSections =
+                            // TODO: this is clumsy.
+                            (hivedOffMatches union remainingContestedMatches)
+                              .foldLeft(
+                                remainingMatchesAndTheirSectionsWithoutSubsumedMatches
+                                  .withoutTheseMatches(
+                                    matchesThatAreNotSubsumed diff unsplitMatchesWithoutOverlaps
+                                  )
+                              )(
+                                _ withMatch _
+                              )
+                              .withoutRedundantPairwiseMatches,
+                          remainingContestedMatches =
+                            // TODO: this is also clumsy.
+                            hivedOffMatches union remainingContestedMatches
+                        )
+                      )
+                    end for
+                  end if
+                end reconcileUsing
+
+                FlatMap[ParallelMatchesGroupIdTracking]
+                  .tailRecM(
+                    RecursionState(
+                      remainingMatchesAndTheirSections = this,
+                      remainingContestedMatches = overlappingMatches
+                    )
+                  )(reconcileUsing)
+                  .runA(parallelMatchesGroupIdsByMatch)
+                  .value
+              }: @unchecked
+
+            reconciled
+          else
+            throw new AdmissibleFailure(
+              s"""Overlapping matches found: ${pprintCustomised(
+                  overlappingMatches
+                )}.
+                 |Consider setting the command line parameter `--minimum-match-size` to something larger than ${overlappingMatches.map {
+                  case Match.AllSides(baseSection, _, _)  => baseSection.size
+                  case Match.BaseAndLeft(baseSection, _)  => baseSection.size
+                  case Match.BaseAndRight(baseSection, _) => baseSection.size
+                  case Match.LeftAndRight(leftSection, _) => leftSection.size
+                }.min}.
+                 |""".stripMargin
+            )
+        else this
+        end if
+      end reconcileMatchesWithOverlappingSections
+
+      private def hiveOffNonOverlappedMatchFrom(
+          aMatch: GenericMatch[Element]
+      ): Either[
+        GenericMatch[Element], /* Original match if not split. */
+        ParallelMatchesGroupIdTracking[HivedOffNonOverlappedMatchResult]
+      ] =
+        enum Encroachment:
+          def startToLeftAndEndToRight: Either[Int, Int] =
+            this match
+              case OnTheStart(advancingRelativeStartOffset) =>
+                Left(advancingRelativeStartOffset)
+              case OnTheEnd(limitingRelativeEndOffset) =>
+                Right(limitingRelativeEndOffset)
+
+          case OnTheStart(advancingRelativeStartOffset: Int)
+          case OnTheEnd(limitingRelativeEndOffset: Int)
+        end Encroachment
+
+        def encroachments(
+            side: Sources[Path, Element],
+            sectionsByPath: Map[Path, SectionsSeen]
+        )(
+            section: Section[Element]
+        ): Iterable[Encroachment] =
+
+          sectionsByPath
+            .get(side.pathFor(section))
+            .fold(ifEmpty = Set.empty)(
+              _.filterOverlaps(section.closedOpenInterval)
+                // Subsuming sections are considered to be overlapping by the
+                // implementation of `SectionSeen.filterOverlaps`, so collect
+                // with a nuanced predicate.
+                // NOTE: this is a strict overlap, so if the candidate section
+                // is equivalent to `section`, it isn't considered to be a
+                // degenerate overlap. This is important, because the calling
+                // logic in `purgedOfMatchesWithOverlappingSections` needs to
+                // both completely hive off matches from overlaps *and* trim the
+                // overlaps down to ambiguous matches, so we expect to see
+                // equivalent sections belonging to multiple ambiguous matches.
+                .collect {
+                  case candidateSection
+                      if candidateSection.startOffset > section.startOffset && candidateSection.onePastEndOffset < section.onePastEndOffset =>
+                    throw new IllegalArgumentException(
+                      s"Precondition failure: match ${pprintCustomised(aMatch)} subsumes another match on at least one side."
+                    )
+                  case candidateSection
+                      if candidateSection.startOffset < section.startOffset && candidateSection.onePastEndOffset > section.onePastEndOffset =>
+                    throw new IllegalArgumentException(
+                      s"Precondition failure: match ${pprintCustomised(aMatch)} is subsumed by another match on at least one side."
+                    )
+                  case candidateSection
+                      if candidateSection.startOffset > section.startOffset =>
+                    // The overlapping `candidateSection` extends up to or past
+                    // the end of `section`, so this encroaches on the end. We
+                    // do allow a special case subsumption here where
+                    // `candidateSection` aligns with the end.
+                    Encroachment.OnTheEnd(
+                      candidateSection.startOffset - section.startOffset
+                    )
+                  case candidateSection
+                      if candidateSection.onePastEndOffset < section.onePastEndOffset =>
+                    // The overlapping `candidateSection` extends back to or
+                    // before the start of `section`, so this encroaches on the
+                    // start. We do allow a special case subsumption here where
+                    // `candidateSection` aligns with the start.
+                    Encroachment.OnTheStart(
+                      candidateSection.onePastEndOffset - section.startOffset
+                    )
+                }
+            )
+        end encroachments
+
+        val baseEncroachments =
+          aMatch.baseContribution.fold(ifEmpty = Seq.empty)(
+            encroachments(
+              baseSources,
+              baseSectionsByPath
+            )
+          )
+        val leftEncroachments =
+          aMatch.leftContribution.fold(ifEmpty = Seq.empty)(
+            encroachments(
+              leftSources,
+              leftSectionsByPath
+            )
+          )
+        val rightEncroachments =
+          aMatch.rightContribution.fold(ifEmpty = Seq.empty)(
+            encroachments(
+              rightSources,
+              rightSectionsByPath
+            )
+          )
+
+        val overallEncroachments =
+          baseEncroachments ++ leftEncroachments ++ rightEncroachments
+
+        val (
+          advancingRelativeStartOffsets,
+          advancingRelativeOnePastEndOffsets
+        ) =
+          overallEncroachments.partitionMap(_.startToLeftAndEndToRight)
+
+        val relativeStartOffsetToHiveOffFrom =
+          advancingRelativeStartOffsets.maxOption
+
+        val relativeOnePastEndOffsetToHiveOffTo =
+          advancingRelativeOnePastEndOffsets.minOption
+
+        (
+          relativeStartOffsetToHiveOffFrom,
+          relativeOnePastEndOffsetToHiveOffTo
+        ) match
+          case (None, None)                      => Left(aMatch)
+          case (Some(relativeStartOffset), None) =>
+            val remainingContestedMatch =
+              aMatch.slice(relativeStartOffset = 0, size = relativeStartOffset)
+            val hivedOffMatch = aMatch.slice(
+              relativeStartOffset = relativeStartOffset,
+              size = aMatch.size - relativeStartOffset
+            )
+
+            Right(
+              for
+                _ <- propagateGroupId(aMatch, remainingContestedMatch)
+                _ <- propagateGroupId(aMatch, hivedOffMatch)
+              yield new HivedOffNonOverlappedMatchResult:
+                def hivedOffNonOverlappedMatch: Option[GenericMatch[Element]] =
+                  Some(hivedOffMatch)
+                def remainingContestedMatches: Seq[GenericMatch[Element]] =
+                  Seq(remainingContestedMatch)
+            )
+          case (None, Some(relativeOnePastEndOffset)) =>
+            val hivedOffMatch = aMatch.slice(
+              relativeStartOffset = 0,
+              size = relativeOnePastEndOffset
+            )
+            val remainingContestedMatch = aMatch.slice(
+              relativeStartOffset = relativeOnePastEndOffset,
+              size = aMatch.size - relativeOnePastEndOffset
+            )
+
+            Right(
+              for
+                _ <- propagateGroupId(aMatch, hivedOffMatch)
+                _ <- propagateGroupId(aMatch, remainingContestedMatch)
+              yield new HivedOffNonOverlappedMatchResult:
+                def hivedOffNonOverlappedMatch: Option[GenericMatch[Element]] =
+                  Some(hivedOffMatch)
+                def remainingContestedMatches: Seq[GenericMatch[Element]] =
+                  Seq(remainingContestedMatch)
+            )
+          case (Some(relativeStartOffset), Some(relativeOnePastEndOffset)) =>
+            val leadingRemainingContestedMatch =
+              aMatch.slice(relativeStartOffset = 0, size = relativeStartOffset)
+            val hivedOffMatch =
+              Option.when(relativeStartOffset < relativeOnePastEndOffset)(
+                aMatch.slice(
+                  relativeStartOffset = relativeStartOffset,
+                  size = relativeOnePastEndOffset - relativeStartOffset
+                )
+              )
+            val trailingRemainingContestedMatch = aMatch.slice(
+              relativeStartOffset = relativeOnePastEndOffset,
+              size = aMatch.size - relativeOnePastEndOffset
+            )
+
+            Right(
+              for
+                _ <- propagateGroupId(aMatch, leadingRemainingContestedMatch)
+                _ <- hivedOffMatch.traverse(propagateGroupId(aMatch, _))
+                _ <- propagateGroupId(aMatch, trailingRemainingContestedMatch)
+              yield new HivedOffNonOverlappedMatchResult:
+                def hivedOffNonOverlappedMatch: Option[GenericMatch[Element]] =
+                  hivedOffMatch
+                def remainingContestedMatches: Seq[GenericMatch[Element]] =
+                  Seq(
+                    leadingRemainingContestedMatch,
+                    trailingRemainingContestedMatch
+                  )
+            )
+        end match
+      end hiveOffNonOverlappedMatchFrom
 
       private def reconciliationPostcondition(): Unit =
         baseSectionsByPath.values.flatMap(_.iterator).foreach { baseSection =>

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1629,10 +1629,10 @@ object MatchAnalysis extends StrictLogging:
           overallEncroachments.partitionMap(_.startToLeftAndEndToRight)
 
         val relativeStartOffsetToHiveOffFrom =
-          advancingRelativeOnePastEndOffsets.maxOption
+          advancingRelativeStartOffsets.maxOption
 
         val relativeOnePastEndOffsetToHiveOffTo =
-          advancingRelativeStartOffsets.minOption
+          advancingRelativeOnePastEndOffsets.minOption
 
         (
           relativeStartOffsetToHiveOffFrom,

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -599,12 +599,7 @@ object MatchAnalysis extends StrictLogging:
             // ambiguous matches.
             Some(sections + section)
           case None =>
-            Some(
-              // NOTE: don't use `Ordering[Int]` as while that is valid, it will
-              // pull in a Cats `Order[Int]` which round-trips back to an
-              // `Ordering`. That makes profiling difficult.
-              SectionsSeen.empty[Element] + section
-            )
+            Some(SectionsSeen.empty[Element] + section)
         }
       end including
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -832,11 +832,12 @@ object MatchAnalysis extends StrictLogging:
               parallelMatchesGroupIdsByMatch <- State
                 .get[ParallelMatchesGroupIdsByMatch[Element]]
 
-              biteEdgesWithGroupIds = bites.toSeq.flatMap {
-                case (bitingMatch, biteStart, biteEnd) =>
+              biteEdgesWithGroupIds = bites.toSeq
+                .flatMap { case (bitingMatch, biteStart, biteEnd) =>
                   val groupId = parallelMatchesGroupIdsByMatch(bitingMatch)
                   Seq(biteStart -> groupId, biteEnd -> groupId)
-              }.sortBy(_._1)
+                }
+                .sortBy(_._1)
 
               fragmentsFromMatch <-
                 biteEdgesWithGroupIds.eatIntoMatch(
@@ -863,7 +864,6 @@ object MatchAnalysis extends StrictLogging:
           // NOTE: here we work with zero-relative offsets from the start of the
           // meal, thus we can work directly with the offsets from the bite
           // edges.
-
 
           trait FragmentFactory:
             def apply(
@@ -1112,6 +1112,7 @@ object MatchAnalysis extends StrictLogging:
                 nextGroupId += 1
                 updated
             }
+          end if
         }
 
       private def propagateGroupIds(
@@ -1448,7 +1449,8 @@ object MatchAnalysis extends StrictLogging:
 
                   val associations =
                     matches.flatMap(aMatch =>
-                      overlappingMatchesWithBiteEdgesAndBitingMatch(aMatch)
+                      remnant
+                        .overlappingMatchesWithBiteEdgesAndBitingMatch(aMatch)
                         .map {
                           case (
                                 overlappingMatch,
@@ -1465,23 +1467,25 @@ object MatchAnalysis extends StrictLogging:
                         }
                     )
 
-                  val (overlapping, disjoint) =
-                    matches.partition(aMatch =>
-                      associations.exists(_._1 == aMatch)
-                    )
-
                   if associations.isEmpty then
                     State.pure(
                       Right(
-                        accumulatedMatches.foldLeft(remnant)(_ withMatch _)
+                        (accumulatedMatches union matches).foldLeft(remnant)(
+                          _ withMatch _
+                        )
                       )
                     )
                   else
+                    val (overlapping, disjoint) =
+                      matches.partition(aMatch =>
+                        associations.exists(_._1 == aMatch)
+                      )
+
                     for
                       _ <- enrolGroupIds(associations.flatMap {
                         case (overlappingMatch, (aMatch, _, _, bitingMatch)) =>
                           Seq(overlappingMatch, aMatch)
-                      }.toSet)
+                      })
 
                       _ <- associations.toSeq.traverse {
                         case (overlappingMatch, (aMatch, _, _, bitingMatch)) =>
@@ -1493,7 +1497,10 @@ object MatchAnalysis extends StrictLogging:
                         (GenericMatch[Element], BiteEdge, BiteEdge)
                       ] =
                         MultiDict.from(associations.map {
-                          case (key, (aMatch, biteStart, biteEnd, bitingMatch)) =>
+                          case (
+                                key,
+                                (aMatch, biteStart, biteEnd, bitingMatch)
+                              ) =>
                             key -> (bitingMatch, biteStart, biteEnd)
                         })
 
@@ -1517,20 +1524,15 @@ object MatchAnalysis extends StrictLogging:
                           )
                         )(_ withMatch _)
 
-                      withReplacements = (replacements.values.toSet ++ disjoint)
+                      withReplacements = replacements.values.toSet
                         .foldLeft(
                           takingFragmentationIntoAccount
                         )(_ withMatch _)
                         .withoutRedundantPairwiseMatches
-
-                      (overlappingAtEnd, disjointAtEnd) =
-                        withReplacements.matches.partition(aMatch =>
-                          overlappingMatchesWithBiteEdgesAndBitingMatch(aMatch).nonEmpty
-                        )
                     yield Left(
                       LoopState(
-                        withReplacements.withoutTheseMatches(disjointAtEnd),
-                        accumulatedMatches ++ disjointAtEnd
+                        withReplacements,
+                        accumulatedMatches ++ disjoint
                       )
                     )
                     end for
@@ -1714,6 +1716,7 @@ object MatchAnalysis extends StrictLogging:
                   sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
               )
           end match
+        end if
       end withMatch
 
       def reconcileMatches(
@@ -3076,8 +3079,7 @@ object MatchAnalysis extends StrictLogging:
           sectionsByPath
             .get(side.pathFor(section))
             .fold(ifEmpty = Set.empty)(
-              _.filterOverlaps(section.closedOpenInterval)
-                .toSet
+              _.filterOverlaps(section.closedOpenInterval).toSet
                 .filter(candidateSection =>
                   candidateSection.startOffset != section.startOffset || candidateSection.onePastEndOffset != section.onePastEndOffset
                 )

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1411,8 +1411,8 @@ object MatchAnalysis extends StrictLogging:
               Using(
                 progressRecording.newSession(
                   label = sessionLabel,
-                  maximumProgress = matches.size
-                )(initialProgress = matches.size)
+                  maximumProgress = overlappingMatches.size
+                )(initialProgress = overlappingMatches.size)
               ) { progressRecordingSession =>
                 case class RecursionState(
                     remainingMatchesAndTheirSections: MatchesAndTheirSections,
@@ -1429,13 +1429,29 @@ object MatchAnalysis extends StrictLogging:
                     accumulatedMatches
                   ) = recursionState
 
-                  val matches = remainingMatchesAndTheirSections.matches
-
-                  val (unsplitMatchesWithoutOverlaps, splits) = matches
-                    .map(
-                      remainingMatchesAndTheirSections.hiveOffNonOverlappedMatchFrom
+                  val (matchesThatAreSubsumed, matchesThatAreNotSubsumed) =
+                    remainingMatchesAndTheirSections.matches.partition(aMatch =>
+                      aMatch.baseContribution.fold(ifEmpty = false)(
+                        remainingMatchesAndTheirSections.baseSubsumes(_)
+                      ) || aMatch.leftContribution.fold(ifEmpty = false)(
+                        remainingMatchesAndTheirSections.leftSubsumes(_)
+                      ) || aMatch.rightContribution.fold(ifEmpty = false)(
+                        remainingMatchesAndTheirSections.rightSubsumes(_)
+                      )
                     )
-                    .partitionMap(identity)
+
+                  val remainingMatchesAndTheirSectionsWithoutSubsumedMatches =
+                    remainingMatchesAndTheirSections
+                      .withoutTheseMatches(matchesThatAreSubsumed)
+
+                  val (unsplitMatchesWithoutOverlaps, splits) =
+                    matchesThatAreNotSubsumed
+                      .map(
+                        remainingMatchesAndTheirSectionsWithoutSubsumedMatches.hiveOffNonOverlappedMatchFrom
+                      )
+                      .partitionMap(identity)
+
+                  progressRecordingSession.upTo(splits.size)
 
                   if splits.isEmpty then
                     for updatedParallelMatchesGroupIdsByMatch <- State.get
@@ -1449,11 +1465,9 @@ object MatchAnalysis extends StrictLogging:
                             fullyReconciledMatches.contains(key)
                           )
 
-                      progressRecordingSession.upTo(amount = 0)
-
                       Right(
-                        accumulatedMatches
-                          .foldLeft(remainingMatchesAndTheirSections)(
+                        fullyReconciledMatches
+                          .foldLeft(MatchesAndTheirSections.empty)(
                             _ withMatch _
                           )
                           .copy(parallelMatchesGroupIdsByMatch =
@@ -1464,13 +1478,9 @@ object MatchAnalysis extends StrictLogging:
                     for splitResults <- splits.sequence
                     yield
                       val hivedOffMatches =
-                        splitResults.map(_.hivedOffNonOverlappedMatch)
+                        splitResults.flatMap(_.hivedOffNonOverlappedMatch)
                       val remainingContestedMatches =
                         splitResults.flatMap(_.remainingContestedMatches)
-
-                      progressRecordingSession.upTo(
-                        remainingContestedMatches.size
-                      )
 
                       Left(
                         RecursionState(
@@ -1642,8 +1652,8 @@ object MatchAnalysis extends StrictLogging:
                 _ <- propagateGroupId(aMatch, remainingContestedMatch)
                 _ <- propagateGroupId(aMatch, hivedOffMatch)
               yield new HivedOffNonOverlappedMatchResult:
-                def hivedOffNonOverlappedMatch: GenericMatch[Element] =
-                  hivedOffMatch
+                def hivedOffNonOverlappedMatch: Option[GenericMatch[Element]] =
+                  Some(hivedOffMatch)
                 def remainingContestedMatches: Seq[GenericMatch[Element]] =
                   Seq(remainingContestedMatch)
             )
@@ -1662,25 +1672,21 @@ object MatchAnalysis extends StrictLogging:
                 _ <- propagateGroupId(aMatch, hivedOffMatch)
                 _ <- propagateGroupId(aMatch, remainingContestedMatch)
               yield new HivedOffNonOverlappedMatchResult:
-                def hivedOffNonOverlappedMatch: GenericMatch[Element] =
-                  hivedOffMatch
+                def hivedOffNonOverlappedMatch: Option[GenericMatch[Element]] =
+                  Some(hivedOffMatch)
                 def remainingContestedMatches: Seq[GenericMatch[Element]] =
                   Seq(remainingContestedMatch)
             )
           case (Some(relativeStartOffset), Some(relativeOnePastEndOffset)) =>
-            // TODO: suppose the encroachments *meet*? Presumably there should
-            // be
-            // no hived off match, only the remaining contested matches? Need to
-            // make `hivedOffNonOverlappedMatch` return an `Option` and make
-            // this assertion a weak inequality...
-            require(relativeStartOffset < relativeOnePastEndOffset)
-
             val leadingRemainingContestedMatch =
               aMatch.slice(relativeStartOffset = 0, size = relativeStartOffset)
-            val hivedOffMatch = aMatch.slice(
-              relativeStartOffset = relativeStartOffset,
-              size = relativeOnePastEndOffset - relativeStartOffset
-            )
+            val hivedOffMatch =
+              Option.when(relativeStartOffset < relativeOnePastEndOffset)(
+                aMatch.slice(
+                  relativeStartOffset = relativeStartOffset,
+                  size = relativeOnePastEndOffset - relativeStartOffset
+                )
+              )
             val trailingRemainingContestedMatch = aMatch.slice(
               relativeStartOffset = relativeOnePastEndOffset,
               size = aMatch.size - relativeOnePastEndOffset
@@ -1689,10 +1695,10 @@ object MatchAnalysis extends StrictLogging:
             Right(
               for
                 _ <- propagateGroupId(aMatch, leadingRemainingContestedMatch)
-                _ <- propagateGroupId(aMatch, hivedOffMatch)
+                _ <- hivedOffMatch.traverse(propagateGroupId(aMatch, _))
                 _ <- propagateGroupId(aMatch, trailingRemainingContestedMatch)
               yield new HivedOffNonOverlappedMatchResult:
-                def hivedOffNonOverlappedMatch: GenericMatch[Element] =
+                def hivedOffNonOverlappedMatch: Option[GenericMatch[Element]] =
                   hivedOffMatch
                 def remainingContestedMatches: Seq[GenericMatch[Element]] =
                   Seq(
@@ -1702,186 +1708,6 @@ object MatchAnalysis extends StrictLogging:
             )
         end match
       end hiveOffNonOverlappedMatchFrom
-
-      // Cleans up the state when a putative all-sides match that would have
-      // been ambiguous on one side with another all-sides match was partially
-      // suppressed by a larger pairwise match. This situation results in a
-      // pairwise match that shares its sections on both sides with the other
-      // all-sides match; remove any such redundant pairwise matches.
-      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
-        val redundantMatches =
-          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
-
-        if redundantMatches.nonEmpty then
-          logger.debug(
-            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
-          )
-        end if
-
-        withoutTheseMatches(redundantMatches)
-      end withoutRedundantPairwiseMatches
-
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
-                  allSides
-                )
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
-                  baseAndLeft
-                )
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
-                  baseAndRight
-                )
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
-                  leftAndRight
-                )
-            )
-        }
-      end withoutTheseMatches
-
-      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
-        aMatch match
-          case Match.BaseAndLeft(baseSection, leftSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(leftSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.BaseAndRight(baseSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.LeftAndRight(leftSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(leftSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case _: Match.AllSides[Section[Element]] => false
-
-      private def withMatch(
-          aMatch: GenericMatch[Element]
-      ): MatchesAndTheirSections =
-        aMatch match
-          case Match.AllSides(baseSection, leftSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
-              baseFingerprintedInclusionsByPath =
-                knockOutFromBaseFingerprintedInclusions(baseSection),
-              leftFingerprintedInclusionsByPath =
-                knockOutFromLeftFingerprintedInclusions(leftSection),
-              rightFingerprintedInclusionsByPath =
-                knockOutFromRightFingerprintedInclusions(rightSection)
-            )
-          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
-            )
-          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
-            )
-          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
-            copy(
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
-            )
-        end match
-      end withMatch
 
       def reconcileMatches(
           suppressMatchesInvolvingOverlappingSections: Boolean
@@ -2314,6 +2140,144 @@ object MatchAnalysis extends StrictLogging:
           .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
       end parallelMatchesOnly
 
+      // Cleans up the state when a putative all-sides match that would have
+      // been ambiguous on one side with another all-sides match was partially
+      // suppressed by a larger pairwise match. This situation results in a
+      // pairwise match that shares its sections on both sides with the other
+      // all-sides match; remove any such redundant pairwise matches.
+      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
+        val redundantMatches =
+          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
+
+        if redundantMatches.nonEmpty then
+          logger.debug(
+            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
+          )
+        end if
+
+        withoutTheseMatches(redundantMatches)
+      end withoutRedundantPairwiseMatches
+
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
+                  allSides
+                )
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
+                  baseAndLeft
+                )
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
+                  baseAndRight
+                )
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
+                  leftAndRight
+                )
+            )
+        }
+      end withoutTheseMatches
+
+      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
+        aMatch match
+          case Match.BaseAndLeft(baseSection, leftSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(leftSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.BaseAndRight(baseSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.LeftAndRight(leftSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(leftSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case _: Match.AllSides[Section[Element]] => false
+
       private def isSubsumedNonTriviallyByAnAllSidesMatch(
           baseSection: Section[Element],
           leftSection: Section[Element],
@@ -2513,6 +2477,48 @@ object MatchAnalysis extends StrictLogging:
           pathInclusions = pathInclusions
         )
       end withMatches
+
+      private def withMatch(
+          aMatch: GenericMatch[Element]
+      ): MatchesAndTheirSections =
+        aMatch match
+          case Match.AllSides(baseSection, leftSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
+              baseFingerprintedInclusionsByPath =
+                knockOutFromBaseFingerprintedInclusions(baseSection),
+              leftFingerprintedInclusionsByPath =
+                knockOutFromLeftFingerprintedInclusions(leftSection),
+              rightFingerprintedInclusionsByPath =
+                knockOutFromRightFingerprintedInclusions(rightSection)
+            )
+          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
+            )
+          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
+            )
+          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
+            copy(
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
+            )
+        end match
+      end withMatch
 
       private def reconciliationPostcondition(): Unit =
         baseSectionsByPath.values.flatMap(_.iterator).foreach { baseSection =>
@@ -3664,7 +3670,7 @@ object MatchAnalysis extends StrictLogging:
       trait HivedOffNonOverlappedMatchResult:
         require(remainingContestedMatches.nonEmpty)
 
-        def hivedOffNonOverlappedMatch: GenericMatch[Element]
+        def hivedOffNonOverlappedMatch: Option[GenericMatch[Element]]
         def remainingContestedMatches: Seq[GenericMatch[Element]]
       end HivedOffNonOverlappedMatchResult
     end MatchesAndTheirSections

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -197,6 +197,71 @@ object MatchAnalysis extends StrictLogging:
       type ParallelMatchesGroupIdTracking[X] =
         State[ParallelMatchesGroupIdsByMatch[Element], X]
 
+      def sectionSlice(
+          sources: Sources[Path, Element],
+          section: Section[Element]
+      )(
+          relativeOffset: Int,
+          size: Int
+      ) =
+        sources.section(sources.pathFor(section))(
+          section.startOffset + relativeOffset,
+          size
+        )
+
+      extension (aMatch: GenericMatch[Element])
+        def slice(relativeOffset: Int, sliceSize: Int): GenericMatch[Element] =
+          aMatch match
+            case Match.AllSides(baseSection, leftSection, rightSection) =>
+              Match.AllSides(
+                sectionSlice(
+                  baseSources,
+                  baseSection
+                )(relativeOffset, sliceSize),
+                sectionSlice(
+                  leftSources,
+                  leftSection
+                )(relativeOffset, sliceSize),
+                sectionSlice(
+                  rightSources,
+                  rightSection
+                )(relativeOffset, sliceSize)
+              )
+            case Match.BaseAndLeft(baseSection, leftSection) =>
+              Match.BaseAndLeft(
+                sectionSlice(
+                  baseSources,
+                  baseSection
+                )(relativeOffset, sliceSize),
+                sectionSlice(
+                  leftSources,
+                  leftSection
+                )(relativeOffset, sliceSize)
+              )
+            case Match.BaseAndRight(baseSection, rightSection) =>
+              Match.BaseAndRight(
+                sectionSlice(
+                  baseSources,
+                  baseSection
+                )(relativeOffset, sliceSize),
+                sectionSlice(
+                  rightSources,
+                  rightSection
+                )(relativeOffset, sliceSize)
+              )
+            case Match.LeftAndRight(leftSection, rightSection) =>
+              Match.LeftAndRight(
+                sectionSlice(
+                  leftSources,
+                  leftSection
+                )(relativeOffset, sliceSize),
+                sectionSlice(
+                  rightSources,
+                  rightSection
+                )(relativeOffset, sliceSize)
+              )
+      end extension
+
       lazy val empty: MatchesAndTheirSections = MatchesAndTheirSections(
         baseSectionsByPath = Map.empty,
         leftSectionsByPath = Map.empty,
@@ -803,17 +868,6 @@ object MatchAnalysis extends StrictLogging:
           // meal, thus we can work directly with the offsets from the bite
           // edges.
 
-          def sectionSlice(
-              sources: Sources[Path, Element],
-              section: Section[Element]
-          )(
-              mealStartOffsetRelativeToMeal: Int,
-              size: Int
-          ) =
-            sources.section(sources.pathFor(section))(
-              section.startOffset + mealStartOffsetRelativeToMeal,
-              size
-            )
 
           trait FragmentFactory:
             def apply(
@@ -1042,6 +1096,25 @@ object MatchAnalysis extends StrictLogging:
         }
 
       // TODO: use the singular - only one group id is propagated, if at all.
+      private def enrolGroupIds(
+          matches: Iterable[GenericMatch[Element]]
+      ): ParallelMatchesGroupIdTracking[Unit] =
+        State.modify { groupIdsByMatch =>
+          val matchesMissingGroupIds =
+            matches.filterNot(groupIdsByMatch.contains)
+          if matchesMissingGroupIds.isEmpty then groupIdsByMatch
+          else
+            var nextGroupId =
+              if groupIdsByMatch.isEmpty then 0
+              else 1 + groupIdsByMatch.values.max
+            matchesMissingGroupIds.foldLeft(groupIdsByMatch) {
+              (groupIdsByMatch, aMatch) =>
+                val updated = groupIdsByMatch + (aMatch -> nextGroupId)
+                nextGroupId += 1
+                updated
+            }
+        }
+
       private def propagateGroupIds(
           original: GenericMatch[Element],
           replacement: GenericMatch[Element]
@@ -1071,6 +1144,11 @@ object MatchAnalysis extends StrictLogging:
         case Start(startOffsetRelativeToMeal: Int)
         case End(onePastEndOffsetRelativeToMeal: Int)
       end BiteEdge
+
+      case class LoopState(
+          remnant: MatchesAndTheirSections,
+          accumulatedMatches: Set[GenericMatch[Element]]
+      )
 
       case class MatchingResult(
           matchesAndTheirSections: MatchesAndTheirSections,
@@ -1353,7 +1431,7 @@ object MatchAnalysis extends StrictLogging:
                 s"${configuration.label} - number of overlapping matches to reconcile:"
               else "Number of overlapping matches to reconcile:"
 
-            val Success(reconciled) =
+            val reconciled =
               Using(
                 progressRecording.newSession(
                   label = sessionLabel,
@@ -1361,11 +1439,13 @@ object MatchAnalysis extends StrictLogging:
                 )(initialProgress = matches.size)
               ) { progressRecordingSession =>
                 def reconcileUsing(
-                    matchesAndTheirSections: MatchesAndTheirSections
+                    loopState: LoopState
                 ): ParallelMatchesGroupIdTracking[
-                  Either[MatchesAndTheirSections, MatchesAndTheirSections]
+                  Either[LoopState, MatchesAndTheirSections]
                 ] =
-                  val matches = matchesAndTheirSections.matches
+                  val LoopState(remnant, accumulatedMatches) = loopState
+
+                  val matches = remnant.matches
 
                   val associations =
                     matches.flatMap(aMatch =>
@@ -1386,27 +1466,46 @@ object MatchAnalysis extends StrictLogging:
                         }
                     )
 
+                  val (overlapping, disjoint) =
+                    matches.partition(aMatch =>
+                      associations.exists(_._1 == aMatch)
+                    )
+
                   if associations.isEmpty then
-                    State.pure(Right(matchesAndTheirSections))
-                  else
-                    val matchesToBeEaten: MultiDict[GenericMatch[
-                      Element
-                    ], (GenericMatch[Element], BiteEdge, BiteEdge)] =
-                      MultiDict.from(associations.map { case (key, quadruple) =>
-                        key -> quadruple.init
-                      })
-
-                    val replacements: MultiDict[GenericMatch[
-                      Element
-                    ], GenericMatch[Element]] =
-                      MultiDict.from(associations.map { case (key, quadruple) =>
-                        key -> quadruple.last
-                      })
-
-                    for
-                      _ <- State.set(
-                        matchesAndTheirSections.parallelMatchesGroupIdsByMatch
+                    State.pure(
+                      Right(
+                        accumulatedMatches.foldLeft(remnant)(_ withMatch _)
                       )
+                    )
+                  else
+                    for
+                      _ <- enrolGroupIds(associations.flatMap {
+                        case (overlappingMatch, (aMatch, _, _, bitingMatch)) =>
+                          Seq(overlappingMatch, aMatch)
+                      }.toSet)
+
+                      _ <- associations.toSeq.traverse {
+                        case (overlappingMatch, (aMatch, _, _, bitingMatch)) =>
+                          propagateGroupIds(aMatch, bitingMatch)
+                      }
+
+                      matchesToBeEaten: MultiDict[
+                        GenericMatch[Element],
+                        (GenericMatch[Element], BiteEdge, BiteEdge)
+                      ] =
+                        MultiDict.from(associations.map {
+                          case (key, (aMatch, biteStart, biteEnd, bitingMatch)) =>
+                            key -> (bitingMatch, biteStart, biteEnd)
+                        })
+
+                      replacements: MultiDict[
+                        GenericMatch[Element],
+                        GenericMatch[Element]
+                      ] =
+                        MultiDict.from(associations.map {
+                          case (key, quadruple) =>
+                            key -> quadruple.last
+                        })
 
                       fragments <- fragmentsOf(matchesToBeEaten).map(
                         _.diff(matches)
@@ -1414,26 +1513,25 @@ object MatchAnalysis extends StrictLogging:
 
                       takingFragmentationIntoAccount =
                         fragments.foldLeft(
-                          matchesAndTheirSections.withoutTheseMatches(
+                          remnant.withoutTheseMatches(
                             matchesToBeEaten.keySet
                           )
                         )(_ withMatch _)
 
-                      withReplacements = replacements.values
+                      withReplacements = (replacements.values.toSet ++ disjoint)
                         .foldLeft(
                           takingFragmentationIntoAccount
                         )(_ withMatch _)
                         .withoutRedundantPairwiseMatches
 
-                      _ <- replacements.toSeq.traverse {
-                        case (former, replacement) =>
-                          propagateGroupIds(former, replacement)
-                      }
-
-                      parallelMatchesGroupIdsByMatch <- State.get
+                      (overlappingAtEnd, disjointAtEnd) =
+                        withReplacements.matches.partition(aMatch =>
+                          overlappingMatchesWithBiteEdgesAndBitingMatch(aMatch).nonEmpty
+                        )
                     yield Left(
-                      withReplacements.copy(parallelMatchesGroupIdsByMatch =
-                        parallelMatchesGroupIdsByMatch
+                      LoopState(
+                        withReplacements.withoutTheseMatches(disjointAtEnd),
+                        accumulatedMatches ++ disjointAtEnd
                       )
                     )
                     end for
@@ -1441,10 +1539,10 @@ object MatchAnalysis extends StrictLogging:
                 end reconcileUsing
 
                 FlatMap[ParallelMatchesGroupIdTracking]
-                  .tailRecM(this)(reconcileUsing)
+                  .tailRecM(LoopState(this, Set.empty))(reconcileUsing)
                   .runA(Map.empty)
                   .value
-              }: @unchecked
+              }.get
 
             reconciled
           else
@@ -1568,43 +1666,55 @@ object MatchAnalysis extends StrictLogging:
       private def withMatch(
           aMatch: GenericMatch[Element]
       ): MatchesAndTheirSections =
-        aMatch match
-          case Match.AllSides(baseSection, leftSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
-              baseFingerprintedInclusionsByPath =
-                knockOutFromBaseFingerprintedInclusions(baseSection),
-              leftFingerprintedInclusionsByPath =
-                knockOutFromLeftFingerprintedInclusions(leftSection),
-              rightFingerprintedInclusionsByPath =
-                knockOutFromRightFingerprintedInclusions(rightSection)
-            )
-          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
-            )
-          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
-            )
-          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
-            copy(
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
-            )
-        end match
+        val alreadyPresent = aMatch match
+          case Match.AllSides(baseSection, _, _) =>
+            sectionsAndTheirMatches.get(baseSection).contains(aMatch)
+          case Match.BaseAndLeft(baseSection, _) =>
+            sectionsAndTheirMatches.get(baseSection).contains(aMatch)
+          case Match.BaseAndRight(baseSection, _) =>
+            sectionsAndTheirMatches.get(baseSection).contains(aMatch)
+          case Match.LeftAndRight(leftSection, _) =>
+            sectionsAndTheirMatches.get(leftSection).contains(aMatch)
+
+        if alreadyPresent then this
+        else
+          aMatch match
+            case Match.AllSides(baseSection, leftSection, rightSection) =>
+              copy(
+                baseSectionsByPath = baseIncluding(baseSection),
+                leftSectionsByPath = leftIncluding(leftSection),
+                rightSectionsByPath = rightIncluding(rightSection),
+                sectionsAndTheirMatches =
+                  sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
+                baseFingerprintedInclusionsByPath =
+                  knockOutFromBaseFingerprintedInclusions(baseSection),
+                leftFingerprintedInclusionsByPath =
+                  knockOutFromLeftFingerprintedInclusions(leftSection),
+                rightFingerprintedInclusionsByPath =
+                  knockOutFromRightFingerprintedInclusions(rightSection)
+              )
+            case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
+              copy(
+                baseSectionsByPath = baseIncluding(baseSection),
+                leftSectionsByPath = leftIncluding(leftSection),
+                sectionsAndTheirMatches =
+                  sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
+              )
+            case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
+              copy(
+                baseSectionsByPath = baseIncluding(baseSection),
+                rightSectionsByPath = rightIncluding(rightSection),
+                sectionsAndTheirMatches =
+                  sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
+              )
+            case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
+              copy(
+                leftSectionsByPath = leftIncluding(leftSection),
+                rightSectionsByPath = rightIncluding(rightSection),
+                sectionsAndTheirMatches =
+                  sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
+              )
+          end match
       end withMatch
 
       def reconcileMatches(
@@ -2956,7 +3066,72 @@ object MatchAnalysis extends StrictLogging:
           aMatch: GenericMatch[Element]
       ): Set[
         (GenericMatch[Element], BiteEdge, BiteEdge, GenericMatch[Element])
-      ] = ???
+      ] =
+        def overlappingOnSide(
+            side: Sources[Path, Element],
+            sectionsByPath: Map[Path, SectionsSeen],
+            section: Section[Element]
+        ): Set[
+          (GenericMatch[Element], BiteEdge, BiteEdge, GenericMatch[Element])
+        ] =
+          sectionsByPath
+            .get(side.pathFor(section))
+            .fold(ifEmpty = Set.empty)(
+              _.filterOverlaps(section.closedOpenInterval)
+                .toSet
+                .filter(candidateSection =>
+                  candidateSection.startOffset != section.startOffset || candidateSection.onePastEndOffset != section.onePastEndOffset
+                )
+                .flatMap { overlappingSection =>
+                  val intersectionStart =
+                    section.startOffset max overlappingSection.startOffset
+                  val intersectionOnePastEnd =
+                    section.onePastEndOffset min overlappingSection.onePastEndOffset
+
+                  val biteStartOffsetRelativeToOverlappingMatchMeal =
+                    intersectionStart - overlappingSection.startOffset
+                  val biteSize = intersectionOnePastEnd - intersectionStart
+
+                  val biteStartOffsetRelativeToAMatchMeal =
+                    intersectionStart - section.startOffset
+
+                  val bitingMatch = aMatch.slice(
+                    relativeOffset = biteStartOffsetRelativeToAMatchMeal,
+                    sliceSize = biteSize
+                  )
+
+                  sectionsAndTheirMatches.get(overlappingSection).map {
+                    overlappingMatch =>
+                      (
+                        overlappingMatch,
+                        BiteEdge.Start(
+                          biteStartOffsetRelativeToOverlappingMatchMeal
+                        ),
+                        BiteEdge.End(
+                          biteStartOffsetRelativeToOverlappingMatchMeal + biteSize
+                        ),
+                        bitingMatch
+                      )
+                  }
+                }
+            )
+        end overlappingOnSide
+
+        val baseOverlaps = aMatch.baseContribution
+          .fold(ifEmpty = Set.empty)(
+            overlappingOnSide(baseSources, baseSectionsByPath, _)
+          )
+        val leftOverlaps = aMatch.leftContribution
+          .fold(ifEmpty = Set.empty)(
+            overlappingOnSide(leftSources, leftSectionsByPath, _)
+          )
+        val rightOverlaps = aMatch.rightContribution
+          .fold(ifEmpty = Set.empty)(
+            overlappingOnSide(rightSources, rightSectionsByPath, _)
+          )
+
+        baseOverlaps union leftOverlaps union rightOverlaps
+      end overlappingMatchesWithBiteEdgesAndBitingMatch
 
       @tailrec
       private final def withAllSmallFryMatches(

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -197,72 +197,6 @@ object MatchAnalysis extends StrictLogging:
     object MatchesAndTheirSections:
       type ParallelMatchesGroupIdTracking[X] =
         State[ParallelMatchesGroupIdsByMatch[Element], X]
-
-      def sectionSlice(
-          sources: Sources[Path, Element],
-          section: Section[Element]
-      )(
-          relativeOffset: Int,
-          size: Int
-      ) =
-        sources.section(sources.pathFor(section))(
-          section.startOffset + relativeOffset,
-          size
-        )
-
-      extension (aMatch: GenericMatch[Element])
-        def slice(relativeOffset: Int, sliceSize: Int): GenericMatch[Element] =
-          aMatch match
-            case Match.AllSides(baseSection, leftSection, rightSection) =>
-              Match.AllSides(
-                sectionSlice(
-                  baseSources,
-                  baseSection
-                )(relativeOffset, sliceSize),
-                sectionSlice(
-                  leftSources,
-                  leftSection
-                )(relativeOffset, sliceSize),
-                sectionSlice(
-                  rightSources,
-                  rightSection
-                )(relativeOffset, sliceSize)
-              )
-            case Match.BaseAndLeft(baseSection, leftSection) =>
-              Match.BaseAndLeft(
-                sectionSlice(
-                  baseSources,
-                  baseSection
-                )(relativeOffset, sliceSize),
-                sectionSlice(
-                  leftSources,
-                  leftSection
-                )(relativeOffset, sliceSize)
-              )
-            case Match.BaseAndRight(baseSection, rightSection) =>
-              Match.BaseAndRight(
-                sectionSlice(
-                  baseSources,
-                  baseSection
-                )(relativeOffset, sliceSize),
-                sectionSlice(
-                  rightSources,
-                  rightSection
-                )(relativeOffset, sliceSize)
-              )
-            case Match.LeftAndRight(leftSection, rightSection) =>
-              Match.LeftAndRight(
-                sectionSlice(
-                  leftSources,
-                  leftSection
-                )(relativeOffset, sliceSize),
-                sectionSlice(
-                  rightSources,
-                  rightSection
-                )(relativeOffset, sliceSize)
-              )
-      end extension
-
       lazy val empty: MatchesAndTheirSections = MatchesAndTheirSections(
         baseSectionsByPath = Map.empty,
         leftSectionsByPath = Map.empty,
@@ -276,8 +210,80 @@ object MatchAnalysis extends StrictLogging:
           fingerprintedInclusionsByPath(rightSources),
         parallelMatchesGroupIdsByMatch = Map.empty
       )
+
+      extension (aMatch: GenericMatch[Element])
+        def size: Int =
+          aMatch match
+            case Match.AllSides(baseSection, _, _)  => baseSection.size
+            case Match.BaseAndLeft(baseSection, _)  => baseSection.size
+            case Match.BaseAndRight(baseSection, _) => baseSection.size
+            case Match.LeftAndRight(leftSection, _) => leftSection.size
+
+        def slice(relativeStartOffset: Int, size: Int): GenericMatch[Element] =
+          aMatch match
+            case Match.AllSides(baseSection, leftSection, rightSection) =>
+              Match.AllSides(
+                sectionSlice(
+                  baseSources,
+                  baseSection
+                )(relativeStartOffset, size),
+                sectionSlice(
+                  leftSources,
+                  leftSection
+                )(relativeStartOffset, size),
+                sectionSlice(
+                  rightSources,
+                  rightSection
+                )(relativeStartOffset, size)
+              )
+            case Match.BaseAndLeft(baseSection, leftSection) =>
+              Match.BaseAndLeft(
+                sectionSlice(
+                  baseSources,
+                  baseSection
+                )(relativeStartOffset, size),
+                sectionSlice(
+                  leftSources,
+                  leftSection
+                )(relativeStartOffset, size)
+              )
+            case Match.BaseAndRight(baseSection, rightSection) =>
+              Match.BaseAndRight(
+                sectionSlice(
+                  baseSources,
+                  baseSection
+                )(relativeStartOffset, size),
+                sectionSlice(
+                  rightSources,
+                  rightSection
+                )(relativeStartOffset, size)
+              )
+            case Match.LeftAndRight(leftSection, rightSection) =>
+              Match.LeftAndRight(
+                sectionSlice(
+                  leftSources,
+                  leftSection
+                )(relativeStartOffset, size),
+                sectionSlice(
+                  rightSources,
+                  rightSection
+                )(relativeStartOffset, size)
+              )
+      end extension
       private val rollingHashFactoryCache: Cache[Int, RollingHash.Factory] =
         Caffeine.newBuilder().build()
+
+      def sectionSlice(
+          sources: Sources[Path, Element],
+          section: Section[Element]
+      )(
+          relativeStartOffset: Int,
+          size: Int
+      ): Section[Element] =
+        sources.section(sources.pathFor(section))(
+          section.startOffset + relativeStartOffset,
+          size
+        )
 
       def withAllMatchesOfAtLeastTheSureFireWindowSize()
           : MatchesAndTheirSections =
@@ -624,31 +630,6 @@ object MatchAnalysis extends StrictLogging:
               )
           )
       end overlapsOrIsSubsumedBy
-
-      private def overlappingOrSubsumedMatches(
-          sectionsAndTheirMatches: MatchedSections[Element]
-      )(
-          side: Sources[Path, Element],
-          sectionsByPath: Map[Path, SectionsSeen]
-      )(
-          section: Section[Element]
-      ): Set[GenericMatch[Element]] =
-        sectionsByPath
-          .get(side.pathFor(section))
-          .fold(ifEmpty = Set.empty)(
-            _.filterOverlaps(section.closedOpenInterval)
-              // NOTE: convert to a set at this point as we expect sections to
-              // be duplicated when involved in ambiguous matches.
-              .toSet
-              // Subsuming sections are considered to be overlapping by the
-              // implementation of `SectionSeen.filterOverlaps`, so filter with
-              // a nuanced predicate.
-              .filter(candidateSection =>
-                candidateSection.startOffset > section.startOffset || candidateSection.onePastEndOffset < section.onePastEndOffset
-              )
-              .flatMap(sectionsAndTheirMatches.get)
-          )
-      end overlappingOrSubsumedMatches
 
       private def including(
           side: Sources[Path, Element],
@@ -1143,11 +1124,6 @@ object MatchAnalysis extends StrictLogging:
         case End(onePastEndOffsetRelativeToMeal: Int)
       end BiteEdge
 
-      case class LoopState(
-          remnant: MatchesAndTheirSections,
-          accumulatedMatches: Set[GenericMatch[Element]]
-      )
-
       case class MatchingResult(
           matchesAndTheirSections: MatchesAndTheirSections,
           numberOfMatchesForTheGivenWindowSize: Int,
@@ -1390,9 +1366,11 @@ object MatchAnalysis extends StrictLogging:
           enabled: Boolean
       ): MatchesAndTheirSections =
         def overlapsWithSomethingElse(aMatch: GenericMatch[Element]): Boolean =
-          // NOTE: the invariant already guarantees that nothing will be
-          // subsumed by the match's sections, so this is only testing for
-          // overlaps.
+          // NOTE: this is loose: it also considers subsumed matches to be
+          // overlapping. In practise this method should only be called
+          // post-reconciliation, so that's OK. Otherwise, any subsumed matches
+          // will cause a precondition failure later on if overlap
+          // reconciliation is performed.
           aMatch match
             case Match.AllSides(baseSection, leftSection, rightSection) =>
               baseOverlapsOrIsSubsumedBy(baseSection) ||
@@ -1436,110 +1414,86 @@ object MatchAnalysis extends StrictLogging:
                   maximumProgress = matches.size
                 )(initialProgress = matches.size)
               ) { progressRecordingSession =>
+                case class RecursionState(
+                    remainingMatchesAndTheirSections: MatchesAndTheirSections,
+                    accumulatedNonOverlappingMatches: Set[GenericMatch[Element]]
+                )
+
                 def reconcileUsing(
-                    loopState: LoopState
+                    recursionState: RecursionState
                 ): ParallelMatchesGroupIdTracking[
-                  Either[LoopState, MatchesAndTheirSections]
+                  Either[RecursionState, MatchesAndTheirSections]
                 ] =
-                  val LoopState(remnant, accumulatedMatches) = loopState
+                  val RecursionState(
+                    remainingMatchesAndTheirSections,
+                    accumulatedMatches
+                  ) = recursionState
 
-                  val matches = remnant.matches
+                  val matches = remainingMatchesAndTheirSections.matches
 
-                  val associations =
-                    matches.flatMap(aMatch =>
-                      remnant
-                        .overlappingMatchesWithBiteEdgesAndBitingMatch(aMatch)
-                        .map {
-                          case (
-                                overlappingMatch,
-                                biteStart,
-                                biteEnd,
-                                bitingMatch
-                              ) =>
-                            overlappingMatch -> (
-                              aMatch,
-                              biteStart,
-                              biteEnd,
-                              bitingMatch
-                            )
-                        }
+                  val (unsplitMatchesWithoutOverlaps, splits) = matches
+                    .map(
+                      remainingMatchesAndTheirSections.hiveOffNonOverlappedMatchFrom
                     )
+                    .partitionMap(identity)
 
-                  if associations.isEmpty then
-                    State.pure(
+                  if splits.isEmpty then
+                    for updatedParallelMatchesGroupIdsByMatch <- State.get
+                    yield
+                      val fullyReconciledMatches =
+                        accumulatedMatches union unsplitMatchesWithoutOverlaps
+
+                      val parallelMatchesGroupIdsByMatch =
+                        updatedParallelMatchesGroupIdsByMatch
+                          .filter((key, _) =>
+                            fullyReconciledMatches.contains(key)
+                          )
+
+                      progressRecordingSession.upTo(amount = 0)
+
                       Right(
-                        (accumulatedMatches union matches).foldLeft(remnant)(
-                          _ withMatch _
+                        accumulatedMatches
+                          .foldLeft(remainingMatchesAndTheirSections)(
+                            _ withMatch _
+                          )
+                          .copy(parallelMatchesGroupIdsByMatch =
+                            parallelMatchesGroupIdsByMatch
+                          )
+                      )
+                  else
+                    for splitResults <- splits.sequence
+                    yield
+                      val hivedOffMatches =
+                        splitResults.map(_.hivedOffNonOverlappedMatch)
+                      val remainingContestedMatches =
+                        splitResults.flatMap(_.remainingContestedMatches)
+
+                      progressRecordingSession.upTo(
+                        remainingContestedMatches.size
+                      )
+
+                      Left(
+                        RecursionState(
+                          remainingContestedMatches
+                            .foldLeft(MatchesAndTheirSections.empty)(
+                              _ withMatch _
+                            )
+                            .withoutRedundantPairwiseMatches,
+                          accumulatedMatches union unsplitMatchesWithoutOverlaps union hivedOffMatches
                         )
                       )
-                    )
-                  else
-                    val (overlapping, disjoint) =
-                      matches.partition(aMatch =>
-                        associations.exists(_._1 == aMatch)
-                      )
-
-                    for
-                      _ <- enrolGroupIds(associations.flatMap {
-                        case (overlappingMatch, (aMatch, _, _, bitingMatch)) =>
-                          Seq(overlappingMatch, aMatch)
-                      })
-
-                      _ <- associations.toSeq.traverse {
-                        case (overlappingMatch, (aMatch, _, _, bitingMatch)) =>
-                          propagateGroupId(aMatch, bitingMatch)
-                      }
-
-                      matchesToBeEaten: MultiDict[
-                        GenericMatch[Element],
-                        (GenericMatch[Element], BiteEdge, BiteEdge)
-                      ] =
-                        MultiDict.from(associations.map {
-                          case (
-                                key,
-                                (aMatch, biteStart, biteEnd, bitingMatch)
-                              ) =>
-                            key -> (bitingMatch, biteStart, biteEnd)
-                        })
-
-                      replacements: MultiDict[
-                        GenericMatch[Element],
-                        GenericMatch[Element]
-                      ] =
-                        MultiDict.from(associations.map {
-                          case (key, quadruple) =>
-                            key -> quadruple.last
-                        })
-
-                      fragments <- fragmentsOf(matchesToBeEaten).map(
-                        _.diff(matches)
-                      )
-
-                      takingFragmentationIntoAccount =
-                        fragments.foldLeft(
-                          remnant.withoutTheseMatches(
-                            matchesToBeEaten.keySet
-                          )
-                        )(_ withMatch _)
-
-                      withReplacements = replacements.values.toSet
-                        .foldLeft(
-                          takingFragmentationIntoAccount
-                        )(_ withMatch _)
-                        .withoutRedundantPairwiseMatches
-                    yield Left(
-                      LoopState(
-                        withReplacements,
-                        accumulatedMatches ++ disjoint
-                      )
-                    )
                     end for
                   end if
                 end reconcileUsing
 
                 FlatMap[ParallelMatchesGroupIdTracking]
-                  .tailRecM(LoopState(this, Set.empty))(reconcileUsing)
-                  .runA(Map.empty)
+                  .tailRecM(
+                    RecursionState(
+                      remainingMatchesAndTheirSections = this,
+                      accumulatedNonOverlappingMatches = Set.empty
+                    )
+                  )(reconcileUsing)
+                  .runA(parallelMatchesGroupIdsByMatch)
                   .value
               }: @unchecked
 
@@ -1560,6 +1514,374 @@ object MatchAnalysis extends StrictLogging:
         else this
         end if
       end purgedOfMatchesWithOverlappingSections
+
+      private def hiveOffNonOverlappedMatchFrom(
+          aMatch: GenericMatch[Element]
+      ): Either[
+        GenericMatch[Element], /* Original match if not split. */
+        ParallelMatchesGroupIdTracking[HivedOffNonOverlappedMatchResult]
+      ] =
+        enum Encroachment:
+          def startToLeftAndEndToRight: Either[Int, Int] =
+            this match
+              case OnTheStart(advancingRelativeStartOffset) =>
+                Left(advancingRelativeStartOffset)
+              case OnTheEnd(limitingRelativeEndOffset) =>
+                Right(limitingRelativeEndOffset)
+
+          case OnTheStart(advancingRelativeStartOffset: Int)
+          case OnTheEnd(limitingRelativeEndOffset: Int)
+        end Encroachment
+
+        def encroachments(
+            side: Sources[Path, Element],
+            sectionsByPath: Map[Path, SectionsSeen]
+        )(
+            section: Section[Element]
+        ): Iterable[Encroachment] =
+
+          sectionsByPath
+            .get(side.pathFor(section))
+            .fold(ifEmpty = Set.empty)(
+              _.filterOverlaps(section.closedOpenInterval)
+                // Subsuming sections are considered to be overlapping by the
+                // implementation of `SectionSeen.filterOverlaps`, so collect
+                // with a nuanced predicate.
+                // NOTE: this is a strict overlap, so if the candidate section
+                // is equivalent to `section`, it isn't considered to be a
+                // degenerate overlap. This is important, because the calling
+                // logic in `purgedOfMatchesWithOverlappingSections` needs to
+                // both completely hive off matches from overlaps *and* trim the
+                // overlaps down to ambiguous matches, so we expect to see
+                // equivalent sections belonging to multiple ambiguous matches.
+                .collect {
+                  case candidateSection
+                      if candidateSection.startOffset > section.startOffset && candidateSection.onePastEndOffset < section.onePastEndOffset =>
+                    throw new IllegalArgumentException(
+                      s"Precondition failure: match ${pprintCustomised(aMatch)} subsumes another match on at least one side."
+                    )
+                  case candidateSection
+                      if candidateSection.startOffset < section.startOffset && candidateSection.onePastEndOffset > section.onePastEndOffset =>
+                    throw new IllegalArgumentException(
+                      s"Precondition failure: match ${pprintCustomised(aMatch)} is subsumed by another match on at least one side."
+                    )
+                  case candidateSection
+                      if candidateSection.startOffset > section.startOffset =>
+                    // The overlapping `candidateSection` extends up to or past
+                    // the end of `section`, so this encroaches on the end. We
+                    // do allow a special case subsumption here where
+                    // `candidateSection` aligns with the end.
+                    Encroachment.OnTheEnd(
+                      candidateSection.startOffset - section.startOffset
+                    )
+                  case candidateSection
+                      if candidateSection.onePastEndOffset < section.onePastEndOffset =>
+                    // The overlapping `candidateSection` extends back to or
+                    // before the start of `section`, so this encroaches on the
+                    // start. We do allow a special case subsumption here where
+                    // `candidateSection` aligns with the start.
+                    Encroachment.OnTheStart(
+                      candidateSection.onePastEndOffset - section.startOffset
+                    )
+                }
+            )
+        end encroachments
+
+        val baseEncroachments =
+          aMatch.baseContribution.fold(ifEmpty = Seq.empty)(
+            encroachments(
+              baseSources,
+              baseSectionsByPath
+            )
+          )
+        val leftEncroachments =
+          aMatch.leftContribution.fold(ifEmpty = Seq.empty)(
+            encroachments(
+              leftSources,
+              leftSectionsByPath
+            )
+          )
+        val rightEncroachments =
+          aMatch.rightContribution.fold(ifEmpty = Seq.empty)(
+            encroachments(
+              rightSources,
+              rightSectionsByPath
+            )
+          )
+
+        val overallEncroachments =
+          baseEncroachments ++ leftEncroachments ++ rightEncroachments
+
+        val (
+          advancingRelativeStartOffsets,
+          advancingRelativeOnePastEndOffsets
+        ) =
+          overallEncroachments.partitionMap(_.startToLeftAndEndToRight)
+
+        val relativeStartOffsetToHiveOffFrom =
+          advancingRelativeOnePastEndOffsets.maxOption
+
+        val relativeOnePastEndOffsetToHiveOffTo =
+          advancingRelativeStartOffsets.minOption
+
+        (
+          relativeStartOffsetToHiveOffFrom,
+          relativeOnePastEndOffsetToHiveOffTo
+        ) match
+          case (None, None)                      => Left(aMatch)
+          case (Some(relativeStartOffset), None) =>
+            val remainingContestedMatch =
+              aMatch.slice(relativeStartOffset = 0, size = relativeStartOffset)
+            val hivedOffMatch = aMatch.slice(
+              relativeStartOffset = relativeStartOffset,
+              size = aMatch.size - relativeStartOffset
+            )
+
+            Right(
+              for
+                _ <- propagateGroupId(aMatch, remainingContestedMatch)
+                _ <- propagateGroupId(aMatch, hivedOffMatch)
+              yield new HivedOffNonOverlappedMatchResult:
+                def hivedOffNonOverlappedMatch: GenericMatch[Element] =
+                  hivedOffMatch
+                def remainingContestedMatches: Seq[GenericMatch[Element]] =
+                  Seq(remainingContestedMatch)
+            )
+          case (None, Some(relativeOnePastEndOffset)) =>
+            val hivedOffMatch = aMatch.slice(
+              relativeStartOffset = 0,
+              size = relativeOnePastEndOffset
+            )
+            val remainingContestedMatch = aMatch.slice(
+              relativeStartOffset = relativeOnePastEndOffset,
+              size = aMatch.size - relativeOnePastEndOffset
+            )
+
+            Right(
+              for
+                _ <- propagateGroupId(aMatch, hivedOffMatch)
+                _ <- propagateGroupId(aMatch, remainingContestedMatch)
+              yield new HivedOffNonOverlappedMatchResult:
+                def hivedOffNonOverlappedMatch: GenericMatch[Element] =
+                  hivedOffMatch
+                def remainingContestedMatches: Seq[GenericMatch[Element]] =
+                  Seq(remainingContestedMatch)
+            )
+          case (Some(relativeStartOffset), Some(relativeOnePastEndOffset)) =>
+            // TODO: suppose the encroachments *meet*? Presumably there should
+            // be
+            // no hived off match, only the remaining contested matches? Need to
+            // make `hivedOffNonOverlappedMatch` return an `Option` and make
+            // this assertion a weak inequality...
+            require(relativeStartOffset < relativeOnePastEndOffset)
+
+            val leadingRemainingContestedMatch =
+              aMatch.slice(relativeStartOffset = 0, size = relativeStartOffset)
+            val hivedOffMatch = aMatch.slice(
+              relativeStartOffset = relativeStartOffset,
+              size = relativeOnePastEndOffset - relativeStartOffset
+            )
+            val trailingRemainingContestedMatch = aMatch.slice(
+              relativeStartOffset = relativeOnePastEndOffset,
+              size = aMatch.size - relativeOnePastEndOffset
+            )
+
+            Right(
+              for
+                _ <- propagateGroupId(aMatch, leadingRemainingContestedMatch)
+                _ <- propagateGroupId(aMatch, hivedOffMatch)
+                _ <- propagateGroupId(aMatch, trailingRemainingContestedMatch)
+              yield new HivedOffNonOverlappedMatchResult:
+                def hivedOffNonOverlappedMatch: GenericMatch[Element] =
+                  hivedOffMatch
+                def remainingContestedMatches: Seq[GenericMatch[Element]] =
+                  Seq(
+                    leadingRemainingContestedMatch,
+                    trailingRemainingContestedMatch
+                  )
+            )
+        end match
+      end hiveOffNonOverlappedMatchFrom
+
+      // Cleans up the state when a putative all-sides match that would have
+      // been ambiguous on one side with another all-sides match was partially
+      // suppressed by a larger pairwise match. This situation results in a
+      // pairwise match that shares its sections on both sides with the other
+      // all-sides match; remove any such redundant pairwise matches.
+      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
+        val redundantMatches =
+          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
+
+        if redundantMatches.nonEmpty then
+          logger.debug(
+            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
+          )
+        end if
+
+        withoutTheseMatches(redundantMatches)
+      end withoutRedundantPairwiseMatches
+
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
+                  allSides
+                )
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
+                  baseAndLeft
+                )
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
+                  baseAndRight
+                )
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
+                  leftAndRight
+                )
+            )
+        }
+      end withoutTheseMatches
+
+      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
+        aMatch match
+          case Match.BaseAndLeft(baseSection, leftSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(leftSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.BaseAndRight(baseSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(baseSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case Match.LeftAndRight(leftSection, rightSection) =>
+            sectionsAndTheirMatches
+              .get(leftSection)
+              .intersect(sectionsAndTheirMatches.get(rightSection))
+              .exists(_.isAnAllSidesMatch)
+          case _: Match.AllSides[Section[Element]] => false
+
+      private def withMatch(
+          aMatch: GenericMatch[Element]
+      ): MatchesAndTheirSections =
+        aMatch match
+          case Match.AllSides(baseSection, leftSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
+              baseFingerprintedInclusionsByPath =
+                knockOutFromBaseFingerprintedInclusions(baseSection),
+              leftFingerprintedInclusionsByPath =
+                knockOutFromLeftFingerprintedInclusions(leftSection),
+              rightFingerprintedInclusionsByPath =
+                knockOutFromRightFingerprintedInclusions(rightSection)
+            )
+          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
+            )
+          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
+            )
+          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
+            copy(
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
+            )
+        end match
+      end withMatch
 
       def reconcileMatches(
           suppressMatchesInvolvingOverlappingSections: Boolean
@@ -1656,13 +1978,15 @@ object MatchAnalysis extends StrictLogging:
                       _          = rebuilt.checkInvariant()
                       reconciled = rebuilt.withoutRedundantPairwiseMatches
                       _          = reconciled.checkInvariant()
-                      _          = progressRecordingSession.upTo(0)
+                      _          = progressRecordingSession.upTo(amount = 0)
                       updatedParallelMatchesGroupIdsByMatch <- State.get
                     yield
-                      val matches                        = reconciled.matches
+                      val fullyReconciledMatches         = reconciled.matches
                       val parallelMatchesGroupIdsByMatch =
                         updatedParallelMatchesGroupIdsByMatch
-                          .filter((key, _) => matches.contains(key))
+                          .filter((key, _) =>
+                            fullyReconciledMatches.contains(key)
+                          )
 
                       val compactGroupIdsKeyedByGroupsIdsWithPossibleGaps: Map[
                         ParallelMatchesGroupId,
@@ -1990,144 +2314,6 @@ object MatchAnalysis extends StrictLogging:
           .copy(parallelMatchesGroupIdsByMatch = parallelMatchesGroupIdsByMatch)
       end parallelMatchesOnly
 
-      // Cleans up the state when a putative all-sides match that would have
-      // been ambiguous on one side with another all-sides match was partially
-      // suppressed by a larger pairwise match. This situation results in a
-      // pairwise match that shares its sections on both sides with the other
-      // all-sides match; remove any such redundant pairwise matches.
-      def withoutRedundantPairwiseMatches: MatchesAndTheirSections =
-        val redundantMatches =
-          sectionsAndTheirMatches.values.toSet.filter(isRedundantPairwiseMatch)
-
-        if redundantMatches.nonEmpty then
-          logger.debug(
-            s"Removing redundant pairwise matches:\n${pprintCustomised(redundantMatches)} as their sections also belong to all-sides matches."
-          )
-        end if
-
-        withoutTheseMatches(redundantMatches)
-      end withoutRedundantPairwiseMatches
-
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
-                  allSides
-                )
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
-                  baseAndLeft
-                )
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
-                  baseAndRight
-                )
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
-                  leftAndRight
-                )
-            )
-        }
-      end withoutTheseMatches
-
-      private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
-        aMatch match
-          case Match.BaseAndLeft(baseSection, leftSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(leftSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.BaseAndRight(baseSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(baseSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case Match.LeftAndRight(leftSection, rightSection) =>
-            sectionsAndTheirMatches
-              .get(leftSection)
-              .intersect(sectionsAndTheirMatches.get(rightSection))
-              .exists(_.isAnAllSidesMatch)
-          case _: Match.AllSides[Section[Element]] => false
-
       private def isSubsumedNonTriviallyByAnAllSidesMatch(
           baseSection: Section[Element],
           leftSection: Section[Element],
@@ -2327,48 +2513,6 @@ object MatchAnalysis extends StrictLogging:
           pathInclusions = pathInclusions
         )
       end withMatches
-
-      private def withMatch(
-          aMatch: GenericMatch[Element]
-      ): MatchesAndTheirSections =
-        aMatch match
-          case Match.AllSides(baseSection, leftSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
-              baseFingerprintedInclusionsByPath =
-                knockOutFromBaseFingerprintedInclusions(baseSection),
-              leftFingerprintedInclusionsByPath =
-                knockOutFromLeftFingerprintedInclusions(leftSection),
-              rightFingerprintedInclusionsByPath =
-                knockOutFromRightFingerprintedInclusions(rightSection)
-            )
-          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
-            )
-          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
-            )
-          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
-            copy(
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
-            )
-        end match
-      end withMatch
 
       private def reconciliationPostcondition(): Unit =
         baseSectionsByPath.values.flatMap(_.iterator).foreach { baseSection =>
@@ -3049,76 +3193,6 @@ object MatchAnalysis extends StrictLogging:
         }
       end pairwiseMatchesSubsumingOnBothSidesWithBiteEdges
 
-      private def overlappingMatchesWithBiteEdgesAndBitingMatch(
-          aMatch: GenericMatch[Element]
-      ): Set[
-        (GenericMatch[Element], BiteEdge, BiteEdge, GenericMatch[Element])
-      ] =
-        def overlappingOnSide(
-            side: Sources[Path, Element],
-            sectionsByPath: Map[Path, SectionsSeen],
-            section: Section[Element]
-        ): Set[
-          (GenericMatch[Element], BiteEdge, BiteEdge, GenericMatch[Element])
-        ] =
-          sectionsByPath
-            .get(side.pathFor(section))
-            .fold(ifEmpty = Set.empty)(
-              _.filterOverlaps(section.closedOpenInterval).toSet
-                .filter(candidateSection =>
-                  candidateSection.startOffset != section.startOffset || candidateSection.onePastEndOffset != section.onePastEndOffset
-                )
-                .flatMap { overlappingSection =>
-                  val intersectionStart =
-                    section.startOffset max overlappingSection.startOffset
-                  val intersectionOnePastEnd =
-                    section.onePastEndOffset min overlappingSection.onePastEndOffset
-
-                  val biteStartOffsetRelativeToOverlappingMatchMeal =
-                    intersectionStart - overlappingSection.startOffset
-                  val biteSize = intersectionOnePastEnd - intersectionStart
-
-                  val biteStartOffsetRelativeToAMatchMeal =
-                    intersectionStart - section.startOffset
-
-                  val bitingMatch = aMatch.slice(
-                    relativeOffset = biteStartOffsetRelativeToAMatchMeal,
-                    sliceSize = biteSize
-                  )
-
-                  sectionsAndTheirMatches.get(overlappingSection).map {
-                    overlappingMatch =>
-                      (
-                        overlappingMatch,
-                        BiteEdge.Start(
-                          biteStartOffsetRelativeToOverlappingMatchMeal
-                        ),
-                        BiteEdge.End(
-                          biteStartOffsetRelativeToOverlappingMatchMeal + biteSize
-                        ),
-                        bitingMatch
-                      )
-                  }
-                }
-            )
-        end overlappingOnSide
-
-        val baseOverlaps = aMatch.baseContribution
-          .fold(ifEmpty = Set.empty)(
-            overlappingOnSide(baseSources, baseSectionsByPath, _)
-          )
-        val leftOverlaps = aMatch.leftContribution
-          .fold(ifEmpty = Set.empty)(
-            overlappingOnSide(leftSources, leftSectionsByPath, _)
-          )
-        val rightOverlaps = aMatch.rightContribution
-          .fold(ifEmpty = Set.empty)(
-            overlappingOnSide(rightSources, rightSectionsByPath, _)
-          )
-
-        baseOverlaps union leftOverlaps union rightOverlaps
-      end overlappingMatchesWithBiteEdgesAndBitingMatch
-
       @tailrec
       private final def withAllSmallFryMatches(
           candidateWindowSize: Int
@@ -3586,6 +3660,13 @@ object MatchAnalysis extends StrictLogging:
           haveTrimmedMatches = false
         )
       end matchesForWindowSize
+
+      trait HivedOffNonOverlappedMatchResult:
+        require(remainingContestedMatches.nonEmpty)
+
+        def hivedOffNonOverlappedMatch: GenericMatch[Element]
+        def remainingContestedMatches: Seq[GenericMatch[Element]]
+      end HivedOffNonOverlappedMatchResult
     end MatchesAndTheirSections
 
     object PotentialMatchKey:

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1039,16 +1039,16 @@ object MatchAnalysis extends StrictLogging:
             groupIdsByMatch + (fragment -> assignedGroupId)
         }
 
-      private def propagateGroupIds(
+      private def propagateGroupId(
           original: GenericMatch[Element],
           replacement: GenericMatch[Element]
       ): ParallelMatchesGroupIdTracking[Unit] =
         State.modify { groupIdsByMatch =>
-          val groupIds = groupIdsByMatch.get(original)
-
-          groupIds.fold(ifEmpty = groupIdsByMatch)(groupId =>
-            groupIdsByMatch + (replacement -> groupId)
-          )
+          groupIdsByMatch
+            .get(original)
+            .fold(ifEmpty = groupIdsByMatch)(groupId =>
+              groupIdsByMatch + (replacement -> groupId)
+            )
         }
 
       trait PathInclusions:
@@ -2767,7 +2767,7 @@ object MatchAnalysis extends StrictLogging:
           case _ => None
 
         result.traverse(paredDownMatch =>
-          propagateGroupIds(aMatch, paredDownMatch) as paredDownMatch
+          propagateGroupId(aMatch, paredDownMatch) as paredDownMatch
         )
       end pareDownOrSuppressCompletely
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -2257,8 +2257,7 @@ object MatchAnalysis extends StrictLogging:
                 )(initialProgress = overlappingMatches.size)
               ) { progressRecordingSession =>
                 case class RecursionState(
-                    remainingMatchesAndTheirSections: MatchesAndTheirSections,
-                    accumulatedNonOverlappingMatches: Set[GenericMatch[Element]]
+                    remainingMatchesAndTheirSections: MatchesAndTheirSections
                 )
 
                 def reconcileUsing(
@@ -2266,10 +2265,8 @@ object MatchAnalysis extends StrictLogging:
                 ): ParallelMatchesGroupIdTracking[
                   Either[RecursionState, MatchesAndTheirSections]
                 ] =
-                  val RecursionState(
-                    remainingMatchesAndTheirSections,
-                    accumulatedMatches
-                  ) = recursionState
+                  val RecursionState(remainingMatchesAndTheirSections) =
+                    recursionState
 
                   val matches = remainingMatchesAndTheirSections.matches
 
@@ -2285,20 +2282,12 @@ object MatchAnalysis extends StrictLogging:
                   if splits.isEmpty then
                     for updatedParallelMatchesGroupIdsByMatch <- State.get
                     yield
-                      val fullyReconciledMatches =
-                        accumulatedMatches union unsplitMatchesWithoutOverlaps
-
                       val parallelMatchesGroupIdsByMatch =
                         updatedParallelMatchesGroupIdsByMatch
-                          .filter((key, _) =>
-                            fullyReconciledMatches.contains(key)
-                          )
+                          .filter((key, _) => matches.contains(key))
 
                       Right(
-                        fullyReconciledMatches
-                          .foldLeft(MatchesAndTheirSections.empty)(
-                            _ withMatch _
-                          )
+                        remainingMatchesAndTheirSections
                           .copy(parallelMatchesGroupIdsByMatch =
                             parallelMatchesGroupIdsByMatch
                           )
@@ -2313,12 +2302,16 @@ object MatchAnalysis extends StrictLogging:
 
                       Left(
                         RecursionState(
-                          remainingContestedMatches
-                            .foldLeft(MatchesAndTheirSections.empty)(
+                          (hivedOffMatches union remainingContestedMatches) // TODO: maybe we should accumulate `hivedOffMatches`? Can they be subsumed or subsume other things?
+                            .foldLeft(
+                              remainingMatchesAndTheirSections
+                                .withoutTheseMatches(
+                                  matches diff unsplitMatchesWithoutOverlaps
+                                )
+                            )(
                               _ withMatch _
                             )
-                            .withoutRedundantPairwiseMatches,
-                          accumulatedMatches union unsplitMatchesWithoutOverlaps union hivedOffMatches
+                            .withoutRedundantPairwiseMatches
                         )
                       )
                     end for
@@ -2328,8 +2321,7 @@ object MatchAnalysis extends StrictLogging:
                 FlatMap[ParallelMatchesGroupIdTracking]
                   .tailRecM(
                     RecursionState(
-                      remainingMatchesAndTheirSections = this,
-                      accumulatedNonOverlappingMatches = Set.empty
+                      remainingMatchesAndTheirSections = this
                     )
                   )(reconcileUsing)
                   .runA(parallelMatchesGroupIdsByMatch)

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1369,8 +1369,7 @@ object MatchAnalysis extends StrictLogging:
           // NOTE: this is loose: it also considers subsumed matches to be
           // overlapping. In practise this method should only be called
           // post-reconciliation, so that's OK. Otherwise, any subsumed matches
-          // will cause a precondition failure later on if overlap
-          // reconciliation is performed.
+          // will cause a precondition failure later on.
           aMatch match
             case Match.AllSides(baseSection, leftSection, rightSection) =>
               baseOverlapsOrIsSubsumedBy(baseSection) ||
@@ -1416,7 +1415,7 @@ object MatchAnalysis extends StrictLogging:
               ) { progressRecordingSession =>
                 case class RecursionState(
                     remainingMatchesAndTheirSections: MatchesAndTheirSections,
-                    accumulatedNonOverlappingMatches: Set[GenericMatch[Element]]
+                    remainingContestedMatches: Set[GenericMatch[Element]]
                 )
 
                 def reconcileUsing(
@@ -1426,11 +1425,11 @@ object MatchAnalysis extends StrictLogging:
                 ] =
                   val RecursionState(
                     remainingMatchesAndTheirSections,
-                    accumulatedMatches
+                    remainingContestedMatches
                   ) = recursionState
 
                   val (matchesThatAreSubsumed, matchesThatAreNotSubsumed) =
-                    remainingMatchesAndTheirSections.matches.partition(aMatch =>
+                    remainingContestedMatches.partition(aMatch =>
                       aMatch.baseContribution.fold(ifEmpty = false)(
                         remainingMatchesAndTheirSections.baseSubsumes(_)
                       ) || aMatch.leftContribution.fold(ifEmpty = false)(
@@ -1457,7 +1456,7 @@ object MatchAnalysis extends StrictLogging:
                     for updatedParallelMatchesGroupIdsByMatch <- State.get
                     yield
                       val fullyReconciledMatches =
-                        accumulatedMatches union unsplitMatchesWithoutOverlaps
+                        remainingMatchesAndTheirSectionsWithoutSubsumedMatches.matches
 
                       val parallelMatchesGroupIdsByMatch =
                         updatedParallelMatchesGroupIdsByMatch
@@ -1466,10 +1465,7 @@ object MatchAnalysis extends StrictLogging:
                           )
 
                       Right(
-                        fullyReconciledMatches
-                          .foldLeft(MatchesAndTheirSections.empty)(
-                            _ withMatch _
-                          )
+                        remainingMatchesAndTheirSectionsWithoutSubsumedMatches
                           .copy(parallelMatchesGroupIdsByMatch =
                             parallelMatchesGroupIdsByMatch
                           )
@@ -1484,12 +1480,21 @@ object MatchAnalysis extends StrictLogging:
 
                       Left(
                         RecursionState(
-                          remainingContestedMatches
-                            .foldLeft(MatchesAndTheirSections.empty)(
-                              _ withMatch _
-                            )
-                            .withoutRedundantPairwiseMatches,
-                          accumulatedMatches union unsplitMatchesWithoutOverlaps union hivedOffMatches
+                          remainingMatchesAndTheirSections =
+                            // TODO: this is clumsy.
+                            (hivedOffMatches union remainingContestedMatches)
+                              .foldLeft(
+                                remainingMatchesAndTheirSectionsWithoutSubsumedMatches
+                                  .withoutTheseMatches(
+                                    matchesThatAreNotSubsumed diff unsplitMatchesWithoutOverlaps
+                                  )
+                              )(
+                                _ withMatch _
+                              )
+                              .withoutRedundantPairwiseMatches,
+                          remainingContestedMatches =
+                            // TODO: this is also clumsy.
+                            hivedOffMatches union remainingContestedMatches
                         )
                       )
                     end for
@@ -1500,7 +1505,7 @@ object MatchAnalysis extends StrictLogging:
                   .tailRecM(
                     RecursionState(
                       remainingMatchesAndTheirSections = this,
-                      accumulatedNonOverlappingMatches = Set.empty
+                      remainingContestedMatches = overlappingMatches
                     )
                   )(reconcileUsing)
                   .runA(parallelMatchesGroupIdsByMatch)

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -35,11 +35,13 @@ import scala.util.{Success, Using}
 trait MatchAnalysis[Path, Element]:
   def withAllSmallFryMatches(): MatchAnalysis[Path, Element]
 
+  def reconcileMatchesWithOverlappingSections(
+      enabled: Boolean
+  ): MatchAnalysis[Path, Element]
+
   def parallelMatchesOnly: MatchAnalysis[Path, Element]
 
-  def reconcileMatches(
-      suppressMatchesInvolvingOverlappingSections: Boolean
-  ): MatchAnalysis[Path, Element]
+  def reconcileMatches: MatchAnalysis[Path, Element]
 
   def groupsOfParallelMatches
       : Map[ParallelMatchesGroupId, SortedSet[GenericMatch[Element]]]
@@ -1400,9 +1402,7 @@ object MatchAnalysis extends StrictLogging:
         end if
       end purgedOfMatchesWithOverlappingSections
 
-      def reconcileMatches(
-          suppressMatchesInvolvingOverlappingSections: Boolean
-      ): MatchesAndTheirSections =
+      def reconcileMatches: MatchesAndTheirSections =
         val matches = this.matches
 
         val sessionLabel =
@@ -1538,18 +1538,13 @@ object MatchAnalysis extends StrictLogging:
               .value
           }: @unchecked
 
-        val result =
-          reconciled.reconcileMatchesWithOverlappingSections(enabled =
-            suppressMatchesInvolvingOverlappingSections
-          )
-
-        result.reconciliationPostcondition()
+        reconciled.reconciliationPostcondition()
 
         logger.debug(
-          s"Groups of parallel matches after reconciliation:\n${pprintCustomised(result.groupsOfParallelMatches)}"
+          s"Groups of parallel matches after reconciliation:\n${pprintCustomised(reconciled.groupsOfParallelMatches)}"
         )
 
-        result
+        reconciled
       end reconcileMatches
 
       def groupsOfParallelMatches: Map[ParallelMatchesGroupId, SortedSet[
@@ -2212,14 +2207,12 @@ object MatchAnalysis extends StrictLogging:
         end match
       end withMatch
 
-      private def reconcileMatchesWithOverlappingSections(
+      def reconcileMatchesWithOverlappingSections(
           enabled: Boolean
       ): MatchesAndTheirSections =
         def overlapsWithSomethingElse(aMatch: GenericMatch[Element]): Boolean =
           // NOTE: this is loose: it also considers subsumed matches to be
-          // overlapping. In practise this method should only be called
-          // post-reconciliation, so that's OK. Otherwise, any subsumed matches
-          // will cause a precondition failure later on.
+          // overlapping.
           aMatch match
             case Match.AllSides(baseSection, leftSection, rightSection) =>
               baseOverlapsOrIsSubsumedBy(baseSection) ||
@@ -2265,7 +2258,7 @@ object MatchAnalysis extends StrictLogging:
               ) { progressRecordingSession =>
                 case class RecursionState(
                     remainingMatchesAndTheirSections: MatchesAndTheirSections,
-                    remainingContestedMatches: Set[GenericMatch[Element]]
+                    accumulatedNonOverlappingMatches: Set[GenericMatch[Element]]
                 )
 
                 def reconcileUsing(
@@ -2275,28 +2268,15 @@ object MatchAnalysis extends StrictLogging:
                 ] =
                   val RecursionState(
                     remainingMatchesAndTheirSections,
-                    remainingContestedMatches
+                    accumulatedMatches
                   ) = recursionState
 
-                  val (matchesThatAreSubsumed, matchesThatAreNotSubsumed) =
-                    remainingContestedMatches.partition(aMatch =>
-                      aMatch.baseContribution.fold(ifEmpty = false)(
-                        remainingMatchesAndTheirSections.baseSubsumes(_)
-                      ) || aMatch.leftContribution.fold(ifEmpty = false)(
-                        remainingMatchesAndTheirSections.leftSubsumes(_)
-                      ) || aMatch.rightContribution.fold(ifEmpty = false)(
-                        remainingMatchesAndTheirSections.rightSubsumes(_)
-                      )
-                    )
-
-                  val remainingMatchesAndTheirSectionsWithoutSubsumedMatches =
-                    remainingMatchesAndTheirSections
-                      .withoutTheseMatches(matchesThatAreSubsumed)
+                  val matches = remainingMatchesAndTheirSections.matches
 
                   val (unsplitMatchesWithoutOverlaps, splits) =
-                    matchesThatAreNotSubsumed
+                    matches
                       .map(
-                        remainingMatchesAndTheirSectionsWithoutSubsumedMatches.hiveOffNonOverlappedMatchFrom
+                        remainingMatchesAndTheirSections.hiveOffNonOverlappedMatchFrom
                       )
                       .partitionMap(identity)
 
@@ -2306,7 +2286,7 @@ object MatchAnalysis extends StrictLogging:
                     for updatedParallelMatchesGroupIdsByMatch <- State.get
                     yield
                       val fullyReconciledMatches =
-                        remainingMatchesAndTheirSectionsWithoutSubsumedMatches.matches
+                        accumulatedMatches union unsplitMatchesWithoutOverlaps
 
                       val parallelMatchesGroupIdsByMatch =
                         updatedParallelMatchesGroupIdsByMatch
@@ -2315,7 +2295,10 @@ object MatchAnalysis extends StrictLogging:
                           )
 
                       Right(
-                        remainingMatchesAndTheirSectionsWithoutSubsumedMatches
+                        fullyReconciledMatches
+                          .foldLeft(MatchesAndTheirSections.empty)(
+                            _ withMatch _
+                          )
                           .copy(parallelMatchesGroupIdsByMatch =
                             parallelMatchesGroupIdsByMatch
                           )
@@ -2330,21 +2313,12 @@ object MatchAnalysis extends StrictLogging:
 
                       Left(
                         RecursionState(
-                          remainingMatchesAndTheirSections =
-                            // TODO: this is clumsy.
-                            (hivedOffMatches union remainingContestedMatches)
-                              .foldLeft(
-                                remainingMatchesAndTheirSectionsWithoutSubsumedMatches
-                                  .withoutTheseMatches(
-                                    matchesThatAreNotSubsumed diff unsplitMatchesWithoutOverlaps
-                                  )
-                              )(
-                                _ withMatch _
-                              )
-                              .withoutRedundantPairwiseMatches,
-                          remainingContestedMatches =
-                            // TODO: this is also clumsy.
-                            hivedOffMatches union remainingContestedMatches
+                          remainingContestedMatches
+                            .foldLeft(MatchesAndTheirSections.empty)(
+                              _ withMatch _
+                            )
+                            .withoutRedundantPairwiseMatches,
+                          accumulatedMatches union unsplitMatchesWithoutOverlaps union hivedOffMatches
                         )
                       )
                     end for
@@ -2355,7 +2329,7 @@ object MatchAnalysis extends StrictLogging:
                   .tailRecM(
                     RecursionState(
                       remainingMatchesAndTheirSections = this,
-                      remainingContestedMatches = overlappingMatches
+                      accumulatedNonOverlappingMatches = Set.empty
                     )
                   )(reconcileUsing)
                   .runA(parallelMatchesGroupIdsByMatch)
@@ -2404,7 +2378,6 @@ object MatchAnalysis extends StrictLogging:
         )(
             section: Section[Element]
         ): Iterable[Encroachment] =
-
           sectionsByPath
             .get(side.pathFor(section))
             .fold(ifEmpty = Set.empty)(
@@ -2421,17 +2394,7 @@ object MatchAnalysis extends StrictLogging:
                 // equivalent sections belonging to multiple ambiguous matches.
                 .collect {
                   case candidateSection
-                      if candidateSection.startOffset > section.startOffset && candidateSection.onePastEndOffset < section.onePastEndOffset =>
-                    throw new IllegalArgumentException(
-                      s"Precondition failure: match ${pprintCustomised(aMatch)} subsumes another match on at least one side."
-                    )
-                  case candidateSection
-                      if candidateSection.startOffset < section.startOffset && candidateSection.onePastEndOffset > section.onePastEndOffset =>
-                    throw new IllegalArgumentException(
-                      s"Precondition failure: match ${pprintCustomised(aMatch)} is subsumed by another match on at least one side."
-                    )
-                  case candidateSection
-                      if candidateSection.startOffset > section.startOffset =>
+                      if candidateSection.startOffset > section.startOffset && candidateSection.onePastEndOffset >= section.onePastEndOffset =>
                     // The overlapping `candidateSection` extends up to or past
                     // the end of `section`, so this encroaches on the end. We
                     // do allow a special case subsumption here where
@@ -2440,7 +2403,7 @@ object MatchAnalysis extends StrictLogging:
                       candidateSection.startOffset - section.startOffset
                     )
                   case candidateSection
-                      if candidateSection.onePastEndOffset < section.onePastEndOffset =>
+                      if candidateSection.startOffset <= section.startOffset && candidateSection.onePastEndOffset < section.onePastEndOffset =>
                     // The overlapping `candidateSection` extends back to or
                     // before the start of `section`, so this encroaches on the
                     // start. We do allow a special case subsumption here where

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -832,16 +832,18 @@ object MatchAnalysis extends StrictLogging:
               parallelMatchesGroupIdsByMatch <- State
                 .get[ParallelMatchesGroupIdsByMatch[Element]]
 
-              biteEdgesWithGroupIds = bites.toSeq
-                .flatMap { case (bitingMatch, biteStart, biteEnd) =>
-                  val groupId = parallelMatchesGroupIdsByMatch(bitingMatch)
-                  Seq(biteStart -> groupId, biteEnd -> groupId)
-                }
-                .sortBy(_._1)
+              groupIdsBySortedBiteEdge = SortedMap.from(bites.flatMap {
+                case (bitingMatch, biteStart, biteEnd) =>
+                  Seq(biteStart, biteEnd)
+                    .map(_ -> parallelMatchesGroupIdsByMatch(bitingMatch))
+              })
+
+              sortedBiteEdges = groupIdsBySortedBiteEdge.keySet
 
               fragmentsFromMatch <-
-                biteEdgesWithGroupIds.eatIntoMatch(
-                  matchBeingBittenInto
+                sortedBiteEdges.eatIntoMatch(
+                  matchBeingBittenInto,
+                  groupIdsBySortedBiteEdge
                 )
             yield
               logger.debug(
@@ -855,9 +857,10 @@ object MatchAnalysis extends StrictLogging:
       // There are contracts buried in the implementation that require the bite
       // edges to be sorted in terms of their offsets and not exceed the
       // boundaries of the match's sections.
-      extension (biteEdgesWithGroupIds: Seq[(BiteEdge, ParallelMatchesGroupId)])
+      extension (biteEdges: SortedSet[BiteEdge])
         private def eatIntoMatch[MatchType <: GenericMatch[Element]](
-            aMatch: MatchType
+            aMatch: MatchType,
+            groupIdsBySortedBiteEdge: Map[BiteEdge, ParallelMatchesGroupId]
         ): ParallelMatchesGroupIdTracking[
           Vector[DependentMatchType[MatchType]]
         ] =
@@ -955,7 +958,7 @@ object MatchAnalysis extends StrictLogging:
               deferredGroupIdFromPrecedingBite: Option[ParallelMatchesGroupId],
               mealStartOffsetRelativeToMeal: Int,
               biteDepth: Int,
-              remainingBiteEdges: Seq[(BiteEdge, ParallelMatchesGroupId)],
+              remainingBiteEdges: Seq[BiteEdge],
               fragments: Vector[DependentMatchType[MatchType]]
           ):
             final def biteEdgeStep: ParallelMatchesGroupIdTracking[
@@ -976,10 +979,7 @@ object MatchAnalysis extends StrictLogging:
                   else State.pure(Right(fragments))
 
                 case Seq(
-                      (
-                        biteEdge @ BiteEdge.Start(startOffsetRelativeToMeal),
-                        groupIdFromSucceedingBite
-                      ),
+                      biteEdge @ BiteEdge.Start(startOffsetRelativeToMeal),
                       tail*
                     ) =>
                   require(
@@ -992,6 +992,9 @@ object MatchAnalysis extends StrictLogging:
                       then
                         val size =
                           startOffsetRelativeToMeal - mealStartOffsetRelativeToMeal
+
+                        val groupIdFromSucceedingBite =
+                          groupIdsBySortedBiteEdge(biteEdge)
 
                         val groupId =
                           deferredGroupIdFromPrecedingBite.fold(ifEmpty =
@@ -1031,10 +1034,7 @@ object MatchAnalysis extends StrictLogging:
                   )
 
                 case Seq(
-                      (
-                        biteEdge @ BiteEdge.End(onePastEndOffsetRelativeToMeal),
-                        groupIdFromEndingBite
-                      ),
+                      biteEdge @ BiteEdge.End(onePastEndOffsetRelativeToMeal),
                       tail*
                     ) =>
                   assume(0 < biteDepth)
@@ -1052,7 +1052,7 @@ object MatchAnalysis extends StrictLogging:
                           // overwrite any prior contribution of a group id to
                           // the *succeeding* context.
                           deferredGroupIdFromPrecedingBite =
-                            Some(groupIdFromEndingBite),
+                            Some(groupIdsBySortedBiteEdge(biteEdge)),
                           mealStartOffsetRelativeToMeal =
                             onePastEndOffsetRelativeToMeal,
                           biteDepth = biteDepth - 1,
@@ -1070,7 +1070,7 @@ object MatchAnalysis extends StrictLogging:
               deferredGroupIdFromPrecedingBite = None,
               mealStartOffsetRelativeToMeal = 0,
               biteDepth = 0,
-              remainingBiteEdges = biteEdgesWithGroupIds,
+              remainingBiteEdges = biteEdges.toSeq,
               fragments = Vector.empty
             )
           )(_.biteEdgeStep)
@@ -1431,7 +1431,7 @@ object MatchAnalysis extends StrictLogging:
                 s"${configuration.label} - number of overlapping matches to reconcile:"
               else "Number of overlapping matches to reconcile:"
 
-            val reconciled =
+            val Success(reconciled) =
               Using(
                 progressRecording.newSession(
                   label = sessionLabel,
@@ -1543,7 +1543,7 @@ object MatchAnalysis extends StrictLogging:
                   .tailRecM(LoopState(this, Set.empty))(reconcileUsing)
                   .runA(Map.empty)
                   .value
-              }.get
+              }: @unchecked
 
             reconciled
           else
@@ -1667,56 +1667,43 @@ object MatchAnalysis extends StrictLogging:
       private def withMatch(
           aMatch: GenericMatch[Element]
       ): MatchesAndTheirSections =
-        val alreadyPresent = aMatch match
-          case Match.AllSides(baseSection, _, _) =>
-            sectionsAndTheirMatches.get(baseSection).contains(aMatch)
-          case Match.BaseAndLeft(baseSection, _) =>
-            sectionsAndTheirMatches.get(baseSection).contains(aMatch)
-          case Match.BaseAndRight(baseSection, _) =>
-            sectionsAndTheirMatches.get(baseSection).contains(aMatch)
-          case Match.LeftAndRight(leftSection, _) =>
-            sectionsAndTheirMatches.get(leftSection).contains(aMatch)
-
-        if alreadyPresent then this
-        else
-          aMatch match
-            case Match.AllSides(baseSection, leftSection, rightSection) =>
-              copy(
-                baseSectionsByPath = baseIncluding(baseSection),
-                leftSectionsByPath = leftIncluding(leftSection),
-                rightSectionsByPath = rightIncluding(rightSection),
-                sectionsAndTheirMatches =
-                  sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
-                baseFingerprintedInclusionsByPath =
-                  knockOutFromBaseFingerprintedInclusions(baseSection),
-                leftFingerprintedInclusionsByPath =
-                  knockOutFromLeftFingerprintedInclusions(leftSection),
-                rightFingerprintedInclusionsByPath =
-                  knockOutFromRightFingerprintedInclusions(rightSection)
-              )
-            case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
-              copy(
-                baseSectionsByPath = baseIncluding(baseSection),
-                leftSectionsByPath = leftIncluding(leftSection),
-                sectionsAndTheirMatches =
-                  sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
-              )
-            case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
-              copy(
-                baseSectionsByPath = baseIncluding(baseSection),
-                rightSectionsByPath = rightIncluding(rightSection),
-                sectionsAndTheirMatches =
-                  sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
-              )
-            case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
-              copy(
-                leftSectionsByPath = leftIncluding(leftSection),
-                rightSectionsByPath = rightIncluding(rightSection),
-                sectionsAndTheirMatches =
-                  sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
-              )
-          end match
-        end if
+        aMatch match
+          case Match.AllSides(baseSection, leftSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
+              baseFingerprintedInclusionsByPath =
+                knockOutFromBaseFingerprintedInclusions(baseSection),
+              leftFingerprintedInclusionsByPath =
+                knockOutFromLeftFingerprintedInclusions(leftSection),
+              rightFingerprintedInclusionsByPath =
+                knockOutFromRightFingerprintedInclusions(rightSection)
+            )
+          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
+            )
+          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
+            )
+          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
+            copy(
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
+            )
+        end match
       end withMatch
 
       def reconcileMatches(

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -24,6 +24,7 @@ import scala.annotation.tailrec
 import scala.collection.immutable.{
   MultiDict,
   SortedMap,
+  SortedMultiDict,
   SortedMultiSet,
   SortedSet
 }
@@ -767,7 +768,7 @@ object MatchAnalysis extends StrictLogging:
               parallelMatchesGroupIdsByMatch <- State
                 .get[ParallelMatchesGroupIdsByMatch[Element]]
 
-              groupIdsBySortedBiteEdge = SortedMap.from(bites.flatMap {
+              groupIdsBySortedBiteEdge = SortedMultiDict.from(bites.flatMap {
                 case (bitingMatch, biteStart, biteEnd) =>
                   Seq(biteStart, biteEnd)
                     .map(_ -> parallelMatchesGroupIdsByMatch(bitingMatch))
@@ -792,10 +793,13 @@ object MatchAnalysis extends StrictLogging:
       // There are contracts buried in the implementation that require the bite
       // edges to be sorted in terms of their offsets and not exceed the
       // boundaries of the match's sections.
-      extension (biteEdges: SortedSet[BiteEdge])
+      extension (biteEdges: collection.Set[BiteEdge])
         private def eatIntoMatch[MatchType <: GenericMatch[Element]](
             aMatch: MatchType,
-            groupIdsBySortedBiteEdge: Map[BiteEdge, ParallelMatchesGroupId]
+            groupIdsByBiteEdge: collection.MultiDict[
+              BiteEdge,
+              ParallelMatchesGroupId
+            ]
         ): ParallelMatchesGroupIdTracking[
           Vector[DependentMatchType[MatchType]]
         ] =
@@ -902,7 +906,9 @@ object MatchAnalysis extends StrictLogging:
                 )
 
           case class RecursionState(
-              deferredGroupIdFromPrecedingBite: Option[ParallelMatchesGroupId],
+              deferredGroupIdsFromPrecedingBite: collection.Set[
+                ParallelMatchesGroupId
+              ],
               mealStartOffsetRelativeToMeal: Int,
               biteDepth: Int,
               remainingBiteEdges: Seq[BiteEdge],
@@ -919,9 +925,9 @@ object MatchAnalysis extends StrictLogging:
                     val fragment =
                       fragmentFactory(mealStartOffsetRelativeToMeal, size)
 
-                    assignGroupId(
+                    assignUniqueGroupId(
                       fragment,
-                      deferredGroupIdFromPrecedingBite
+                      deferredGroupIdsFromPrecedingBite
                     ) as Right(fragments.appended(fragment))
                   else State.pure(Right(fragments))
 
@@ -940,38 +946,35 @@ object MatchAnalysis extends StrictLogging:
                         val size =
                           startOffsetRelativeToMeal - mealStartOffsetRelativeToMeal
 
-                        val groupIdFromSucceedingBite =
-                          groupIdsBySortedBiteEdge(biteEdge)
+                        val groupIdsFromSucceedingBite =
+                          groupIdsByBiteEdge.get(biteEdge)
 
-                        val groupId =
-                          deferredGroupIdFromPrecedingBite.fold(ifEmpty =
-                            Some(groupIdFromSucceedingBite)
-                          )(groupIdFromPrecedingBite =>
-                            if groupIdFromPrecedingBite != groupIdFromSucceedingBite
-                            then
-                              // If the preceding and succeeding bite belong to
-                              // different groups, we regard the fragment as
-                              // 'staying put' and assign it a fresh group id.
-                              // We don't reuse the group id of the original
-                              // pairwise match being bitten into because that
-                              // might result in multiple fragments sharing the
-                              // same group id but with intervening bites
-                              // belonging to other groups.
-                              None
-                            else Some(groupIdFromSucceedingBite)
-                          )
+                        val groupIds =
+                          if deferredGroupIdsFromPrecedingBite.isEmpty then
+                            groupIdsFromSucceedingBite
+                          else
+                            // Enforce consistency between the group ids
+                            // supplied by both bites. This allows some margin
+                            // for thinning out multiple group ids from one bite
+                            // if the bite on the other side has just one group
+                            // id, i.e. when one bite comes from an ambiguous
+                            // move and the other from a plain move in parallel
+                            // to one of the ambiguous ones.
+                            deferredGroupIdsFromPrecedingBite.intersect(
+                              groupIdsFromSucceedingBite
+                            )
 
                         val fragment =
                           fragmentFactory(mealStartOffsetRelativeToMeal, size)
 
-                        assignGroupId(fragment, groupId).as(
+                        assignUniqueGroupId(fragment, groupIds).as(
                           fragments.appended(fragment)
                         )
                       else State.pure(fragments)
                   yield Left(
                     this
                       .copy(
-                        deferredGroupIdFromPrecedingBite = None,
+                        deferredGroupIdsFromPrecedingBite = Set.empty,
                         mealStartOffsetRelativeToMeal =
                           startOffsetRelativeToMeal,
                         biteDepth = 1 + biteDepth,
@@ -998,8 +1001,8 @@ object MatchAnalysis extends StrictLogging:
                           // NOTE: nested or overlapping bites to the right
                           // overwrite any prior contribution of a group id to
                           // the *succeeding* context.
-                          deferredGroupIdFromPrecedingBite =
-                            Some(groupIdsBySortedBiteEdge(biteEdge)),
+                          deferredGroupIdsFromPrecedingBite =
+                            groupIdsByBiteEdge.get(biteEdge),
                           mealStartOffsetRelativeToMeal =
                             onePastEndOffsetRelativeToMeal,
                           biteDepth = biteDepth - 1,
@@ -1014,7 +1017,7 @@ object MatchAnalysis extends StrictLogging:
 
           FlatMap[ParallelMatchesGroupIdTracking].tailRecM(
             RecursionState(
-              deferredGroupIdFromPrecedingBite = None,
+              deferredGroupIdsFromPrecedingBite = Set.empty,
               mealStartOffsetRelativeToMeal = 0,
               biteDepth = 0,
               remainingBiteEdges = biteEdges.toSeq,
@@ -1025,18 +1028,18 @@ object MatchAnalysis extends StrictLogging:
 
       end extension
 
-      private def assignGroupId[MatchType <: GenericMatch[Element]](
+      private def assignUniqueGroupId[MatchType <: GenericMatch[Element]](
           fragment: MatchType,
-          groupId: Option[ParallelMatchesGroupId]
+          groupIds: collection.Set[ParallelMatchesGroupId]
       ): ParallelMatchesGroupIdTracking[Unit] =
         State.modify[ParallelMatchesGroupIdsByMatch[Element]] {
           groupIdsByMatch =>
-            val assignedGroupId = groupId.getOrElse(
+            val assignedGroupId = if 1 == groupIds.size then groupIds.head
+            else
               // TODO: trawling linearly through the group ids to find the
               // maximum isn't a great idea. Perhaps there should be a maximum
               // group id too?
               groupIdsByMatch.values.maxOption.fold(ifEmpty = 0)(1 + _)
-            )
 
             groupIdsByMatch + (fragment -> assignedGroupId)
         }
@@ -1383,149 +1386,6 @@ object MatchAnalysis extends StrictLogging:
         else this
         end if
       end purgedOfMatchesWithOverlappingSections
-
-      private def withoutTheseMatches(
-          matches: Iterable[GenericMatch[Element]]
-      ): MatchesAndTheirSections =
-        matches.foldLeft(this) {
-          case (
-                matchesAndTheirSections,
-                allSides @ Match.AllSides(
-                  baseSection,
-                  leftSection,
-                  rightSection
-                )
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, allSides)
-                  .remove(leftSection, allSides)
-                  .remove(rightSection, allSides),
-              baseFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
-                  baseSection
-                ),
-              leftFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
-                  leftSection
-                ),
-              rightFingerprintedInclusionsByPath =
-                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
-                  rightSection
-                ),
-              parallelMatchesGroupIdsByMatch =
-                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
-                  allSides
-                )
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndLeft)
-                  .remove(leftSection, baseAndLeft),
-              parallelMatchesGroupIdsByMatch =
-                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
-                  baseAndLeft
-                )
-            )
-
-          case (
-                matchesAndTheirSections,
-                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              baseSectionsByPath =
-                matchesAndTheirSections.baseExcluding(baseSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(baseSection, baseAndRight)
-                  .remove(rightSection, baseAndRight),
-              parallelMatchesGroupIdsByMatch =
-                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
-                  baseAndRight
-                )
-            )
-
-          case (
-                matchesAndTheirSections,
-                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
-              ) =>
-            matchesAndTheirSections.copy(
-              leftSectionsByPath =
-                matchesAndTheirSections.leftExcluding(leftSection),
-              rightSectionsByPath =
-                matchesAndTheirSections.rightExcluding(rightSection),
-              sectionsAndTheirMatches =
-                matchesAndTheirSections.sectionsAndTheirMatches
-                  .remove(leftSection, leftAndRight)
-                  .remove(rightSection, leftAndRight),
-              parallelMatchesGroupIdsByMatch =
-                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
-                  leftAndRight
-                )
-            )
-        }
-      end withoutTheseMatches
-
-      private def withMatch(
-          aMatch: GenericMatch[Element]
-      ): MatchesAndTheirSections =
-        aMatch match
-          case Match.AllSides(baseSection, leftSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
-              baseFingerprintedInclusionsByPath =
-                knockOutFromBaseFingerprintedInclusions(baseSection),
-              leftFingerprintedInclusionsByPath =
-                knockOutFromLeftFingerprintedInclusions(leftSection),
-              rightFingerprintedInclusionsByPath =
-                knockOutFromRightFingerprintedInclusions(rightSection)
-            )
-          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              leftSectionsByPath = leftIncluding(leftSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
-            )
-          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
-            copy(
-              baseSectionsByPath = baseIncluding(baseSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
-            )
-          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
-            copy(
-              leftSectionsByPath = leftIncluding(leftSection),
-              rightSectionsByPath = rightIncluding(rightSection),
-              sectionsAndTheirMatches =
-                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
-            )
-        end match
-      end withMatch
 
       def reconcileMatches(
           suppressMatchesInvolvingOverlappingSections: Boolean
@@ -1975,6 +1835,107 @@ object MatchAnalysis extends StrictLogging:
         withoutTheseMatches(redundantMatches)
       end withoutRedundantPairwiseMatches
 
+      private def withoutTheseMatches(
+          matches: Iterable[GenericMatch[Element]]
+      ): MatchesAndTheirSections =
+        matches.foldLeft(this) {
+          case (
+                matchesAndTheirSections,
+                allSides @ Match.AllSides(
+                  baseSection,
+                  leftSection,
+                  rightSection
+                )
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, allSides)
+                  .remove(leftSection, allSides)
+                  .remove(rightSection, allSides),
+              baseFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInBaseFingerprintedInclusions(
+                  baseSection
+                ),
+              leftFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInLeftFingerprintedInclusions(
+                  leftSection
+                ),
+              rightFingerprintedInclusionsByPath =
+                matchesAndTheirSections.reinstateInRightFingerprintedInclusions(
+                  rightSection
+                ),
+              parallelMatchesGroupIdsByMatch =
+                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
+                  allSides
+                )
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndLeft)
+                  .remove(leftSection, baseAndLeft),
+              parallelMatchesGroupIdsByMatch =
+                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
+                  baseAndLeft
+                )
+            )
+
+          case (
+                matchesAndTheirSections,
+                baseAndRight @ Match.BaseAndRight(baseSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              baseSectionsByPath =
+                matchesAndTheirSections.baseExcluding(baseSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(baseSection, baseAndRight)
+                  .remove(rightSection, baseAndRight),
+              parallelMatchesGroupIdsByMatch =
+                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
+                  baseAndRight
+                )
+            )
+
+          case (
+                matchesAndTheirSections,
+                leftAndRight @ Match.LeftAndRight(leftSection, rightSection)
+              ) =>
+            matchesAndTheirSections.copy(
+              leftSectionsByPath =
+                matchesAndTheirSections.leftExcluding(leftSection),
+              rightSectionsByPath =
+                matchesAndTheirSections.rightExcluding(rightSection),
+              sectionsAndTheirMatches =
+                matchesAndTheirSections.sectionsAndTheirMatches
+                  .remove(leftSection, leftAndRight)
+                  .remove(rightSection, leftAndRight),
+              parallelMatchesGroupIdsByMatch =
+                matchesAndTheirSections.parallelMatchesGroupIdsByMatch.removed(
+                  leftAndRight
+                )
+            )
+        }
+      end withoutTheseMatches
+
       private def isRedundantPairwiseMatch(aMatch: GenericMatch[Element]) =
         aMatch match
           case Match.BaseAndLeft(baseSection, leftSection) =>
@@ -2193,6 +2154,48 @@ object MatchAnalysis extends StrictLogging:
           pathInclusions = pathInclusions
         )
       end withMatches
+
+      private def withMatch(
+          aMatch: GenericMatch[Element]
+      ): MatchesAndTheirSections =
+        aMatch match
+          case Match.AllSides(baseSection, leftSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch) + (rightSection -> aMatch),
+              baseFingerprintedInclusionsByPath =
+                knockOutFromBaseFingerprintedInclusions(baseSection),
+              leftFingerprintedInclusionsByPath =
+                knockOutFromLeftFingerprintedInclusions(leftSection),
+              rightFingerprintedInclusionsByPath =
+                knockOutFromRightFingerprintedInclusions(rightSection)
+            )
+          case baseAndLeft @ Match.BaseAndLeft(baseSection, leftSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              leftSectionsByPath = leftIncluding(leftSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (leftSection -> aMatch)
+            )
+          case baseAndRight @ Match.BaseAndRight(baseSection, rightSection) =>
+            copy(
+              baseSectionsByPath = baseIncluding(baseSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (baseSection -> aMatch) + (rightSection -> aMatch)
+            )
+          case leftAndRight @ Match.LeftAndRight(leftSection, rightSection) =>
+            copy(
+              leftSectionsByPath = leftIncluding(leftSection),
+              rightSectionsByPath = rightIncluding(rightSection),
+              sectionsAndTheirMatches =
+                sectionsAndTheirMatches + (leftSection -> aMatch) + (rightSection -> aMatch)
+            )
+        end match
+      end withMatch
 
       private def reconciliationPostcondition(): Unit =
         baseSectionsByPath.values.flatMap(_.iterator).foreach { baseSection =>

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -832,18 +832,15 @@ object MatchAnalysis extends StrictLogging:
               parallelMatchesGroupIdsByMatch <- State
                 .get[ParallelMatchesGroupIdsByMatch[Element]]
 
-              groupIdsBySortedBiteEdge = SortedMap.from(bites.flatMap {
+              biteEdgesWithGroupIds = bites.toSeq.flatMap {
                 case (bitingMatch, biteStart, biteEnd) =>
-                  Seq(biteStart, biteEnd)
-                    .map(_ -> parallelMatchesGroupIdsByMatch(bitingMatch))
-              })
-
-              sortedBiteEdges = groupIdsBySortedBiteEdge.keySet
+                  val groupId = parallelMatchesGroupIdsByMatch(bitingMatch)
+                  Seq(biteStart -> groupId, biteEnd -> groupId)
+              }.sortBy(_._1)
 
               fragmentsFromMatch <-
-                sortedBiteEdges.eatIntoMatch(
-                  matchBeingBittenInto,
-                  groupIdsBySortedBiteEdge
+                biteEdgesWithGroupIds.eatIntoMatch(
+                  matchBeingBittenInto
                 )
             yield
               logger.debug(
@@ -857,10 +854,9 @@ object MatchAnalysis extends StrictLogging:
       // There are contracts buried in the implementation that require the bite
       // edges to be sorted in terms of their offsets and not exceed the
       // boundaries of the match's sections.
-      extension (biteEdges: SortedSet[BiteEdge])
+      extension (biteEdgesWithGroupIds: Seq[(BiteEdge, ParallelMatchesGroupId)])
         private def eatIntoMatch[MatchType <: GenericMatch[Element]](
-            aMatch: MatchType,
-            groupIdsBySortedBiteEdge: Map[BiteEdge, ParallelMatchesGroupId]
+            aMatch: MatchType
         ): ParallelMatchesGroupIdTracking[
           Vector[DependentMatchType[MatchType]]
         ] =
@@ -959,7 +955,7 @@ object MatchAnalysis extends StrictLogging:
               deferredGroupIdFromPrecedingBite: Option[ParallelMatchesGroupId],
               mealStartOffsetRelativeToMeal: Int,
               biteDepth: Int,
-              remainingBiteEdges: Seq[BiteEdge],
+              remainingBiteEdges: Seq[(BiteEdge, ParallelMatchesGroupId)],
               fragments: Vector[DependentMatchType[MatchType]]
           ):
             final def biteEdgeStep: ParallelMatchesGroupIdTracking[
@@ -980,7 +976,10 @@ object MatchAnalysis extends StrictLogging:
                   else State.pure(Right(fragments))
 
                 case Seq(
-                      biteEdge @ BiteEdge.Start(startOffsetRelativeToMeal),
+                      (
+                        biteEdge @ BiteEdge.Start(startOffsetRelativeToMeal),
+                        groupIdFromSucceedingBite
+                      ),
                       tail*
                     ) =>
                   require(
@@ -993,9 +992,6 @@ object MatchAnalysis extends StrictLogging:
                       then
                         val size =
                           startOffsetRelativeToMeal - mealStartOffsetRelativeToMeal
-
-                        val groupIdFromSucceedingBite =
-                          groupIdsBySortedBiteEdge(biteEdge)
 
                         val groupId =
                           deferredGroupIdFromPrecedingBite.fold(ifEmpty =
@@ -1035,7 +1031,10 @@ object MatchAnalysis extends StrictLogging:
                   )
 
                 case Seq(
-                      biteEdge @ BiteEdge.End(onePastEndOffsetRelativeToMeal),
+                      (
+                        biteEdge @ BiteEdge.End(onePastEndOffsetRelativeToMeal),
+                        groupIdFromEndingBite
+                      ),
                       tail*
                     ) =>
                   assume(0 < biteDepth)
@@ -1053,7 +1052,7 @@ object MatchAnalysis extends StrictLogging:
                           // overwrite any prior contribution of a group id to
                           // the *succeeding* context.
                           deferredGroupIdFromPrecedingBite =
-                            Some(groupIdsBySortedBiteEdge(biteEdge)),
+                            Some(groupIdFromEndingBite),
                           mealStartOffsetRelativeToMeal =
                             onePastEndOffsetRelativeToMeal,
                           biteDepth = biteDepth - 1,
@@ -1071,7 +1070,7 @@ object MatchAnalysis extends StrictLogging:
               deferredGroupIdFromPrecedingBite = None,
               mealStartOffsetRelativeToMeal = 0,
               biteDepth = 0,
-              remainingBiteEdges = biteEdges.toSeq,
+              remainingBiteEdges = biteEdgesWithGroupIds,
               fragments = Vector.empty
             )
           )(_.biteEdgeStep)

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCode.scala
@@ -73,15 +73,18 @@ object SectionedCode extends StrictLogging:
     val withTinyMatchesIncluded =
       withAllMatchesOfAtLeastTheMinimumWindowSize.withTinyMatches
 
-    // TODO: this also precariously protects some downstream logic in
-    // `reconcileMatches` that assumes that all matches will have a
-    // parallel matches group id. Need to make this more robust.
-    val parallelMatchesOnly = withTinyMatchesIncluded.parallelMatchesOnly
-
     try
-      val matchesAndTheirSections = parallelMatchesOnly.reconcileMatches(
-        suppressMatchesInvolvingOverlappingSections
-      )
+      val withOverlapsReconciled =
+        withTinyMatchesIncluded.reconcileMatchesWithOverlappingSections(
+          suppressMatchesInvolvingOverlappingSections
+        )
+
+      // TODO: this also precariously protects some downstream logic in
+      // `reconcileMatches` that assumes that all matches will have a
+      // parallel matches group id. Need to make this more robust.
+      val parallelMatchesOnly = withOverlapsReconciled.parallelMatchesOnly
+
+      val matchesAndTheirSections = parallelMatchesOnly.reconcileMatches
 
       val sectionsAndTheirMatches =
         matchesAndTheirSections.sectionsAndTheirMatches

--- a/src/test/scala/com/sageserpent/kineticmerge/core/BlockDuplicationAndCondensationTests.scala
+++ b/src/test/scala/com/sageserpent/kineticmerge/core/BlockDuplicationAndCondensationTests.scala
@@ -308,8 +308,7 @@ class BlockDuplicationAndCondensationTests:
   end duplicateBlocksAreMergedOnOneSide
 
   @TestFactory
-  def issue339BugReproductionThwartedPairwiseMatchDueToSmallerOverlappingAllSidesMatches()
-      : DynamicTests =
+  def overlappingBlocksAreSeparatedOnOneSide(): DynamicTests =
     val configuration = Configuration(
       minimumMatchSize = 1,
       thresholdSizeFractionForMatching = 0,
@@ -382,22 +381,29 @@ class BlockDuplicationAndCondensationTests:
 
       assert(
         Vector(
-          Contribution.CommonToBaseAndLeftOnly(baseElements)
+          Contribution.Common(leadingContent),
+          Contribution.Common(overlapContent),
+          Contribution.Common(trailingContent)
         ) == baseContributions
           .map(_.map(_.content))
       )
       assert(
         Vector(
-          Contribution.CommonToBaseAndLeftOnly(baseElements)
+          Contribution.Common(leadingContent),
+          Contribution.Common(overlapContent),
+          Contribution.Common(trailingContent)
         ) == contributionsOnSideWithoutChanges.map(_.map(_.content))
       )
       assert(
         Vector(
-          Contribution.Difference(elementsOnSideWithSeparation)
+          Contribution.Common(leadingContent),
+          Contribution.Common(overlapContent),
+          Contribution.Difference(overlapContent),
+          Contribution.Common(trailingContent)
         ) == contributionsOnSideWithSeparation.map(_.map(_.content))
       )
     }
-  end issue339BugReproductionThwartedPairwiseMatchDueToSmallerOverlappingAllSidesMatches
+  end overlappingBlocksAreSeparatedOnOneSide
 
   @TestFactory
   def aBlockIsTriplicatedOnTwoSides(): DynamicTests =

--- a/src/test/scala/com/sageserpent/kineticmerge/core/SectionedCodeTest.scala
+++ b/src/test/scala/com/sageserpent/kineticmerge/core/SectionedCodeTest.scala
@@ -733,9 +733,7 @@ class SectionedCodeTest:
 
     // This is an even more pathological situation - we have overlapping matches
     // of the same size, one of which is a pairwise match and the other an
-    // all-sides match. This in itself is permitted (but will result in an
-    // admissible downstream exception due to the overlap when
-    // `CodeMotionAnalysis.of` builds up its files from the matches).
+    // all-sides match. This in itself is permitted.
 
     // The twist is when there is another smaller all-sides that is subsumed by
     // the pairwise match but does *not* overlap with the larger all-sides
@@ -797,14 +795,15 @@ class SectionedCodeTest:
     // There only be all-sides matches.
     assert(matches.forall(_.isAnAllSidesMatch))
 
-    // There should be two matches.
-    assert(matches.size == 2)
+    // There should be three matches.
+    assert(matches.size == 3)
 
-    // The contents should be that of the two all-sides matches.
+    // The contents should reflect the breakdown of the overlapping matches.
     assert(
       matches.map(_.content) == Set(
-        bigAllSidesContent,
-        smallAllSidesContent
+        prefix,
+        overlap,
+        suffix
       )
     )
   end eatenPairwiseMatchesMayBeSuppressedByACompetingOverlappingAllSidesMatch
@@ -1120,10 +1119,10 @@ class SectionedCodeTest:
       : Unit =
     // Here, we set up a larger pairwise match and eat into it via four smaller,
     // ambiguous *and* overlapping all-sides matches. The overlapping causes the
-    // collective all-sides matches to eat into all of the content of the
-    // pairwise matches, so apart from the all-sides matches (which are
-    // suppressed later by virtue of overlapping each other), there are no
-    // fragmented pairwise matches left over.
+    // collective all-sides matches to eat into all the content of the pairwise
+    // matches, so apart from the all-sides matches, there are no fragmented
+    // pairwise matches left over. The overlapping all-sides matches then
+    // reconcile to smaller ones.
 
     val configuration = Configuration(
       minimumMatchSize = 2,
@@ -1170,7 +1169,14 @@ class SectionedCodeTest:
         .map(analysis.matchesFor)
         .reduce(_ union _)
 
-    assert(matches.isEmpty)
+    // There should be just all-sides matches.
+    assert(matches.map(_.ordinal).size == 1)
+
+    // There should be eight all-sides matches.
+    assert((matches count {
+      case _: Match.AllSides[Section[Element]] => true
+      case _                                   => false
+    }) == 8)
   end overlappingSmallerAllSidesMatchesCanEatIntoALargerPairwiseMatchWithoutLeavingAnyFragments
 
   @Test
@@ -1247,8 +1253,14 @@ class SectionedCodeTest:
         .map(analysis.matchesFor)
         .reduce(_ union _)
 
-    // There should be just left-right matches.
-    assert(matches.map(_.ordinal).size == 1)
+    // There should be just all-sides and left-right matches.
+    assert(matches.map(_.ordinal).size == 2)
+
+    // There should be four left-right matches.
+    assert((matches count {
+      case _: Match.AllSides[Section[Element]] => true
+      case _                                   => false
+    }) == 4)
 
     // There should be two left-right matches.
     assert((matches count {
@@ -1260,7 +1272,10 @@ class SectionedCodeTest:
     assert(
       matches.map(_.content) == Set(
         Vector(alpha),
-        Vector(beta)
+        Vector(beta),
+        Vector(gamma),
+        Vector(delta),
+        Vector(epsilon)
       )
     )
   end problematicSituation


### PR DESCRIPTION
This change addresses the requirement to fragment overlapping matches so that the remaining parts can still participate in the merge process. Previously, overlapping matches were suppressed entirely.

The fragmentation is achieved by a 'biting' mechanism where overlapping parts are converted into new matches that 'bite' into the original ones, resulting in disjoint fragments. 

Key technical changes:
1.  **Match Slicing**: Added a `slice` extension method to `GenericMatch` to create sub-matches covering specific intervals.
2.  **Overlap Detection**: Implemented `overlappingMatchesWithBiteEdgesAndBitingMatch` which uses the interval tree (`SectionsSeen`) to find non-identity overlaps and calculate the relative offsets for biting.
3.  **Stable Fragmentation Loop**: Refined `purgedOfMatchesWithOverlappingSections` to use a `tailRecM` loop that separates disjoint matches from overlapping ones in each iteration, accumulating the disjoint ones until no overlaps remain.
4.  **De-duplication**: Enhanced `withMatch` to prevent adding duplicate matches, which is critical since mutual overlaps naturally produce identical biting matches.
5.  **Group ID Tracking**: Ensured that new fragments and biting matches are correctly enrolled in or inherit `ParallelMatchesGroupId`s to maintain alignment group tracking.
6.  **Invariant Preservation**: Added explicit calls to `checkInvariant` during the fragmentation steps to verify that section multiplicities and match associations remain correct.

---
*PR created automatically by Jules for task [797283982927062715](https://jules.google.com/task/797283982927062715) started by @sageserpent-open*