### PR TITLE
Managed to reproduce the stack overflow seen on the GitHub CI build.

### DIFF
--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionsSeen.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionsSeen.scala
@@ -25,13 +25,24 @@ object SectionsSeen:
       maxOnePastEndOffset: Int,
       left: Treap[Element] | Empty.type,
       right: Treap[Element] | Empty.type,
+      multiplicity: Int,
       override val size: Int
   ) extends SectionsSeen[Element]:
+    require(0 < multiplicity)
+
     override val hashCode: Int =
       val leftHash  = left.hashCode
       val rightHash = right.hashCode
 
-      (section, priority, maxOnePastEndOffset, leftHash, rightHash, size)
+      (
+        section,
+        priority,
+        maxOnePastEndOffset,
+        leftHash,
+        rightHash,
+        multiplicity,
+        size
+      )
         .hashCode()
     end hashCode
 
@@ -41,7 +52,7 @@ object SectionsSeen:
       (left match
         case l: Treap[Element] => l.iterator
         case Empty             => Iterator.empty
-      ) ++ Iterator(section) ++ (right match
+      ) ++ Iterator.fill(multiplicity)(section) ++ (right match
         case r: Treap[Element] => r.iterator
         case Empty             => Iterator.empty)
 
@@ -97,17 +108,28 @@ object SectionsSeen:
       val priority = (section, this).hashCode()
       def add(node: Treap[Element] | Empty.type): Treap[Element] = node match
         case Empty =>
-          Treap(section, priority, section.onePastEndOffset, Empty, Empty, 1)
+          Treap(
+            section = section,
+            priority = priority,
+            maxOnePastEndOffset = section.onePastEndOffset,
+            left = Empty,
+            right = Empty,
+            multiplicity = 1,
+            size = 1
+          )
         case t: Treap[Element] =>
-          if priority > t.priority then
+          if t.section == section then
+            t.copy(multiplicity = 1 + t.multiplicity, size = 1 + t.size)
+          else if priority > t.priority then
             val (l, r) = split(t, section.startOffset)
             Treap(
-              section,
-              priority,
-              section.onePastEndOffset,
-              l,
-              r,
-              1
+              section = section,
+              priority = priority,
+              maxOnePastEndOffset = section.onePastEndOffset,
+              left = l,
+              right = r,
+              multiplicity = 1,
+              size = 1
             ).recompute
           else if section.startOffset < t.section.startOffset then
             t.copy(left = add(t.left)).recompute
@@ -122,7 +144,9 @@ object SectionsSeen:
       ): Treap[Element] | Empty.type = node match
         case Empty             => Empty
         case t: Treap[Element] =>
-          if t.section == section then merge(t.left, t.right)
+          if t.section == section then
+            if t.sectionIsUnique then merge(t.left, t.right)
+            else t.copy(multiplicity = t.multiplicity - 1, size = t.size - 1)
           else if section.startOffset < t.section.startOffset then
             val newLeft = remove(t.left)
             if newLeft eq t.left then t else t.copy(left = newLeft).recompute
@@ -134,6 +158,8 @@ object SectionsSeen:
 
       remove(this).asInstanceOf[SectionsSeen[Element]]
     end -
+
+    private def sectionIsUnique: Boolean = 1 == multiplicity
 
     private def split(
         node: Treap[Element] | Empty.type,
@@ -174,7 +200,7 @@ object SectionsSeen:
         case Empty              => 0
       copy(
         maxOnePastEndOffset = section.onePastEndOffset max leftMax max rightMax,
-        size = 1 + leftSize + rightSize
+        size = multiplicity + leftSize + rightSize
       )
     end recompute
   end Treap
@@ -189,12 +215,13 @@ object SectionsSeen:
     override def +(section: Section[Any]): SectionsSeen[Any] =
       val priority = section.hashCode()
       Treap(
-        section,
-        priority,
-        section.onePastEndOffset,
-        Empty,
-        Empty,
-        1
+        section = section,
+        priority = priority,
+        maxOnePastEndOffset = section.onePastEndOffset,
+        left = Empty,
+        right = Empty,
+        multiplicity = 1,
+        size = 1
       )
     end +
     override def -(section: Section[Any]): SectionsSeen[Any] = this


### PR DESCRIPTION
Locally by setting the VM option `-Xss600k`. Fixed that by modelling the bag/multi-set aspects using a multiplicity.

This functionality is only partially tested via `SectionsSeen`, but it is covered indirectly by the higher level tests for now.