### PR TITLE
Resolve inconsistent Order for Block fallback comparison

### DIFF
--- a/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
@@ -461,46 +461,9 @@ object LongestCommonSubsequence:
     // is calculated, merge it with difference contributions from the leftover
     // rejected elements.
 
-    object SetDiagnosingInconsistentOrderImplementation:
-      private val equality = summon[Eq[Element]]
-    end SetDiagnosingInconsistentOrderImplementation
-
-    class SetDiagnosingInconsistentOrderImplementation(
-        elements: IndexedSeq[Element]
-    ):
-      private val elementSet = SortedSet.from(elements)
-
-      def contains(candidate: Element): Boolean =
-        val verdict = elementSet.contains(candidate)
-
-        val referenceVerdict = elements.exists(
-          SetDiagnosingInconsistentOrderImplementation.equality
-            .eqv(_, candidate)
-        )
-
-        assert(
-          referenceVerdict == verdict,
-          s"""Inconsistency between containment verdicts on ${pprintCustomised(
-              candidate
-            )},
-             |the reference verdict using equality is: $referenceVerdict,
-             |whereas the verdict using order is: $verdict.
-             |Using equality would find: ${pprintCustomised(
-              elements.find(
-                SetDiagnosingInconsistentOrderImplementation.equality
-                  .eqv(_, candidate)
-              )
-            )}
-             |The elements are: ${pprintCustomised(elements)}""".stripMargin
-        )
-
-        verdict
-      end contains
-    end SetDiagnosingInconsistentOrderImplementation
-
-    val baseSet  = SetDiagnosingInconsistentOrderImplementation(base)
-    val leftSet  = SetDiagnosingInconsistentOrderImplementation(left)
-    val rightSet = SetDiagnosingInconsistentOrderImplementation(right)
+    val baseSet  = SortedSet.from(base)
+    val leftSet  = SortedSet.from(left)
+    val rightSet = SortedSet.from(right)
 
     val matchableBaseIndices = base.zipWithIndex.collect {
       case (baseElement, index)

--- a/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
@@ -461,9 +461,46 @@ object LongestCommonSubsequence:
     // is calculated, merge it with difference contributions from the leftover
     // rejected elements.
 
-    val baseSet  = SortedSet.from(base)
-    val leftSet  = SortedSet.from(left)
-    val rightSet = SortedSet.from(right)
+    object SetDiagnosingInconsistentOrderImplementation:
+      private val equality = summon[Eq[Element]]
+    end SetDiagnosingInconsistentOrderImplementation
+
+    class SetDiagnosingInconsistentOrderImplementation(
+        elements: IndexedSeq[Element]
+    ):
+      private val elementSet = SortedSet.from(elements)
+
+      def contains(candidate: Element): Boolean =
+        val verdict = elementSet.contains(candidate)
+
+        val referenceVerdict = elements.exists(
+          SetDiagnosingInconsistentOrderImplementation.equality
+            .eqv(_, candidate)
+        )
+
+        assert(
+          referenceVerdict == verdict,
+          s"""Inconsistency between containment verdicts on ${pprintCustomised(
+              candidate
+            )},
+             |the reference verdict using equality is: $referenceVerdict,
+             |whereas the verdict using order is: $verdict.
+             |Using equality would find: ${pprintCustomised(
+              elements.find(
+                SetDiagnosingInconsistentOrderImplementation.equality
+                  .eqv(_, candidate)
+              )
+            )}
+             |The elements are: ${pprintCustomised(elements)}""".stripMargin
+        )
+
+        verdict
+      end contains
+    end SetDiagnosingInconsistentOrderImplementation
+
+    val baseSet  = SetDiagnosingInconsistentOrderImplementation(base)
+    val leftSet  = SetDiagnosingInconsistentOrderImplementation(left)
+    val rightSet = SetDiagnosingInconsistentOrderImplementation(right)
 
     val matchableBaseIndices = base.zipWithIndex.collect {
       case (baseElement, index)
@@ -694,6 +731,10 @@ object LongestCommonSubsequence:
 
           def indexOfLeadingSwathe: Int = _indexOfLeadingSwathe
 
+          inline private def storageLotForLeadingSwathe =
+            _indexOfLeadingSwathe % 2
+          end storageLotForLeadingSwathe
+
           def storeSolutionInLeadingSwathe(
               onePastBaseIndex: Int,
               onePastLeftIndex: Int,
@@ -709,10 +750,6 @@ object LongestCommonSubsequence:
               onePastRightIndex
             ) = longestCommonSubsequence
           end storeSolutionInLeadingSwathe
-
-          inline private def storageLotForLeadingSwathe =
-            _indexOfLeadingSwathe % 2
-          end storageLotForLeadingSwathe
 
           inline private def newStorage = Storage(
             baseEqualToSwatheIndex =

--- a/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/LongestCommonSubsequence.scala
@@ -461,9 +461,46 @@ object LongestCommonSubsequence:
     // is calculated, merge it with difference contributions from the leftover
     // rejected elements.
 
-    val baseSet  = SortedSet.from(base)
-    val leftSet  = SortedSet.from(left)
-    val rightSet = SortedSet.from(right)
+    object SetDiagnosingInconsistentOrderImplementation:
+      private val equality = summon[Eq[Element]]
+    end SetDiagnosingInconsistentOrderImplementation
+
+    class SetDiagnosingInconsistentOrderImplementation(
+        elements: IndexedSeq[Element]
+    ):
+      private val elementSet = SortedSet.from(elements)
+
+      def contains(candidate: Element): Boolean =
+        val verdict = elementSet.contains(candidate)
+
+        val referenceVerdict = elements.exists(
+          SetDiagnosingInconsistentOrderImplementation.equality
+            .eqv(_, candidate)
+        )
+
+        assert(
+          referenceVerdict == verdict,
+          s"""Inconsistency between containment verdicts on ${pprintCustomised(
+              candidate
+            )},
+             |the reference verdict using equality is: $referenceVerdict,
+             |whereas the verdict using order is: $verdict.
+             |Using equality would find: ${pprintCustomised(
+              elements.find(
+                SetDiagnosingInconsistentOrderImplementation.equality
+                  .eqv(_, candidate)
+              )
+            )}
+             |The elements are: ${pprintCustomised(elements)}""".stripMargin
+        )
+
+        verdict
+      end contains
+    end SetDiagnosingInconsistentOrderImplementation
+
+    val baseSet  = SetDiagnosingInconsistentOrderImplementation(base)
+    val leftSet  = SetDiagnosingInconsistentOrderImplementation(left)
+    val rightSet = SetDiagnosingInconsistentOrderImplementation(right)
 
     val matchableBaseIndices = base.zipWithIndex.collect {
       case (baseElement, index)

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -60,31 +60,38 @@ object SectionedCodeExtension extends StrictLogging:
       val rightBlocks = sectionedCode.rightBlocksFor(path)
 
       given Order[Block[Element]] =
+        // NOTE: this is subtle - comparing by `Block.parallelMatchesGroupId` is
+        // OK, but consider situations where two distinct blocks covering the
+        // same content on the same side can fool the following block-level
+        // merge into a less than optimal alignment of blocks whenever the group
+        // ids of the relevant blocks swap around from one to another. Peering
+        // inside the two blocks matched content and the groups of matches that
+        // the blocks refer to allows the merge to ignore the scrambled group
+        // ids.
+        // NOTE: tip of the hat to Jules for suggesting the content-based
+        // comparison approach; I cheerfully ignored it at the time but have
+        // come to realise its virtue!
+        given Order[Match[Section[Element]]] = Order.by(aMatch =>
+          (
+            aMatch.baseContribution.map(_.content: Seq[Element]),
+            aMatch.leftContribution.map(_.content: Seq[Element]),
+            aMatch.rightContribution.map(_.content: Seq[Element])
+          )
+        )
         (lhs, rhs) =>
-          val bothBelongToTheSameParallelMatchesGroup = (
-            lhs.parallelMatchesGroupId,
-            rhs.parallelMatchesGroupId
-          ) match
+          (lhs.parallelMatchesGroupId, rhs.parallelMatchesGroupId) match
             case (Some(lhsGroupId), Some(rhsGroupId)) =>
-              lhsGroupId == rhsGroupId
-            case _ => false
-
-          if bothBelongToTheSameParallelMatchesGroup then 0
-          else
-            def matchedSections(block: Block[Element]): Seq[Section[Element]] =
-              block.parallelMatchesGroupId match
-                case Some(groupId) =>
-                  val groupMatches = groupsOfParallelMatches(groupId)
-                  block.sectionsCoveredByGroup.filter(s =>
-                    sectionedCode.matchesFor(s).intersect(groupMatches).nonEmpty
-                  )
-                case None =>
-                  block.sectionsCoveredByGroup
-            end matchedSections
-
-            Order[Seq[Section[Element]]]
-              .compare(matchedSections(lhs), matchedSections(rhs))
-          end if
+              if lhsGroupId == rhsGroupId then 0
+              else
+                Order.compare(
+                  groupsOfParallelMatches(lhsGroupId),
+                  groupsOfParallelMatches(rhsGroupId)
+                )
+            case (Some(_), None) => -1
+            case (None, Some(_)) => 1
+            case (None, None)    =>
+              Order[Seq[Section[Element]]]
+                .compare(lhs.sectionsCoveredByGroup, rhs.sectionsCoveredByGroup)
       end given
 
       given Sized[Block[Element]] = _.size

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -61,14 +61,30 @@ object SectionedCodeExtension extends StrictLogging:
 
       given Order[Block[Element]] =
         (lhs, rhs) =>
-          (lhs.parallelMatchesGroupId, rhs.parallelMatchesGroupId) match
+          val bothBelongToTheSameParallelMatchesGroup = (
+            lhs.parallelMatchesGroupId,
+            rhs.parallelMatchesGroupId
+          ) match
             case (Some(lhsGroupId), Some(rhsGroupId)) =>
-              lhsGroupId compare rhsGroupId
-            case (Some(_), None) => -1
-            case (None, Some(_)) => 1
-            case (None, None) =>
-              Order[Seq[Section[Element]]]
-                .compare(lhs.sectionsCoveredByGroup, rhs.sectionsCoveredByGroup)
+              lhsGroupId == rhsGroupId
+            case _ => false
+
+          if bothBelongToTheSameParallelMatchesGroup then 0
+          else
+            def matchedSections(block: Block[Element]): Seq[Section[Element]] =
+              block.parallelMatchesGroupId match
+                case Some(groupId) =>
+                  val groupMatches = groupsOfParallelMatches(groupId)
+                  block.sectionsCoveredByGroup.filter(s =>
+                    sectionedCode.matchesFor(s).intersect(groupMatches).nonEmpty
+                  )
+                case None =>
+                  block.sectionsCoveredByGroup
+            end matchedSections
+
+            Order[Seq[Section[Element]]]
+              .compare(matchedSections(lhs), matchedSections(rhs))
+          end if
       end given
 
       given Sized[Block[Element]] = _.size

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -60,30 +60,15 @@ object SectionedCodeExtension extends StrictLogging:
       val rightBlocks = sectionedCode.rightBlocksFor(path)
 
       given Order[Block[Element]] =
-        // NOTE: this is subtle - comparing by `Block.parallelMatchesGroupId` is
-        // OK, but consider situations where two distinct blocks covering the
-        // same content on the same side can fool the following block-level
-        // merge into a less than optimal alignment of blocks whenever the group
-        // ids of the relevant blocks swap around from one to another. Peering
-        // inside the two blocks' matched content allows the merge to ignore the
-        // scrambled group ids.
-        // NOTE: tip of the hat to Jules for suggesting the content-based
-        // comparison approach; I cheerfully ignored it at the time but have
-        // come to realise its virtue!
         (lhs, rhs) =>
-          val bothBelongToTheSameParallelMatchesGroup = (
-            lhs.parallelMatchesGroupId,
-            rhs.parallelMatchesGroupId
-          ) match
+          (lhs.parallelMatchesGroupId, rhs.parallelMatchesGroupId) match
             case (Some(lhsGroupId), Some(rhsGroupId)) =>
-              lhsGroupId == rhsGroupId
-            case _ => false
-
-          if bothBelongToTheSameParallelMatchesGroup then 0
-          else
-            Order[Seq[Section[Element]]]
-              .compare(lhs.sectionsCoveredByGroup, rhs.sectionsCoveredByGroup)
-          end if
+              lhsGroupId compare rhsGroupId
+            case (Some(_), None) => -1
+            case (None, Some(_)) => 1
+            case (None, None) =>
+              Order[Seq[Section[Element]]]
+                .compare(lhs.sectionsCoveredByGroup, rhs.sectionsCoveredByGroup)
       end given
 
       given Sized[Block[Element]] = _.size


### PR DESCRIPTION
Resolves the inconsistent Order for Block fallback comparison by comparing block contents directly instead of using section ordering fallback.

---
*PR created automatically by Jules for task [8920780638768411064](https://jules.google.com/task/8920780638768411064) started by @sageserpent-open*