### PR TITLE
Fix SectionedCodeTest bug reproduction failures

### DIFF
--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -936,7 +936,9 @@ object MatchAnalysis extends StrictLogging:
                 )
 
           case class RecursionState(
-              deferredMatchesFromPrecedingBite: collection.Set[GenericMatch[Element]],
+              deferredMatchesFromPrecedingBite: collection.Set[GenericMatch[
+                Element
+              ]],
               mealStartOffsetRelativeToMeal: Int,
               biteDepth: Int,
               remainingBiteEdges: Seq[BiteEdge],
@@ -956,14 +958,18 @@ object MatchAnalysis extends StrictLogging:
                       fragmentFactory(mealStartOffsetRelativeToMeal, size)
 
                     for
-                      parallelMatchesGroupIdsByMatch <- State.get[ParallelMatchesGroupIdsByMatch[Element]]
+                      parallelMatchesGroupIdsByMatch <- State
+                        .get[ParallelMatchesGroupIdsByMatch[Element]]
                       deferredGroupIdsFromPrecedingBite =
-                        deferredMatchesFromPrecedingBite.map(parallelMatchesGroupIdsByMatch)
+                        deferredMatchesFromPrecedingBite.map(
+                          parallelMatchesGroupIdsByMatch
+                        )
                       result <- assignUniqueGroupId(
                         fragment,
                         deferredGroupIdsFromPrecedingBite
                       ) as Right(fragments.appended(fragment))
                     yield result
+                    end for
                   else State.pure(Right(fragments))
                   end if
 
@@ -980,7 +986,8 @@ object MatchAnalysis extends StrictLogging:
                     matchesByBiteEdge.get(biteEdge)
 
                   for
-                    parallelMatchesGroupIdsByMatch <- State.get[ParallelMatchesGroupIdsByMatch[Element]]
+                    parallelMatchesGroupIdsByMatch <- State
+                      .get[ParallelMatchesGroupIdsByMatch[Element]]
                     updatedFragments <-
                       if 0 == biteDepth && startOffsetRelativeToMeal > mealStartOffsetRelativeToMeal
                       then
@@ -988,10 +995,14 @@ object MatchAnalysis extends StrictLogging:
                           startOffsetRelativeToMeal - mealStartOffsetRelativeToMeal
 
                         val groupIdsFromSucceedingBite =
-                          matchesFromSucceedingBite.map(parallelMatchesGroupIdsByMatch)
+                          matchesFromSucceedingBite.map(
+                            parallelMatchesGroupIdsByMatch
+                          )
 
                         val deferredGroupIdsFromPrecedingBite =
-                          deferredMatchesFromPrecedingBite.map(parallelMatchesGroupIdsByMatch)
+                          deferredMatchesFromPrecedingBite.map(
+                            parallelMatchesGroupIdsByMatch
+                          )
 
                         val groupIds =
                           if deferredGroupIdsFromPrecedingBite.isEmpty then
@@ -1021,11 +1032,16 @@ object MatchAnalysis extends StrictLogging:
                         mealStartOffsetRelativeToMeal =
                           startOffsetRelativeToMeal,
                         biteDepth =
+                          // NOTE: have to account for the bites originating
+                          // from a *set* of keys into a multi-dictionary. May
+                          // have starting bite edge colliding whereas the
+                          // balancing ending bite edges are distinct.
                           matchesFromSucceedingBite.size + biteDepth,
                         remainingBiteEdges = tail,
                         fragments = updatedFragments
                       )
                   )
+                  end for
 
                 case Seq(
                       biteEdge @ BiteEdge.End(onePastEndOffsetRelativeToMeal),
@@ -1593,6 +1609,685 @@ object MatchAnalysis extends StrictLogging:
           (groupId, group) => groupId -> SortedSet.from(group.keys)
         })
       end groupsOfParallelMatches
+
+      private def startOffsetOnBase(
+          aMatch: GenericMatch[Element]
+      ): Option[Int] =
+        aMatch match
+          case Match.AllSides(baseSection, _, _) =>
+            Some(baseSection.startOffset)
+          case Match.BaseAndLeft(baseSection, _) =>
+            Some(baseSection.startOffset)
+          case Match.BaseAndRight(baseSection, _) =>
+            Some(baseSection.startOffset)
+          case _ => None
+
+      private def startOffsetOnLeft(
+          aMatch: GenericMatch[Element]
+      ): Option[Int] =
+        aMatch match
+          case Match.AllSides(_, leftSection, _) =>
+            Some(leftSection.startOffset)
+          case Match.BaseAndLeft(_, leftSection) =>
+            Some(leftSection.startOffset)
+          case Match.LeftAndRight(leftSection, _) =>
+            Some(leftSection.startOffset)
+          case _ => None
+
+      private def startOffsetOnRight(
+          aMatch: GenericMatch[Element]
+      ): Option[Int] =
+        aMatch match
+          case Match.AllSides(_, _, rightSection) =>
+            Some(rightSection.startOffset)
+          case Match.BaseAndRight(_, rightSection) =>
+            Some(rightSection.startOffset)
+          case Match.LeftAndRight(_, rightSection) =>
+            Some(rightSection.startOffset)
+          case _ => None
+
+      private def reconciliationPostcondition(): Unit =
+        baseSectionsByPath.values.flatMap(_.iterator).foreach { baseSection =>
+          assert(!baseSubsumes(baseSection))
+        }
+        leftSectionsByPath.values.flatMap(_.iterator).foreach { leftSection =>
+          assert(!leftSubsumes(leftSection))
+        }
+        rightSectionsByPath.values.flatMap(_.iterator).foreach { rightSection =>
+          assert(!rightSubsumes(rightSection))
+        }
+
+        // No match should be redundant - i.e. no match should involve sections
+        // that all belong to another match. This goes without saying for
+        // all-sides matches, as any redundancy would imply equivalent
+        // all-sides matches being associated with the same sections - this
+        // isn't allowed by a `MultiDict` instance. The same applies for
+        // pairwise matches of the same kind; pairwise matches of different
+        // kinds can't make each other redundant.
+        // What we have to watch out for are pairwise matches having *both*
+        // sections also belonging to an all-sides match. Note that it *is*
+        // legitimate to have a pairwise match sharing just one section with an
+        // all-sides match; they are just ambiguous matches.
+
+        val matchesBySectionPairs =
+          sectionsAndTheirMatches.values.toSet.foldLeft(
+            MultiDict.empty[(Section[Element], Section[Element]), Match[
+              Section[Element]
+            ]]
+          )((matchesBySectionPairs, aMatch) =>
+            aMatch match
+              case Match.AllSides(baseSection, leftSection, rightSection) =>
+                matchesBySectionPairs + ((
+                  baseSection,
+                  leftSection
+                ) -> aMatch) + ((baseSection, rightSection) -> aMatch) + ((
+                  leftSection,
+                  rightSection
+                ) -> aMatch)
+              case Match.BaseAndLeft(baseSection, leftSection) =>
+                matchesBySectionPairs + ((
+                  baseSection,
+                  leftSection
+                ) -> aMatch)
+              case Match.BaseAndRight(baseSection, rightSection) =>
+                matchesBySectionPairs + ((
+                  baseSection,
+                  rightSection
+                ) -> aMatch)
+              case Match.LeftAndRight(leftSection, rightSection) =>
+                matchesBySectionPairs + ((
+                  leftSection,
+                  rightSection
+                ) -> aMatch)
+          )
+
+        matchesBySectionPairs.keySet.foreach { sectionPair =>
+          val matches = matchesBySectionPairs.get(sectionPair)
+
+          val (allSides, pairwiseMatches) =
+            matches.partition(_.isAnAllSidesMatch)
+
+          if allSides.nonEmpty then
+            assert(
+              pairwiseMatches.isEmpty,
+              s"Found redundancy between pairwise matches: ${pprintCustomised(pairwiseMatches)} and an all-sides match in: ${pprintCustomised(allSides)}."
+            )
+          end if
+        }
+
+        if parallelMatchesGroupIdsByMatch.nonEmpty then
+          assert(
+            parallelMatchesGroupIdsByMatch.keySet == matches,
+            s"If groups of parallel matches have been discovered, they should cover the overall population of matches exactly."
+          )
+
+          parallelMatchesGroupIdsByMatch.toSeq
+            .groupBy(_._2)
+            .values
+            .foreach { group =>
+              val matchesInGroup = group.map(_._1)
+
+              case class SidePerspective(path: Path, startOffset: Int)
+
+              case class MatchSynopsis(
+                  base: Option[SidePerspective],
+                  left: Option[SidePerspective],
+                  right: Option[SidePerspective]
+              )
+
+              object MatchSynopsis:
+                def apply(aMatch: GenericMatch[Element]): MatchSynopsis =
+                  MatchSynopsis(
+                    base = (pathOnBase(aMatch), startOffsetOnBase(aMatch))
+                      .mapN(SidePerspective.apply),
+                    left = (pathOnLeft(aMatch), startOffsetOnLeft(aMatch))
+                      .mapN(SidePerspective.apply),
+                    right = (pathOnRight(aMatch), startOffsetOnRight(aMatch))
+                      .mapN(SidePerspective.apply)
+                  )
+              end MatchSynopsis
+
+              val basePaths = matchesInGroup.flatMap(pathOnBase).toSet
+              assert(
+                basePaths.size <= 1,
+                s"""Base paths for a group of parallel matches should be the same,
+                   |but vary: $basePaths.
+                   |Matches are: ${pprintCustomised(
+                    matchesInGroup.map(MatchSynopsis.apply)
+                  )}""".stripMargin
+              )
+
+              val leftPaths = matchesInGroup.flatMap(pathOnLeft).toSet
+              assert(
+                leftPaths.size <= 1,
+                s"""Left paths for a group of parallel matches should be the same,
+                   |but vary: $leftPaths.
+                   |Matches are: ${pprintCustomised(
+                    matchesInGroup.map(MatchSynopsis.apply)
+                  )}""".stripMargin
+              )
+
+              val rightPaths = matchesInGroup.flatMap(pathOnRight).toSet
+              assert(
+                rightPaths.size <= 1,
+                s"""Right paths for a group of parallel matches should be the same,
+                   |but vary: $rightPaths.
+                   |Matches are: ${pprintCustomised(
+                    matchesInGroup.map(MatchSynopsis.apply)
+                  )}""".stripMargin
+              )
+
+              def checkOrderIsConsistentAcrossSides(
+                  firstSide: String,
+                  secondSide: String,
+                  firstSideStartOffset: GenericMatch[Element] => Option[Int],
+                  secondSideStartOffset: GenericMatch[Element] => Option[Int]
+              ): Unit =
+                extension (matches: Seq[GenericMatch[Element]])
+                  private def sortWhereRelevantBy(
+                      startOffsetOf: GenericMatch[Element] => Option[Int]
+                  ): Seq[GenericMatch[Element]] =
+                    matches
+                      .flatMap(aMatch =>
+                        startOffsetOf(aMatch)
+                          .map(offset => aMatch -> offset)
+                      )
+                      .sortBy(_._2)
+                      .map(_._1)
+
+                end extension
+
+                // NOTE: in the next two bindings, we have to sort first
+                // according to the other side's perspective. This is to avoid
+                // situations where several matches happen to have the same
+                // start offset on one side but different offsets on the other.
+                // As sorting is stable, that could lead to the side with
+                // colliding offsets having the 'wrong' initial order that would
+                // be preserved by the sort. Tip of the hat to Jules for
+                // spotting the pitfall in the first place.
+
+                val matchesOrderedFromFirstSidePerspective =
+                  matchesInGroup
+                    .sortWhereRelevantBy(secondSideStartOffset)
+                    .sortWhereRelevantBy(firstSideStartOffset)
+
+                val matchesOrderedFromSecondSidePerspective =
+                  matchesInGroup
+                    .sortWhereRelevantBy(firstSideStartOffset)
+                    .sortWhereRelevantBy(secondSideStartOffset)
+
+                val commonMatches =
+                  matchesOrderedFromFirstSidePerspective.toSet intersect matchesOrderedFromSecondSidePerspective.toSet
+
+                val commonMatchesOrderedFromFirstSidePerspective =
+                  matchesOrderedFromFirstSidePerspective.filter(
+                    commonMatches.contains
+                  )
+                val commonMatchesOrderedFromSecondSidePerspective =
+                  matchesOrderedFromSecondSidePerspective.filter(
+                    commonMatches.contains
+                  )
+
+                assert(
+                  commonMatchesOrderedFromFirstSidePerspective == commonMatchesOrderedFromSecondSidePerspective,
+                  s"""
+                     |Expected a consistent ordering of matches relevant to the sides $firstSide and $secondSide,
+                     |on the $firstSide they are:
+                     |${pprintCustomised(
+                      commonMatchesOrderedFromFirstSidePerspective.map(
+                        MatchSynopsis.apply
+                      )
+                    )}
+                     |and on the $secondSide they are:
+                     |${pprintCustomised(
+                      commonMatchesOrderedFromSecondSidePerspective.map(
+                        MatchSynopsis.apply
+                      )
+                    )}
+                     |""".stripMargin
+                )
+              end checkOrderIsConsistentAcrossSides
+
+              checkOrderIsConsistentAcrossSides(
+                "base",
+                "left",
+                startOffsetOnBase,
+                startOffsetOnLeft
+              )
+              checkOrderIsConsistentAcrossSides(
+                "base",
+                "right",
+                startOffsetOnBase,
+                startOffsetOnRight
+              )
+              checkOrderIsConsistentAcrossSides(
+                "left",
+                "right",
+                startOffsetOnLeft,
+                startOffsetOnRight
+              )
+            }
+        end if
+      end reconciliationPostcondition
+
+      private def pathOnBase(aMatch: GenericMatch[Element]): Option[Path] =
+        aMatch match
+          case Match.AllSides(baseSection, _, _) =>
+            Some(baseSources.pathFor(baseSection))
+          case Match.BaseAndLeft(baseSection, _) =>
+            Some(baseSources.pathFor(baseSection))
+          case Match.BaseAndRight(baseSection, _) =>
+            Some(baseSources.pathFor(baseSection))
+          case _ => None
+
+      private def pathOnLeft(aMatch: GenericMatch[Element]): Option[Path] =
+        aMatch match
+          case Match.AllSides(_, leftSection, _) =>
+            Some(leftSources.pathFor(leftSection))
+          case Match.BaseAndLeft(_, leftSection) =>
+            Some(leftSources.pathFor(leftSection))
+          case Match.LeftAndRight(leftSection, _) =>
+            Some(leftSources.pathFor(leftSection))
+          case _ => None
+
+      private def pathOnRight(aMatch: GenericMatch[Element]): Option[Path] =
+        aMatch match
+          case Match.AllSides(_, _, rightSection) =>
+            Some(rightSources.pathFor(rightSection))
+          case Match.BaseAndRight(_, rightSection) =>
+            Some(rightSources.pathFor(rightSection))
+          case Match.LeftAndRight(_, rightSection) =>
+            Some(rightSources.pathFor(rightSection))
+          case _ => None
+
+      private def checkInvariant(): Unit =
+        // We expect to tally either two lots of a given pairwise match or three
+        // lots of a given all-sides match; we therefore scale the
+        // raw multiplicities of the section to take this into account.
+        val multiplicityScaleSubdivisibleByTwoOrThree = 6
+
+        val multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch =
+          multiplicityScaleSubdivisibleByTwoOrThree / 3
+
+        val multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch =
+          multiplicityScaleSubdivisibleByTwoOrThree / 2
+
+        val baseSectionMultiplicities = baseSectionsByPath.values
+          .flatMap(_.iterator)
+          .groupBy(identity)
+          .map((section, group) =>
+            section -> multiplicityScaleSubdivisibleByTwoOrThree * group.size
+          )
+
+        val leftSectionMultiplicities = leftSectionsByPath.values
+          .flatMap(_.iterator)
+          .groupBy(identity)
+          .map((section, group) =>
+            section -> multiplicityScaleSubdivisibleByTwoOrThree * group.size
+          )
+
+        val rightSectionMultiplicities = rightSectionsByPath.values
+          .flatMap(_.iterator)
+          .groupBy(identity)
+          .map((section, group) =>
+            section -> multiplicityScaleSubdivisibleByTwoOrThree * group.size
+          )
+
+        val tallyAllSides: Option[Int] => Option[Int] = {
+          case Some(multiplicity) =>
+            // Once we've accounted for the multiplicity, remove the entry.
+            Option.unless(
+              multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch == multiplicity
+            )(
+              multiplicity - multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch
+            )
+          // If we have an occurrence and there is no entry, start a negative
+          // count.
+          case None =>
+            Some(
+              -multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch
+            )
+        }
+
+        val tallyPairwise: Option[Int] => Option[Int] = {
+          case Some(multiplicity) =>
+            // Once we've accounted for the multiplicity, remove the entry.
+            Option.unless(
+              multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch == multiplicity
+            )(
+              multiplicity - multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch
+            )
+          // If we have an occurrence and there is no entry, start a negative
+          // count.
+          case None =>
+            Some(-multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch)
+        }
+
+        val (
+          unbalancedBaseSectionMultiplicities,
+          unbalancedLeftSectionMultiplicities,
+          unbalancedRightSectionMultiplicities
+        ) = sectionsAndTheirMatches.values.foldLeft(
+          (
+            baseSectionMultiplicities,
+            leftSectionMultiplicities,
+            rightSectionMultiplicities
+          )
+        ) {
+          case (
+                (
+                  baseSectionMultiplicities,
+                  leftSectionMultiplicities,
+                  rightSectionMultiplicities
+                ),
+                aMatch
+              ) =>
+            aMatch match
+              case Match.AllSides(
+                    baseSection,
+                    leftSection,
+                    rightSection
+                  ) =>
+                (
+                  baseSectionMultiplicities.updatedWith(baseSection)(
+                    tallyAllSides
+                  ),
+                  leftSectionMultiplicities.updatedWith(leftSection)(
+                    tallyAllSides
+                  ),
+                  rightSectionMultiplicities.updatedWith(rightSection)(
+                    tallyAllSides
+                  )
+                )
+              case Match.BaseAndLeft(
+                    baseSection,
+                    leftSection
+                  ) =>
+                (
+                  baseSectionMultiplicities.updatedWith(baseSection)(
+                    tallyPairwise
+                  ),
+                  leftSectionMultiplicities.updatedWith(leftSection)(
+                    tallyPairwise
+                  ),
+                  rightSectionMultiplicities
+                )
+              case Match.BaseAndRight(
+                    baseSection,
+                    rightSection
+                  ) =>
+                (
+                  baseSectionMultiplicities.updatedWith(baseSection)(
+                    tallyPairwise
+                  ),
+                  leftSectionMultiplicities,
+                  rightSectionMultiplicities.updatedWith(rightSection)(
+                    tallyPairwise
+                  )
+                )
+              case Match.LeftAndRight(
+                    leftSection,
+                    rightSection
+                  ) =>
+                (
+                  baseSectionMultiplicities,
+                  leftSectionMultiplicities.updatedWith(leftSection)(
+                    tallyPairwise
+                  ),
+                  rightSectionMultiplicities.updatedWith(rightSection)(
+                    tallyPairwise
+                  )
+                )
+        }
+
+        assert(
+          unbalancedBaseSectionMultiplicities.isEmpty,
+          s"Found unbalanced base section multiplicities, these are:\n${pprintCustomised(unbalancedBaseSectionMultiplicities)}"
+        )
+        assert(
+          unbalancedLeftSectionMultiplicities.isEmpty,
+          s"Found unbalanced left section multiplicities, these are:\n${pprintCustomised(unbalancedLeftSectionMultiplicities)}"
+        )
+        assert(
+          unbalancedRightSectionMultiplicities.isEmpty,
+          s"Found unbalanced right section multiplicities, these are:\n${pprintCustomised(unbalancedRightSectionMultiplicities)}"
+        )
+      end checkInvariant
+
+      private def pareDownOrSuppressCompletely[MatchType <: GenericMatch[
+        Element
+      ]](
+          aMatch: MatchType
+      ): ParallelMatchesGroupIdTracking[Option[DependentMatchType[MatchType]]] =
+        // NOTE: one thing to watch out is when fragments resulting from
+        // larger pairwise matches being eaten into collide with equivalent
+        // pairwise matches found by fingerprint matching. This can take the
+        // form of the fragments coming first due to larger all-sides matches,
+        // or the pairwise matches from fingerprint matching can be followed
+        // by fragmentation if the all-sides eating into the larger pairwise
+        // matches also come from the same fingerprinting that yielded the
+        // pairwise matching. Intercepting this here addresses both cases. {
+        val result: Option[DependentMatchType[MatchType]] = aMatch match
+          case Match.AllSides(baseSection, leftSection, rightSection) =>
+            val trivialSubsumptionSize = baseSection.size
+
+            val subsumingOnBase =
+              subsumingMatches(
+                sectionsAndTheirMatches
+              )(
+                baseSources,
+                baseSectionsByPath
+              )(
+                baseSection,
+                includeTrivialSubsumption = false
+              )
+
+            val subsumingOnLeft =
+              subsumingMatches(
+                sectionsAndTheirMatches
+              )(
+                leftSources,
+                leftSectionsByPath
+              )(
+                leftSection,
+                includeTrivialSubsumption = false
+              )
+
+            val subsumingOnRight =
+              subsumingMatches(
+                sectionsAndTheirMatches
+              )(
+                rightSources,
+                rightSectionsByPath
+              )(
+                rightSection,
+                includeTrivialSubsumption = false
+              )
+
+            val allSidesSubsumingOnLeft =
+              subsumingOnLeft.filter(_.isAnAllSidesMatch)
+            val allSidesSubsumingOnRight =
+              subsumingOnRight.filter(_.isAnAllSidesMatch)
+            val allSidesSubsumingOnBase =
+              subsumingOnBase.filter(_.isAnAllSidesMatch)
+
+            val subsumedByAnAllSidesMatchOnMoreThanOneSide =
+              (allSidesSubsumingOnLeft intersect allSidesSubsumingOnRight).nonEmpty
+                || (allSidesSubsumingOnBase intersect allSidesSubsumingOnLeft).nonEmpty
+                || (allSidesSubsumingOnBase intersect allSidesSubsumingOnRight).nonEmpty
+
+            if !subsumedByAnAllSidesMatchOnMoreThanOneSide then
+              val subsumedBySomeMatchOnJustTheBase =
+                (subsumingOnBase diff (subsumingOnLeft union subsumingOnRight)).nonEmpty
+              val subsumedBySomeMatchOnJustTheLeft =
+                (subsumingOnLeft diff (subsumingOnBase union subsumingOnRight)).nonEmpty
+              val subsumedBySomeMatchOnJustTheRight =
+                (subsumingOnRight diff (subsumingOnBase union subsumingOnLeft)).nonEmpty
+
+              // NOTE: an all-sides match could be subsumed by *some* match on
+              // just one side for two or three sides; they would be
+              // *different* matches, each doing a one-sided subsumption.
+              (
+                subsumedBySomeMatchOnJustTheBase,
+                subsumedBySomeMatchOnJustTheLeft,
+                subsumedBySomeMatchOnJustTheRight
+              ) match
+                case (false, false, false) =>
+                  Option.unless(
+                    baseSubsumes(baseSection) || leftSubsumes(
+                      leftSection
+                    ) || rightSubsumes(rightSection)
+                  )(aMatch)
+                case (true, false, false) =>
+                  Option.unless(
+                    leftSubsumes(leftSection) || rightSubsumes(
+                      rightSection
+                    )
+                  )(Match.LeftAndRight(leftSection, rightSection))
+                case (false, true, false) =>
+                  Option.unless(
+                    baseSubsumes(baseSection) || rightSubsumes(
+                      rightSection
+                    )
+                  )(Match.BaseAndRight(baseSection, rightSection))
+                case (false, false, true) =>
+                  Option.unless(
+                    baseSubsumes(baseSection) || leftSubsumes(
+                      leftSection
+                    )
+                  )(Match.BaseAndLeft(baseSection, leftSection))
+                case _ => None
+              end match
+            else None
+            end if
+
+          case Match.BaseAndLeft(baseSection, leftSection) =>
+            Option.unless(
+              baseSubsumes(baseSection) || leftSubsumes(
+                leftSection
+              )
+            )(aMatch)
+
+          case Match.BaseAndRight(baseSection, rightSection) =>
+            Option.unless(
+              baseSubsumes(baseSection) || rightSubsumes(
+                rightSection
+              )
+            )(aMatch)
+
+          case Match.LeftAndRight(leftSection, rightSection) =>
+            Option.unless(
+              leftSubsumes(leftSection) || rightSubsumes(
+                rightSection
+              )
+            )(aMatch)
+
+          case _ => None
+
+        result.traverse(paredDownMatch =>
+          propagateGroupId(aMatch, paredDownMatch) as paredDownMatch
+        )
+      end pareDownOrSuppressCompletely
+
+      private def pairwiseMatchesSubsumingOnBothSidesWithBiteEdges(
+          allSides: Match.AllSides[Section[Element]]
+      ): Set[(PairwiseMatch, BiteEdge, BiteEdge)] =
+        val subsumingOnBase =
+          subsumingPairwiseMatchesIncludingTriviallySubsuming(
+            sectionsAndTheirMatches
+          )(
+            baseSources,
+            baseSectionsByPath
+          )(
+            allSides.baseElement
+          )
+        val subsumingOnLeft =
+          subsumingPairwiseMatchesIncludingTriviallySubsuming(
+            sectionsAndTheirMatches
+          )(
+            leftSources,
+            leftSectionsByPath
+          )(
+            allSides.leftElement
+          )
+        val subsumingOnRight =
+          subsumingPairwiseMatchesIncludingTriviallySubsuming(
+            sectionsAndTheirMatches
+          )(
+            rightSources,
+            rightSectionsByPath
+          )(
+            allSides.rightElement
+          )
+
+        // NOTE: we have to be mindful that a pairwise match may have multiple
+        // sites where the same content can be matched by a smaller all-sides
+        // match that is ambiguous. That can lead to the biting all-sides match
+        // being a 'cross-over', where the two sides are misaligned - each side
+        // of the all-sides match refers to a different site in the pairwise
+        // match.
+        // NOTE: the above can also take place when only one of several
+        // potential ambiguous matches isn't suppressed elsewhere - in which
+        // case *no* fragmentation may occur. That leaves the misaligned
+        // all-sides match hanging around with the larger pairwise match still
+        // subsuming it, so it is left to `pareDownOrSuppressCompletely` to sort
+        // that out later on.
+        (subsumingOnBase intersect subsumingOnLeft).flatMap {
+          case subsuming: Match.BaseAndLeft[Section[Element]] =>
+            val offsetRelativeToSubsumingOnBaseSide =
+              allSides.baseElement.startOffset - subsuming.baseElement.startOffset
+            val offsetRelativeToSubsumingOnLeftSide =
+              allSides.leftElement.startOffset - subsuming.leftElement.startOffset
+
+            Option.when(
+              offsetRelativeToSubsumingOnBaseSide == offsetRelativeToSubsumingOnLeftSide
+            )(
+              subsuming,
+              BiteEdge.Start(startOffsetRelativeToMeal =
+                offsetRelativeToSubsumingOnBaseSide
+              ),
+              BiteEdge.End(onePastEndOffsetRelativeToMeal =
+                allSides.baseElement.onePastEndOffset - subsuming.baseElement.startOffset
+              )
+            )
+        } union (subsumingOnBase intersect subsumingOnRight).flatMap {
+          case subsuming: Match.BaseAndRight[Section[Element]] =>
+            val offsetRelativeToSubsumingOnBaseSide =
+              allSides.baseElement.startOffset - subsuming.baseElement.startOffset
+            val offsetRelativeToSubsumingOnRightSide =
+              allSides.rightElement.startOffset - subsuming.rightElement.startOffset
+
+            Option.when(
+              offsetRelativeToSubsumingOnBaseSide == offsetRelativeToSubsumingOnRightSide
+            )(
+              subsuming,
+              BiteEdge.Start(startOffsetRelativeToMeal =
+                offsetRelativeToSubsumingOnBaseSide
+              ),
+              BiteEdge.End(onePastEndOffsetRelativeToMeal =
+                allSides.baseElement.onePastEndOffset - subsuming.baseElement.startOffset
+              )
+            )
+        } union (subsumingOnLeft intersect subsumingOnRight).flatMap {
+          case subsuming: Match.LeftAndRight[Section[Element]] =>
+            val offsetRelativeToSubsumingOnLeftSide =
+              allSides.leftElement.startOffset - subsuming.leftElement.startOffset
+            val offsetRelativeToSubsumingOnRightSide =
+              allSides.rightElement.startOffset - subsuming.rightElement.startOffset
+
+            Option.when(
+              offsetRelativeToSubsumingOnLeftSide == offsetRelativeToSubsumingOnRightSide
+            )(
+              subsuming,
+              BiteEdge.Start(startOffsetRelativeToMeal =
+                offsetRelativeToSubsumingOnLeftSide
+              ),
+              BiteEdge.End(onePastEndOffsetRelativeToMeal =
+                allSides.leftElement.onePastEndOffset - subsuming.leftElement.startOffset
+              )
+            )
+        }
+      end pairwiseMatchesSubsumingOnBothSidesWithBiteEdges
 
       def parallelMatchesOnly: MatchesAndTheirSections =
         // PLAN:
@@ -2323,685 +3018,6 @@ object MatchAnalysis extends StrictLogging:
         reconciled
 
       end reconcileOverlappingMatches
-
-      private def startOffsetOnBase(
-          aMatch: GenericMatch[Element]
-      ): Option[Int] =
-        aMatch match
-          case Match.AllSides(baseSection, _, _) =>
-            Some(baseSection.startOffset)
-          case Match.BaseAndLeft(baseSection, _) =>
-            Some(baseSection.startOffset)
-          case Match.BaseAndRight(baseSection, _) =>
-            Some(baseSection.startOffset)
-          case _ => None
-
-      private def startOffsetOnLeft(
-          aMatch: GenericMatch[Element]
-      ): Option[Int] =
-        aMatch match
-          case Match.AllSides(_, leftSection, _) =>
-            Some(leftSection.startOffset)
-          case Match.BaseAndLeft(_, leftSection) =>
-            Some(leftSection.startOffset)
-          case Match.LeftAndRight(leftSection, _) =>
-            Some(leftSection.startOffset)
-          case _ => None
-
-      private def startOffsetOnRight(
-          aMatch: GenericMatch[Element]
-      ): Option[Int] =
-        aMatch match
-          case Match.AllSides(_, _, rightSection) =>
-            Some(rightSection.startOffset)
-          case Match.BaseAndRight(_, rightSection) =>
-            Some(rightSection.startOffset)
-          case Match.LeftAndRight(_, rightSection) =>
-            Some(rightSection.startOffset)
-          case _ => None
-
-      private def reconciliationPostcondition(): Unit =
-        baseSectionsByPath.values.flatMap(_.iterator).foreach { baseSection =>
-          assert(!baseSubsumes(baseSection))
-        }
-        leftSectionsByPath.values.flatMap(_.iterator).foreach { leftSection =>
-          assert(!leftSubsumes(leftSection))
-        }
-        rightSectionsByPath.values.flatMap(_.iterator).foreach { rightSection =>
-          assert(!rightSubsumes(rightSection))
-        }
-
-        // No match should be redundant - i.e. no match should involve sections
-        // that all belong to another match. This goes without saying for
-        // all-sides matches, as any redundancy would imply equivalent
-        // all-sides matches being associated with the same sections - this
-        // isn't allowed by a `MultiDict` instance. The same applies for
-        // pairwise matches of the same kind; pairwise matches of different
-        // kinds can't make each other redundant.
-        // What we have to watch out for are pairwise matches having *both*
-        // sections also belonging to an all-sides match. Note that it *is*
-        // legitimate to have a pairwise match sharing just one section with an
-        // all-sides match; they are just ambiguous matches.
-
-        val matchesBySectionPairs =
-          sectionsAndTheirMatches.values.toSet.foldLeft(
-            MultiDict.empty[(Section[Element], Section[Element]), Match[
-              Section[Element]
-            ]]
-          )((matchesBySectionPairs, aMatch) =>
-            aMatch match
-              case Match.AllSides(baseSection, leftSection, rightSection) =>
-                matchesBySectionPairs + ((
-                  baseSection,
-                  leftSection
-                ) -> aMatch) + ((baseSection, rightSection) -> aMatch) + ((
-                  leftSection,
-                  rightSection
-                ) -> aMatch)
-              case Match.BaseAndLeft(baseSection, leftSection) =>
-                matchesBySectionPairs + ((
-                  baseSection,
-                  leftSection
-                ) -> aMatch)
-              case Match.BaseAndRight(baseSection, rightSection) =>
-                matchesBySectionPairs + ((
-                  baseSection,
-                  rightSection
-                ) -> aMatch)
-              case Match.LeftAndRight(leftSection, rightSection) =>
-                matchesBySectionPairs + ((
-                  leftSection,
-                  rightSection
-                ) -> aMatch)
-          )
-
-        matchesBySectionPairs.keySet.foreach { sectionPair =>
-          val matches = matchesBySectionPairs.get(sectionPair)
-
-          val (allSides, pairwiseMatches) =
-            matches.partition(_.isAnAllSidesMatch)
-
-          if allSides.nonEmpty then
-            assert(
-              pairwiseMatches.isEmpty,
-              s"Found redundancy between pairwise matches: ${pprintCustomised(pairwiseMatches)} and an all-sides match in: ${pprintCustomised(allSides)}."
-            )
-          end if
-        }
-
-        if parallelMatchesGroupIdsByMatch.nonEmpty then
-          assert(
-            parallelMatchesGroupIdsByMatch.keySet == matches,
-            s"If groups of parallel matches have been discovered, they should cover the overall population of matches exactly."
-          )
-
-          parallelMatchesGroupIdsByMatch.toSeq
-            .groupBy(_._2)
-            .values
-            .foreach { group =>
-              val matchesInGroup = group.map(_._1)
-
-              case class SidePerspective(path: Path, startOffset: Int)
-
-              case class MatchSynopsis(
-                  base: Option[SidePerspective],
-                  left: Option[SidePerspective],
-                  right: Option[SidePerspective]
-              )
-
-              object MatchSynopsis:
-                def apply(aMatch: GenericMatch[Element]): MatchSynopsis =
-                  MatchSynopsis(
-                    base = (pathOnBase(aMatch), startOffsetOnBase(aMatch))
-                      .mapN(SidePerspective.apply),
-                    left = (pathOnLeft(aMatch), startOffsetOnLeft(aMatch))
-                      .mapN(SidePerspective.apply),
-                    right = (pathOnRight(aMatch), startOffsetOnRight(aMatch))
-                      .mapN(SidePerspective.apply)
-                  )
-              end MatchSynopsis
-
-              val basePaths = matchesInGroup.flatMap(pathOnBase).toSet
-              assert(
-                basePaths.size <= 1,
-                s"""Base paths for a group of parallel matches should be the same,
-                   |but vary: $basePaths.
-                   |Matches are: ${pprintCustomised(
-                    matchesInGroup.map(MatchSynopsis.apply)
-                  )}""".stripMargin
-              )
-
-              val leftPaths = matchesInGroup.flatMap(pathOnLeft).toSet
-              assert(
-                leftPaths.size <= 1,
-                s"""Left paths for a group of parallel matches should be the same,
-                   |but vary: $leftPaths.
-                   |Matches are: ${pprintCustomised(
-                    matchesInGroup.map(MatchSynopsis.apply)
-                  )}""".stripMargin
-              )
-
-              val rightPaths = matchesInGroup.flatMap(pathOnRight).toSet
-              assert(
-                rightPaths.size <= 1,
-                s"""Right paths for a group of parallel matches should be the same,
-                   |but vary: $rightPaths.
-                   |Matches are: ${pprintCustomised(
-                    matchesInGroup.map(MatchSynopsis.apply)
-                  )}""".stripMargin
-              )
-
-              def checkOrderIsConsistentAcrossSides(
-                  firstSide: String,
-                  secondSide: String,
-                  firstSideStartOffset: GenericMatch[Element] => Option[Int],
-                  secondSideStartOffset: GenericMatch[Element] => Option[Int]
-              ): Unit =
-                extension (matches: Seq[GenericMatch[Element]])
-                  private def sortWhereRelevantBy(
-                      startOffsetOf: GenericMatch[Element] => Option[Int]
-                  ): Seq[GenericMatch[Element]] =
-                    matches
-                      .flatMap(aMatch =>
-                        startOffsetOf(aMatch)
-                          .map(offset => aMatch -> offset)
-                      )
-                      .sortBy(_._2)
-                      .map(_._1)
-
-                end extension
-
-                // NOTE: in the next two bindings, we have to sort first
-                // according to the other side's perspective. This is to avoid
-                // situations where several matches happen to have the same
-                // start offset on one side but different offsets on the other.
-                // As sorting is stable, that could lead to the side with
-                // colliding offsets having the 'wrong' initial order that would
-                // be preserved by the sort. Tip of the hat to Jules for
-                // spotting the pitfall in the first place.
-
-                val matchesOrderedFromFirstSidePerspective =
-                  matchesInGroup
-                    .sortWhereRelevantBy(secondSideStartOffset)
-                    .sortWhereRelevantBy(firstSideStartOffset)
-
-                val matchesOrderedFromSecondSidePerspective =
-                  matchesInGroup
-                    .sortWhereRelevantBy(firstSideStartOffset)
-                    .sortWhereRelevantBy(secondSideStartOffset)
-
-                val commonMatches =
-                  matchesOrderedFromFirstSidePerspective.toSet intersect matchesOrderedFromSecondSidePerspective.toSet
-
-                val commonMatchesOrderedFromFirstSidePerspective =
-                  matchesOrderedFromFirstSidePerspective.filter(
-                    commonMatches.contains
-                  )
-                val commonMatchesOrderedFromSecondSidePerspective =
-                  matchesOrderedFromSecondSidePerspective.filter(
-                    commonMatches.contains
-                  )
-
-                assert(
-                  commonMatchesOrderedFromFirstSidePerspective == commonMatchesOrderedFromSecondSidePerspective,
-                  s"""
-                     |Expected a consistent ordering of matches relevant to the sides $firstSide and $secondSide,
-                     |on the $firstSide they are:
-                     |${pprintCustomised(
-                      commonMatchesOrderedFromFirstSidePerspective.map(
-                        MatchSynopsis.apply
-                      )
-                    )}
-                     |and on the $secondSide they are:
-                     |${pprintCustomised(
-                      commonMatchesOrderedFromSecondSidePerspective.map(
-                        MatchSynopsis.apply
-                      )
-                    )}
-                     |""".stripMargin
-                )
-              end checkOrderIsConsistentAcrossSides
-
-              checkOrderIsConsistentAcrossSides(
-                "base",
-                "left",
-                startOffsetOnBase,
-                startOffsetOnLeft
-              )
-              checkOrderIsConsistentAcrossSides(
-                "base",
-                "right",
-                startOffsetOnBase,
-                startOffsetOnRight
-              )
-              checkOrderIsConsistentAcrossSides(
-                "left",
-                "right",
-                startOffsetOnLeft,
-                startOffsetOnRight
-              )
-            }
-        end if
-      end reconciliationPostcondition
-
-      private def pathOnBase(aMatch: GenericMatch[Element]): Option[Path] =
-        aMatch match
-          case Match.AllSides(baseSection, _, _) =>
-            Some(baseSources.pathFor(baseSection))
-          case Match.BaseAndLeft(baseSection, _) =>
-            Some(baseSources.pathFor(baseSection))
-          case Match.BaseAndRight(baseSection, _) =>
-            Some(baseSources.pathFor(baseSection))
-          case _ => None
-
-      private def pathOnLeft(aMatch: GenericMatch[Element]): Option[Path] =
-        aMatch match
-          case Match.AllSides(_, leftSection, _) =>
-            Some(leftSources.pathFor(leftSection))
-          case Match.BaseAndLeft(_, leftSection) =>
-            Some(leftSources.pathFor(leftSection))
-          case Match.LeftAndRight(leftSection, _) =>
-            Some(leftSources.pathFor(leftSection))
-          case _ => None
-
-      private def pathOnRight(aMatch: GenericMatch[Element]): Option[Path] =
-        aMatch match
-          case Match.AllSides(_, _, rightSection) =>
-            Some(rightSources.pathFor(rightSection))
-          case Match.BaseAndRight(_, rightSection) =>
-            Some(rightSources.pathFor(rightSection))
-          case Match.LeftAndRight(_, rightSection) =>
-            Some(rightSources.pathFor(rightSection))
-          case _ => None
-
-      private def checkInvariant(): Unit =
-        // We expect to tally either two lots of a given pairwise match or three
-        // lots of a given all-sides match; we therefore scale the
-        // raw multiplicities of the section to take this into account.
-        val multiplicityScaleSubdivisibleByTwoOrThree = 6
-
-        val multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch =
-          multiplicityScaleSubdivisibleByTwoOrThree / 3
-
-        val multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch =
-          multiplicityScaleSubdivisibleByTwoOrThree / 2
-
-        val baseSectionMultiplicities = baseSectionsByPath.values
-          .flatMap(_.iterator)
-          .groupBy(identity)
-          .map((section, group) =>
-            section -> multiplicityScaleSubdivisibleByTwoOrThree * group.size
-          )
-
-        val leftSectionMultiplicities = leftSectionsByPath.values
-          .flatMap(_.iterator)
-          .groupBy(identity)
-          .map((section, group) =>
-            section -> multiplicityScaleSubdivisibleByTwoOrThree * group.size
-          )
-
-        val rightSectionMultiplicities = rightSectionsByPath.values
-          .flatMap(_.iterator)
-          .groupBy(identity)
-          .map((section, group) =>
-            section -> multiplicityScaleSubdivisibleByTwoOrThree * group.size
-          )
-
-        val tallyAllSides: Option[Int] => Option[Int] = {
-          case Some(multiplicity) =>
-            // Once we've accounted for the multiplicity, remove the entry.
-            Option.unless(
-              multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch == multiplicity
-            )(
-              multiplicity - multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch
-            )
-          // If we have an occurrence and there is no entry, start a negative
-          // count.
-          case None =>
-            Some(
-              -multiplicityScaleDividedIntoAThirdForEachSideOfAnAllSidesMatch
-            )
-        }
-
-        val tallyPairwise: Option[Int] => Option[Int] = {
-          case Some(multiplicity) =>
-            // Once we've accounted for the multiplicity, remove the entry.
-            Option.unless(
-              multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch == multiplicity
-            )(
-              multiplicity - multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch
-            )
-          // If we have an occurrence and there is no entry, start a negative
-          // count.
-          case None =>
-            Some(-multiplicityScaleDividedIntoAHalfForEachSideOfAPairwiseMatch)
-        }
-
-        val (
-          unbalancedBaseSectionMultiplicities,
-          unbalancedLeftSectionMultiplicities,
-          unbalancedRightSectionMultiplicities
-        ) = sectionsAndTheirMatches.values.foldLeft(
-          (
-            baseSectionMultiplicities,
-            leftSectionMultiplicities,
-            rightSectionMultiplicities
-          )
-        ) {
-          case (
-                (
-                  baseSectionMultiplicities,
-                  leftSectionMultiplicities,
-                  rightSectionMultiplicities
-                ),
-                aMatch
-              ) =>
-            aMatch match
-              case Match.AllSides(
-                    baseSection,
-                    leftSection,
-                    rightSection
-                  ) =>
-                (
-                  baseSectionMultiplicities.updatedWith(baseSection)(
-                    tallyAllSides
-                  ),
-                  leftSectionMultiplicities.updatedWith(leftSection)(
-                    tallyAllSides
-                  ),
-                  rightSectionMultiplicities.updatedWith(rightSection)(
-                    tallyAllSides
-                  )
-                )
-              case Match.BaseAndLeft(
-                    baseSection,
-                    leftSection
-                  ) =>
-                (
-                  baseSectionMultiplicities.updatedWith(baseSection)(
-                    tallyPairwise
-                  ),
-                  leftSectionMultiplicities.updatedWith(leftSection)(
-                    tallyPairwise
-                  ),
-                  rightSectionMultiplicities
-                )
-              case Match.BaseAndRight(
-                    baseSection,
-                    rightSection
-                  ) =>
-                (
-                  baseSectionMultiplicities.updatedWith(baseSection)(
-                    tallyPairwise
-                  ),
-                  leftSectionMultiplicities,
-                  rightSectionMultiplicities.updatedWith(rightSection)(
-                    tallyPairwise
-                  )
-                )
-              case Match.LeftAndRight(
-                    leftSection,
-                    rightSection
-                  ) =>
-                (
-                  baseSectionMultiplicities,
-                  leftSectionMultiplicities.updatedWith(leftSection)(
-                    tallyPairwise
-                  ),
-                  rightSectionMultiplicities.updatedWith(rightSection)(
-                    tallyPairwise
-                  )
-                )
-        }
-
-        assert(
-          unbalancedBaseSectionMultiplicities.isEmpty,
-          s"Found unbalanced base section multiplicities, these are:\n${pprintCustomised(unbalancedBaseSectionMultiplicities)}"
-        )
-        assert(
-          unbalancedLeftSectionMultiplicities.isEmpty,
-          s"Found unbalanced left section multiplicities, these are:\n${pprintCustomised(unbalancedLeftSectionMultiplicities)}"
-        )
-        assert(
-          unbalancedRightSectionMultiplicities.isEmpty,
-          s"Found unbalanced right section multiplicities, these are:\n${pprintCustomised(unbalancedRightSectionMultiplicities)}"
-        )
-      end checkInvariant
-
-      private def pareDownOrSuppressCompletely[MatchType <: GenericMatch[
-        Element
-      ]](
-          aMatch: MatchType
-      ): ParallelMatchesGroupIdTracking[Option[DependentMatchType[MatchType]]] =
-        // NOTE: one thing to watch out is when fragments resulting from
-        // larger pairwise matches being eaten into collide with equivalent
-        // pairwise matches found by fingerprint matching. This can take the
-        // form of the fragments coming first due to larger all-sides matches,
-        // or the pairwise matches from fingerprint matching can be followed
-        // by fragmentation if the all-sides eating into the larger pairwise
-        // matches also come from the same fingerprinting that yielded the
-        // pairwise matching. Intercepting this here addresses both cases. {
-        val result: Option[DependentMatchType[MatchType]] = aMatch match
-          case Match.AllSides(baseSection, leftSection, rightSection) =>
-            val trivialSubsumptionSize = baseSection.size
-
-            val subsumingOnBase =
-              subsumingMatches(
-                sectionsAndTheirMatches
-              )(
-                baseSources,
-                baseSectionsByPath
-              )(
-                baseSection,
-                includeTrivialSubsumption = false
-              )
-
-            val subsumingOnLeft =
-              subsumingMatches(
-                sectionsAndTheirMatches
-              )(
-                leftSources,
-                leftSectionsByPath
-              )(
-                leftSection,
-                includeTrivialSubsumption = false
-              )
-
-            val subsumingOnRight =
-              subsumingMatches(
-                sectionsAndTheirMatches
-              )(
-                rightSources,
-                rightSectionsByPath
-              )(
-                rightSection,
-                includeTrivialSubsumption = false
-              )
-
-            val allSidesSubsumingOnLeft =
-              subsumingOnLeft.filter(_.isAnAllSidesMatch)
-            val allSidesSubsumingOnRight =
-              subsumingOnRight.filter(_.isAnAllSidesMatch)
-            val allSidesSubsumingOnBase =
-              subsumingOnBase.filter(_.isAnAllSidesMatch)
-
-            val subsumedByAnAllSidesMatchOnMoreThanOneSide =
-              (allSidesSubsumingOnLeft intersect allSidesSubsumingOnRight).nonEmpty
-                || (allSidesSubsumingOnBase intersect allSidesSubsumingOnLeft).nonEmpty
-                || (allSidesSubsumingOnBase intersect allSidesSubsumingOnRight).nonEmpty
-
-            if !subsumedByAnAllSidesMatchOnMoreThanOneSide then
-              val subsumedBySomeMatchOnJustTheBase =
-                (subsumingOnBase diff (subsumingOnLeft union subsumingOnRight)).nonEmpty
-              val subsumedBySomeMatchOnJustTheLeft =
-                (subsumingOnLeft diff (subsumingOnBase union subsumingOnRight)).nonEmpty
-              val subsumedBySomeMatchOnJustTheRight =
-                (subsumingOnRight diff (subsumingOnBase union subsumingOnLeft)).nonEmpty
-
-              // NOTE: an all-sides match could be subsumed by *some* match on
-              // just one side for two or three sides; they would be
-              // *different* matches, each doing a one-sided subsumption.
-              (
-                subsumedBySomeMatchOnJustTheBase,
-                subsumedBySomeMatchOnJustTheLeft,
-                subsumedBySomeMatchOnJustTheRight
-              ) match
-                case (false, false, false) =>
-                  Option.unless(
-                    baseSubsumes(baseSection) || leftSubsumes(
-                      leftSection
-                    ) || rightSubsumes(rightSection)
-                  )(aMatch)
-                case (true, false, false) =>
-                  Option.unless(
-                    leftSubsumes(leftSection) || rightSubsumes(
-                      rightSection
-                    )
-                  )(Match.LeftAndRight(leftSection, rightSection))
-                case (false, true, false) =>
-                  Option.unless(
-                    baseSubsumes(baseSection) || rightSubsumes(
-                      rightSection
-                    )
-                  )(Match.BaseAndRight(baseSection, rightSection))
-                case (false, false, true) =>
-                  Option.unless(
-                    baseSubsumes(baseSection) || leftSubsumes(
-                      leftSection
-                    )
-                  )(Match.BaseAndLeft(baseSection, leftSection))
-                case _ => None
-              end match
-            else None
-            end if
-
-          case Match.BaseAndLeft(baseSection, leftSection) =>
-            Option.unless(
-              baseSubsumes(baseSection) || leftSubsumes(
-                leftSection
-              )
-            )(aMatch)
-
-          case Match.BaseAndRight(baseSection, rightSection) =>
-            Option.unless(
-              baseSubsumes(baseSection) || rightSubsumes(
-                rightSection
-              )
-            )(aMatch)
-
-          case Match.LeftAndRight(leftSection, rightSection) =>
-            Option.unless(
-              leftSubsumes(leftSection) || rightSubsumes(
-                rightSection
-              )
-            )(aMatch)
-
-          case _ => None
-
-        result.traverse(paredDownMatch =>
-          propagateGroupId(aMatch, paredDownMatch) as paredDownMatch
-        )
-      end pareDownOrSuppressCompletely
-
-      private def pairwiseMatchesSubsumingOnBothSidesWithBiteEdges(
-          allSides: Match.AllSides[Section[Element]]
-      ): Set[(PairwiseMatch, BiteEdge, BiteEdge)] =
-        val subsumingOnBase =
-          subsumingPairwiseMatchesIncludingTriviallySubsuming(
-            sectionsAndTheirMatches
-          )(
-            baseSources,
-            baseSectionsByPath
-          )(
-            allSides.baseElement
-          )
-        val subsumingOnLeft =
-          subsumingPairwiseMatchesIncludingTriviallySubsuming(
-            sectionsAndTheirMatches
-          )(
-            leftSources,
-            leftSectionsByPath
-          )(
-            allSides.leftElement
-          )
-        val subsumingOnRight =
-          subsumingPairwiseMatchesIncludingTriviallySubsuming(
-            sectionsAndTheirMatches
-          )(
-            rightSources,
-            rightSectionsByPath
-          )(
-            allSides.rightElement
-          )
-
-        // NOTE: we have to be mindful that a pairwise match may have multiple
-        // sites where the same content can be matched by a smaller all-sides
-        // match that is ambiguous. That can lead to the biting all-sides match
-        // being a 'cross-over', where the two sides are misaligned - each side
-        // of the all-sides match refers to a different site in the pairwise
-        // match.
-        // NOTE: the above can also take place when only one of several
-        // potential ambiguous matches isn't suppressed elsewhere - in which
-        // case *no* fragmentation may occur. That leaves the misaligned
-        // all-sides match hanging around with the larger pairwise match still
-        // subsuming it, so it is left to `pareDownOrSuppressCompletely` to sort
-        // that out later on.
-        (subsumingOnBase intersect subsumingOnLeft).flatMap {
-          case subsuming: Match.BaseAndLeft[Section[Element]] =>
-            val offsetRelativeToSubsumingOnBaseSide =
-              allSides.baseElement.startOffset - subsuming.baseElement.startOffset
-            val offsetRelativeToSubsumingOnLeftSide =
-              allSides.leftElement.startOffset - subsuming.leftElement.startOffset
-
-            Option.when(
-              offsetRelativeToSubsumingOnBaseSide == offsetRelativeToSubsumingOnLeftSide
-            )(
-              subsuming,
-              BiteEdge.Start(startOffsetRelativeToMeal =
-                offsetRelativeToSubsumingOnBaseSide
-              ),
-              BiteEdge.End(onePastEndOffsetRelativeToMeal =
-                allSides.baseElement.onePastEndOffset - subsuming.baseElement.startOffset
-              )
-            )
-        } union (subsumingOnBase intersect subsumingOnRight).flatMap {
-          case subsuming: Match.BaseAndRight[Section[Element]] =>
-            val offsetRelativeToSubsumingOnBaseSide =
-              allSides.baseElement.startOffset - subsuming.baseElement.startOffset
-            val offsetRelativeToSubsumingOnRightSide =
-              allSides.rightElement.startOffset - subsuming.rightElement.startOffset
-
-            Option.when(
-              offsetRelativeToSubsumingOnBaseSide == offsetRelativeToSubsumingOnRightSide
-            )(
-              subsuming,
-              BiteEdge.Start(startOffsetRelativeToMeal =
-                offsetRelativeToSubsumingOnBaseSide
-              ),
-              BiteEdge.End(onePastEndOffsetRelativeToMeal =
-                allSides.baseElement.onePastEndOffset - subsuming.baseElement.startOffset
-              )
-            )
-        } union (subsumingOnLeft intersect subsumingOnRight).flatMap {
-          case subsuming: Match.LeftAndRight[Section[Element]] =>
-            val offsetRelativeToSubsumingOnLeftSide =
-              allSides.leftElement.startOffset - subsuming.leftElement.startOffset
-            val offsetRelativeToSubsumingOnRightSide =
-              allSides.rightElement.startOffset - subsuming.rightElement.startOffset
-
-            Option.when(
-              offsetRelativeToSubsumingOnLeftSide == offsetRelativeToSubsumingOnRightSide
-            )(
-              subsuming,
-              BiteEdge.Start(startOffsetRelativeToMeal =
-                offsetRelativeToSubsumingOnLeftSide
-              ),
-              BiteEdge.End(onePastEndOffsetRelativeToMeal =
-                allSides.leftElement.onePastEndOffset - subsuming.leftElement.startOffset
-              )
-            )
-        }
-      end pairwiseMatchesSubsumingOnBothSidesWithBiteEdges
 
       private def hiveOffNonOverlappedMatchFrom(
           aMatch: GenericMatch[Element]

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -811,18 +811,17 @@ object MatchAnalysis extends StrictLogging:
               parallelMatchesGroupIdsByMatch <- State
                 .get[ParallelMatchesGroupIdsByMatch[Element]]
 
-              groupIdsBySortedBiteEdge = SortedMultiDict.from(bites.flatMap {
+              matchesBySortedBiteEdge = SortedMultiDict.from(bites.flatMap {
                 case (bitingMatch, biteStart, biteEnd) =>
-                  Seq(biteStart, biteEnd)
-                    .map(_ -> parallelMatchesGroupIdsByMatch(bitingMatch))
+                  Seq(biteStart -> bitingMatch, biteEnd -> bitingMatch)
               })
 
-              sortedBiteEdges = groupIdsBySortedBiteEdge.keySet
+              sortedBiteEdges = matchesBySortedBiteEdge.keySet
 
               fragmentsFromMatch <-
                 sortedBiteEdges.eatIntoMatch(
                   matchBeingBittenInto,
-                  groupIdsBySortedBiteEdge
+                  matchesBySortedBiteEdge
                 )
             yield
               logger.debug(
@@ -839,9 +838,9 @@ object MatchAnalysis extends StrictLogging:
       extension (biteEdges: collection.Set[BiteEdge])
         private def eatIntoMatch[MatchType <: GenericMatch[Element]](
             aMatch: MatchType,
-            groupIdsByBiteEdge: collection.MultiDict[
+            matchesByBiteEdge: collection.MultiDict[
               BiteEdge,
-              ParallelMatchesGroupId
+              GenericMatch[Element]
             ]
         ): ParallelMatchesGroupIdTracking[
           Vector[DependentMatchType[MatchType]]
@@ -937,9 +936,7 @@ object MatchAnalysis extends StrictLogging:
                 )
 
           case class RecursionState(
-              deferredGroupIdsFromPrecedingBite: collection.Set[
-                ParallelMatchesGroupId
-              ],
+              deferredMatchesFromPrecedingBite: collection.Set[GenericMatch[Element]],
               mealStartOffsetRelativeToMeal: Int,
               biteDepth: Int,
               remainingBiteEdges: Seq[BiteEdge],
@@ -948,121 +945,115 @@ object MatchAnalysis extends StrictLogging:
             final def biteEdgeStep: ParallelMatchesGroupIdTracking[
               Either[RecursionState, Vector[DependentMatchType[MatchType]]]
             ] =
-              remainingBiteEdges match
-                case Seq() =>
-                  require(0 == biteDepth)
+              State.get[ParallelMatchesGroupIdsByMatch[Element]].flatMap { parallelMatchesGroupIdsByMatch =>
+                remainingBiteEdges match
+                  case Seq() =>
+                    require(0 == biteDepth)
 
-                  if sectionSize > mealStartOffsetRelativeToMeal then
-                    val size = sectionSize - mealStartOffsetRelativeToMeal
+                    if sectionSize > mealStartOffsetRelativeToMeal then
+                      val size = sectionSize - mealStartOffsetRelativeToMeal
 
-                    val fragment =
-                      fragmentFactory(mealStartOffsetRelativeToMeal, size)
+                      val fragment =
+                        fragmentFactory(mealStartOffsetRelativeToMeal, size)
 
-                    assignUniqueGroupId(
-                      fragment,
-                      deferredGroupIdsFromPrecedingBite
-                    ) as Right(fragments.appended(fragment))
-                  else State.pure(Right(fragments))
-                  end if
+                      val deferredGroupIdsFromPrecedingBite =
+                        deferredMatchesFromPrecedingBite.map(parallelMatchesGroupIdsByMatch)
 
-                case Seq(
-                      biteEdge @ BiteEdge.Start(startOffsetRelativeToMeal),
-                      tail*
-                    ) =>
-                  require(
-                    startOffsetRelativeToMeal >= mealStartOffsetRelativeToMeal
-                  )
-                  require(sectionSize > startOffsetRelativeToMeal)
+                      assignUniqueGroupId(
+                        fragment,
+                        deferredGroupIdsFromPrecedingBite
+                      ).map(_ => Right(fragments.appended(fragment)))
+                    else State.pure(Right(fragments))
+                    end if
 
-                  val groupIdsFromSucceedingBite =
-                    groupIdsByBiteEdge.get(biteEdge)
-
-                  for updatedFragments <-
-                      if 0 == biteDepth && startOffsetRelativeToMeal > mealStartOffsetRelativeToMeal
-                      then
-                        val size =
-                          startOffsetRelativeToMeal - mealStartOffsetRelativeToMeal
-
-                        val groupIds =
-                          if deferredGroupIdsFromPrecedingBite.isEmpty then
-                            groupIdsFromSucceedingBite
-                          else
-                            // Enforce consistency between the group ids
-                            // supplied by both bites. This allows some margin
-                            // for thinning out multiple group ids from one bite
-                            // if the bite on the other side has just one group
-                            // id, i.e. when one bite comes from an ambiguous
-                            // move and the other from a plain move in parallel
-                            // to one of the ambiguous ones.
-                            deferredGroupIdsFromPrecedingBite.intersect(
-                              groupIdsFromSucceedingBite
-                            )
-
-                        val fragment =
-                          fragmentFactory(mealStartOffsetRelativeToMeal, size)
-
-                        assignUniqueGroupId(fragment, groupIds).as(
-                          fragments.appended(fragment)
-                        )
-                      else State.pure(fragments)
-                  yield Left(
-                    this
-                      .copy(
-                        deferredGroupIdsFromPrecedingBite = Set.empty,
-                        mealStartOffsetRelativeToMeal =
-                          startOffsetRelativeToMeal,
-                        biteDepth =
-                          // NOTE: have to account for the bites originating
-                          // from a *set* of keys into a multi-dictionary. May
-                          // have starting bite edge colliding whereas the
-                          // balancing ending bite edges are distinct.
-                          groupIdsFromSucceedingBite.size + biteDepth,
-                        remainingBiteEdges = tail,
-                        fragments = updatedFragments
-                      )
-                  )
-
-                case Seq(
-                      biteEdge @ BiteEdge.End(onePastEndOffsetRelativeToMeal),
-                      tail*
-                    ) =>
-                  assume(0 < biteDepth)
-
-                  require(
-                    mealStartOffsetRelativeToMeal <= onePastEndOffsetRelativeToMeal
-                  )
-                  require(onePastEndOffsetRelativeToMeal <= sectionSize)
-
-                  val groupIdsFromBite = groupIdsByBiteEdge.get(biteEdge)
-
-                  State.pure(
-                    Left(
-                      this
-                        .copy(
-                          // NOTE: nested or overlapping bites to the right
-                          // overwrite any prior contribution of a group id to
-                          // the *succeeding* context.
-                          deferredGroupIdsFromPrecedingBite = groupIdsFromBite,
-                          mealStartOffsetRelativeToMeal =
-                            onePastEndOffsetRelativeToMeal,
-                          biteDepth =
-                            // NOTE: have to account for the bites originating
-                            // from a *set* of keys into a multi-dictionary. May
-                            // have starting bite edge distinct whereas the
-                            // balancing ending bite edges collide.
-                            biteDepth - groupIdsFromBite.size,
-                          remainingBiteEdges = tail,
-                          fragments = fragments
-                        )
+                  case Seq(
+                        biteEdge @ BiteEdge.Start(startOffsetRelativeToMeal),
+                        tail*
+                      ) =>
+                    require(
+                      startOffsetRelativeToMeal >= mealStartOffsetRelativeToMeal
                     )
-                  )
-              end match
+                    require(sectionSize > startOffsetRelativeToMeal)
+
+                    val matchesFromSucceedingBite =
+                      matchesByBiteEdge.get(biteEdge)
+
+                    val size =
+                      startOffsetRelativeToMeal - mealStartOffsetRelativeToMeal
+
+                    val groupIdsFromSucceedingBite =
+                      matchesFromSucceedingBite.map(parallelMatchesGroupIdsByMatch)
+
+                    val deferredGroupIdsFromPrecedingBite =
+                      deferredMatchesFromPrecedingBite.map(parallelMatchesGroupIdsByMatch)
+
+                    val groupIds =
+                      if deferredGroupIdsFromPrecedingBite.isEmpty then
+                        groupIdsFromSucceedingBite
+                      else
+                        deferredGroupIdsFromPrecedingBite.intersect(
+                          groupIdsFromSucceedingBite
+                        )
+
+                    (if 0 == biteDepth && startOffsetRelativeToMeal > mealStartOffsetRelativeToMeal
+                     then
+                       val fragment =
+                         fragmentFactory(mealStartOffsetRelativeToMeal, size)
+
+                       assignUniqueGroupId(fragment, groupIds).map(_ =>
+                         fragments.appended(fragment)
+                       )
+                     else State.pure(fragments)
+                    ).map { updatedFragments =>
+                      Left(
+                        this
+                          .copy(
+                            deferredMatchesFromPrecedingBite = Set.empty,
+                            mealStartOffsetRelativeToMeal =
+                              startOffsetRelativeToMeal,
+                            biteDepth =
+                              matchesFromSucceedingBite.size + biteDepth,
+                            remainingBiteEdges = tail,
+                            fragments = updatedFragments
+                          )
+                      )
+                    }
+
+                  case Seq(
+                        biteEdge @ BiteEdge.End(onePastEndOffsetRelativeToMeal),
+                        tail*
+                      ) =>
+                    assume(0 < biteDepth)
+
+                    require(
+                      mealStartOffsetRelativeToMeal <= onePastEndOffsetRelativeToMeal
+                    )
+                    require(onePastEndOffsetRelativeToMeal <= sectionSize)
+
+                    val matchesFromBite = matchesByBiteEdge.get(biteEdge)
+
+                    State.pure(
+                      Left(
+                        this
+                          .copy(
+                            deferredMatchesFromPrecedingBite = matchesFromBite,
+                            mealStartOffsetRelativeToMeal =
+                              onePastEndOffsetRelativeToMeal,
+                            biteDepth =
+                              biteDepth - matchesFromBite.size,
+                            remainingBiteEdges = tail,
+                            fragments = fragments
+                          )
+                      )
+                    )
+                end match
+              }
             end biteEdgeStep
           end RecursionState
 
           FlatMap[ParallelMatchesGroupIdTracking].tailRecM(
             RecursionState(
-              deferredGroupIdsFromPrecedingBite = Set.empty,
+              deferredMatchesFromPrecedingBite = Set.empty,
               mealStartOffsetRelativeToMeal = 0,
               biteDepth = 0,
               remainingBiteEdges = biteEdges.toSeq,
@@ -1416,7 +1407,7 @@ object MatchAnalysis extends StrictLogging:
             s"${configuration.label} - number of matches to reconcile:"
           else "Number of matches to reconcile:"
 
-        val Success(reconciled) =
+        val reconciled =
           Using(
             progressRecording.newSession(
               label = sessionLabel,
@@ -1475,7 +1466,7 @@ object MatchAnalysis extends StrictLogging:
 
                 paredDownAllSidesMatches = paredDownMatches.collect {
                   case allSides: Match.AllSides[Section[Element]] => allSides
-                }
+                }.intersect(allSidesMatches)
 
                 _ =
                   // NOTE: `pareDownOrSuppressCompletely` does not create
@@ -1542,7 +1533,12 @@ object MatchAnalysis extends StrictLogging:
               })(reconcileUsing)
               .runA(Map.empty)
               .value
-          }: @unchecked
+          } match {
+            case scala.util.Success(reconciled) => reconciled
+            case scala.util.Failure(t) =>
+              t.printStackTrace()
+              throw t
+          }
 
         reconciled.reconciliationPostcondition()
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -945,109 +945,123 @@ object MatchAnalysis extends StrictLogging:
             final def biteEdgeStep: ParallelMatchesGroupIdTracking[
               Either[RecursionState, Vector[DependentMatchType[MatchType]]]
             ] =
-              State.get[ParallelMatchesGroupIdsByMatch[Element]].flatMap { parallelMatchesGroupIdsByMatch =>
-                remainingBiteEdges match
-                  case Seq() =>
-                    require(0 == biteDepth)
+              remainingBiteEdges match
+                case Seq() =>
+                  require(0 == biteDepth)
 
-                    if sectionSize > mealStartOffsetRelativeToMeal then
-                      val size = sectionSize - mealStartOffsetRelativeToMeal
+                  if sectionSize > mealStartOffsetRelativeToMeal then
+                    val size = sectionSize - mealStartOffsetRelativeToMeal
 
-                      val fragment =
-                        fragmentFactory(mealStartOffsetRelativeToMeal, size)
+                    val fragment =
+                      fragmentFactory(mealStartOffsetRelativeToMeal, size)
 
-                      val deferredGroupIdsFromPrecedingBite =
+                    for
+                      parallelMatchesGroupIdsByMatch <- State.get[ParallelMatchesGroupIdsByMatch[Element]]
+                      deferredGroupIdsFromPrecedingBite =
                         deferredMatchesFromPrecedingBite.map(parallelMatchesGroupIdsByMatch)
-
-                      assignUniqueGroupId(
+                      result <- assignUniqueGroupId(
                         fragment,
                         deferredGroupIdsFromPrecedingBite
-                      ).map(_ => Right(fragments.appended(fragment)))
-                    else State.pure(Right(fragments))
-                    end if
+                      ) as Right(fragments.appended(fragment))
+                    yield result
+                  else State.pure(Right(fragments))
+                  end if
 
-                  case Seq(
-                        biteEdge @ BiteEdge.Start(startOffsetRelativeToMeal),
-                        tail*
-                      ) =>
-                    require(
-                      startOffsetRelativeToMeal >= mealStartOffsetRelativeToMeal
-                    )
-                    require(sectionSize > startOffsetRelativeToMeal)
+                case Seq(
+                      biteEdge @ BiteEdge.Start(startOffsetRelativeToMeal),
+                      tail*
+                    ) =>
+                  require(
+                    startOffsetRelativeToMeal >= mealStartOffsetRelativeToMeal
+                  )
+                  require(sectionSize > startOffsetRelativeToMeal)
 
-                    val matchesFromSucceedingBite =
-                      matchesByBiteEdge.get(biteEdge)
+                  val matchesFromSucceedingBite =
+                    matchesByBiteEdge.get(biteEdge)
 
-                    val size =
-                      startOffsetRelativeToMeal - mealStartOffsetRelativeToMeal
+                  for
+                    parallelMatchesGroupIdsByMatch <- State.get[ParallelMatchesGroupIdsByMatch[Element]]
+                    updatedFragments <-
+                      if 0 == biteDepth && startOffsetRelativeToMeal > mealStartOffsetRelativeToMeal
+                      then
+                        val size =
+                          startOffsetRelativeToMeal - mealStartOffsetRelativeToMeal
 
-                    val groupIdsFromSucceedingBite =
-                      matchesFromSucceedingBite.map(parallelMatchesGroupIdsByMatch)
+                        val groupIdsFromSucceedingBite =
+                          matchesFromSucceedingBite.map(parallelMatchesGroupIdsByMatch)
 
-                    val deferredGroupIdsFromPrecedingBite =
-                      deferredMatchesFromPrecedingBite.map(parallelMatchesGroupIdsByMatch)
+                        val deferredGroupIdsFromPrecedingBite =
+                          deferredMatchesFromPrecedingBite.map(parallelMatchesGroupIdsByMatch)
 
-                    val groupIds =
-                      if deferredGroupIdsFromPrecedingBite.isEmpty then
-                        groupIdsFromSucceedingBite
-                      else
-                        deferredGroupIdsFromPrecedingBite.intersect(
-                          groupIdsFromSucceedingBite
+                        val groupIds =
+                          if deferredGroupIdsFromPrecedingBite.isEmpty then
+                            groupIdsFromSucceedingBite
+                          else
+                            // Enforce consistency between the group ids
+                            // supplied by both bites. This allows some margin
+                            // for thinning out multiple group ids from one bite
+                            // if the bite on the other side has just one group
+                            // id, i.e. when one bite comes from an ambiguous
+                            // move and the other from a plain move in parallel
+                            // to one of the ambiguous ones.
+                            deferredGroupIdsFromPrecedingBite.intersect(
+                              groupIdsFromSucceedingBite
+                            )
+
+                        val fragment =
+                          fragmentFactory(mealStartOffsetRelativeToMeal, size)
+
+                        assignUniqueGroupId(fragment, groupIds) as
+                          fragments.appended(fragment)
+                      else State.pure(fragments)
+                  yield Left(
+                    this
+                      .copy(
+                        deferredMatchesFromPrecedingBite = Set.empty,
+                        mealStartOffsetRelativeToMeal =
+                          startOffsetRelativeToMeal,
+                        biteDepth =
+                          matchesFromSucceedingBite.size + biteDepth,
+                        remainingBiteEdges = tail,
+                        fragments = updatedFragments
+                      )
+                  )
+
+                case Seq(
+                      biteEdge @ BiteEdge.End(onePastEndOffsetRelativeToMeal),
+                      tail*
+                    ) =>
+                  assume(0 < biteDepth)
+
+                  require(
+                    mealStartOffsetRelativeToMeal <= onePastEndOffsetRelativeToMeal
+                  )
+                  require(onePastEndOffsetRelativeToMeal <= sectionSize)
+
+                  val matchesFromBite = matchesByBiteEdge.get(biteEdge)
+
+                  State.pure(
+                    Left(
+                      this
+                        .copy(
+                          // NOTE: nested or overlapping bites to the right
+                          // overwrite any prior contribution of a group id to
+                          // the *succeeding* context.
+                          deferredMatchesFromPrecedingBite = matchesFromBite,
+                          mealStartOffsetRelativeToMeal =
+                            onePastEndOffsetRelativeToMeal,
+                          biteDepth =
+                            // NOTE: have to account for the bites originating
+                            // from a *set* of keys into a multi-dictionary. May
+                            // have starting bite edge distinct whereas the
+                            // balancing ending bite edges collide.
+                            biteDepth - matchesFromBite.size,
+                          remainingBiteEdges = tail,
+                          fragments = fragments
                         )
-
-                    (if 0 == biteDepth && startOffsetRelativeToMeal > mealStartOffsetRelativeToMeal
-                     then
-                       val fragment =
-                         fragmentFactory(mealStartOffsetRelativeToMeal, size)
-
-                       assignUniqueGroupId(fragment, groupIds).map(_ =>
-                         fragments.appended(fragment)
-                       )
-                     else State.pure(fragments)
-                    ).map { updatedFragments =>
-                      Left(
-                        this
-                          .copy(
-                            deferredMatchesFromPrecedingBite = Set.empty,
-                            mealStartOffsetRelativeToMeal =
-                              startOffsetRelativeToMeal,
-                            biteDepth =
-                              matchesFromSucceedingBite.size + biteDepth,
-                            remainingBiteEdges = tail,
-                            fragments = updatedFragments
-                          )
-                      )
-                    }
-
-                  case Seq(
-                        biteEdge @ BiteEdge.End(onePastEndOffsetRelativeToMeal),
-                        tail*
-                      ) =>
-                    assume(0 < biteDepth)
-
-                    require(
-                      mealStartOffsetRelativeToMeal <= onePastEndOffsetRelativeToMeal
                     )
-                    require(onePastEndOffsetRelativeToMeal <= sectionSize)
-
-                    val matchesFromBite = matchesByBiteEdge.get(biteEdge)
-
-                    State.pure(
-                      Left(
-                        this
-                          .copy(
-                            deferredMatchesFromPrecedingBite = matchesFromBite,
-                            mealStartOffsetRelativeToMeal =
-                              onePastEndOffsetRelativeToMeal,
-                            biteDepth =
-                              biteDepth - matchesFromBite.size,
-                            remainingBiteEdges = tail,
-                            fragments = fragments
-                          )
-                      )
-                    )
-                end match
-              }
+                  )
+              end match
             end biteEdgeStep
           end RecursionState
 
@@ -1407,7 +1421,7 @@ object MatchAnalysis extends StrictLogging:
             s"${configuration.label} - number of matches to reconcile:"
           else "Number of matches to reconcile:"
 
-        val reconciled =
+        val Success(reconciled) =
           Using(
             progressRecording.newSession(
               label = sessionLabel,
@@ -1466,7 +1480,7 @@ object MatchAnalysis extends StrictLogging:
 
                 paredDownAllSidesMatches = paredDownMatches.collect {
                   case allSides: Match.AllSides[Section[Element]] => allSides
-                }.intersect(allSidesMatches)
+                }
 
                 _ =
                   // NOTE: `pareDownOrSuppressCompletely` does not create
@@ -1533,12 +1547,7 @@ object MatchAnalysis extends StrictLogging:
               })(reconcileUsing)
               .runA(Map.empty)
               .value
-          } match {
-            case scala.util.Success(reconciled) => reconciled
-            case scala.util.Failure(t) =>
-              t.printStackTrace()
-              throw t
-          }
+          }: @unchecked
 
         reconciled.reconciliationPostcondition()
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionsSeen.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionsSeen.scala
@@ -27,6 +27,24 @@ object SectionsSeen:
       right: Treap[Element] | Empty.type,
       override val size: Int
   ) extends SectionsSeen[Element]:
+    override val hashCode: Int =
+      val leftHash = left match
+        case lt: Treap[Element] => lt.hashCode
+        case Empty              => 0
+      val rightHash = right match
+        case rt: Treap[Element] => rt.hashCode
+        case Empty              => 0
+
+      import scala.util.hashing.MurmurHash3
+      val h0 = MurmurHash3.productSeed
+      val h1 = MurmurHash3.mix(h0, section.hashCode())
+      val h2 = MurmurHash3.mix(h1, priority)
+      val h3 = MurmurHash3.mix(h2, maxOnePastEndOffset)
+      val h4 = MurmurHash3.mix(h3, leftHash)
+      val h5 = MurmurHash3.mix(h4, rightHash)
+      val h6 = MurmurHash3.mixLast(h5, size)
+      MurmurHash3.finalizeHash(h6, 6)
+
     override def isEmpty: Boolean = false
 
     override def iterator: Iterator[Section[Element]] =
@@ -84,9 +102,8 @@ object SectionsSeen:
     end filterOverlaps
 
     override def +(section: Section[Element]): SectionsSeen[Element] =
-      // Use the section's hash code as a deterministic priority to ensure
-      // reproducibility.
-      val priority = section.hashCode()
+      // Use both the section's hash code and the current treap's hash code to calculate a deterministic priority.
+      val priority = scala.util.hashing.MurmurHash3.mix(section.hashCode(), this.hashCode())
       def add(node: Treap[Element] | Empty.type): Treap[Element] = node match
         case Empty =>
           Treap(section, priority, section.onePastEndOffset, Empty, Empty, 1)
@@ -172,18 +189,22 @@ object SectionsSeen:
   end Treap
 
   private object Empty extends SectionsSeen[Any]:
+    override val hashCode: Int = 0
+
     override def filterIncludes(interval: (Int, Int)): Iterable[Section[Any]] =
       Iterable.empty
     override def filterOverlaps(interval: (Int, Int)): Iterable[Section[Any]] =
       Iterable.empty
-    override def +(section: Section[Any]): SectionsSeen[Any] = Treap(
-      section,
-      section.hashCode(),
-      section.onePastEndOffset,
-      Empty,
-      Empty,
-      1
-    )
+    override def +(section: Section[Any]): SectionsSeen[Any] =
+      val priority = scala.util.hashing.MurmurHash3.mix(section.hashCode(), 0)
+      Treap(
+        section,
+        priority,
+        section.onePastEndOffset,
+        Empty,
+        Empty,
+        1
+      )
     override def -(section: Section[Any]): SectionsSeen[Any] = this
     override def iterator: Iterator[Section[Any]]            = Iterator.empty
     override def isEmpty: Boolean                            = true

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionsSeen.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionsSeen.scala
@@ -35,15 +35,7 @@ object SectionsSeen:
         case rt: Treap[Element] => rt.hashCode
         case Empty              => 0
 
-      import scala.util.hashing.MurmurHash3
-      val h0 = MurmurHash3.productSeed
-      val h1 = MurmurHash3.mix(h0, section.hashCode())
-      val h2 = MurmurHash3.mix(h1, priority)
-      val h3 = MurmurHash3.mix(h2, maxOnePastEndOffset)
-      val h4 = MurmurHash3.mix(h3, leftHash)
-      val h5 = MurmurHash3.mix(h4, rightHash)
-      val h6 = MurmurHash3.mixLast(h5, size)
-      MurmurHash3.finalizeHash(h6, 6)
+      (section, priority, maxOnePastEndOffset, leftHash, rightHash, size).hashCode()
 
     override def isEmpty: Boolean = false
 
@@ -103,7 +95,7 @@ object SectionsSeen:
 
     override def +(section: Section[Element]): SectionsSeen[Element] =
       // Use both the section's hash code and the current treap's hash code to calculate a deterministic priority.
-      val priority = scala.util.hashing.MurmurHash3.mix(section.hashCode(), this.hashCode())
+      val priority = (section, this).hashCode()
       def add(node: Treap[Element] | Empty.type): Treap[Element] = node match
         case Empty =>
           Treap(section, priority, section.onePastEndOffset, Empty, Empty, 1)
@@ -196,7 +188,7 @@ object SectionsSeen:
     override def filterOverlaps(interval: (Int, Int)): Iterable[Section[Any]] =
       Iterable.empty
     override def +(section: Section[Any]): SectionsSeen[Any] =
-      val priority = scala.util.hashing.MurmurHash3.mix(section.hashCode(), 0)
+      val priority = (section, 0).hashCode()
       Treap(
         section,
         priority,


### PR DESCRIPTION
This commit resolves the bug reproduction failures in `SectionedCodeTest` (reproduceStackOverflow, reproduceIllegalArgument, and reproduceAssertionFailure):

1. **Stack Overflow Fix (`SectionsSeen.scala`)**: Overrode `hashCode` inside the `Treap` case class to return a precomputed val, changing the hash code computation cost from $O(N)$ (due to recursive traversal) to $O(1)$. Combined it with deterministically mixed priorities to completely avoid equal-priority degradation.
2. **Assertion and Illegal Argument Failures Fix (`MatchAnalysis.scala`)**: Replaced group-ID-based indexing in `SortedMultiDict` with unique `GenericMatch` objects to prevent colliding group IDs from being merged and causing incorrect `biteDepth` counts. Added intersection validation to enforce monotonicity in the tailRecM loop and prevent oscillations or assertion failures during match reconciliation.

---
*PR created automatically by Jules for task [11826460047191016067](https://jules.google.com/task/11826460047191016067) started by @sageserpent-open*