### PR TITLE
Optimize block order calculation in block-level LCS

### DIFF
--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -59,7 +59,7 @@ object SectionedCodeExtension extends StrictLogging:
       val leftBlocks  = sectionedCode.leftBlocksFor(path)
       val rightBlocks = sectionedCode.rightBlocksFor(path)
 
-      val blockKeys: Map[Block[Element], Either[Seq[Section[Element]], Seq[
+      val comparableContentByBlock: Map[Block[Element], Either[Seq[Section[Element]], Seq[
         (Option[Seq[Element]], Int)
       ]]] =
         (baseBlocks ++ leftBlocks ++ rightBlocks).distinct.map { block =>
@@ -91,7 +91,7 @@ object SectionedCodeExtension extends StrictLogging:
           // expect bugs that are difficult to diagnose if you botch this up!
           if lhs == rhs then 0
           else
-            (blockKeys(lhs), blockKeys(rhs)) match
+            (comparableContentByBlock(lhs), comparableContentByBlock(rhs)) match
               case (Right(lhsContent), Right(rhsContent)) =>
                 if lhs.parallelMatchesGroupIds == rhs.parallelMatchesGroupIds
                 then 0

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -59,6 +59,27 @@ object SectionedCodeExtension extends StrictLogging:
       val leftBlocks  = sectionedCode.leftBlocksFor(path)
       val rightBlocks = sectionedCode.rightBlocksFor(path)
 
+      val blockKeys: Map[Block[Element], Either[Seq[Section[Element]], Seq[
+        (Option[Seq[Element]], Int)
+      ]]] =
+        (baseBlocks ++ leftBlocks ++ rightBlocks).distinct.map { block =>
+          if block.parallelMatchesGroupIds.nonEmpty then
+            val content = block.parallelMatchesGroupIds
+              .map(groupsOfParallelMatches.apply)
+              .flatMap(
+                _.toSeq.map(aMatch =>
+                  (
+                    (aMatch.baseContribution orElse aMatch.leftContribution orElse aMatch.rightContribution)
+                      .map(_.content: Seq[Element]),
+                    aMatch.ordinal
+                  )
+                )
+              )
+              .toSeq
+            block -> Right(content)
+          else block -> Left(block.sectionsCoveredByGroup)
+        }.toMap
+
       given Order[Block[Element]] =
         (lhs, rhs) =>
           // NOTE: be *very* careful about changing the logic here - for the
@@ -68,34 +89,17 @@ object SectionedCodeExtension extends StrictLogging:
           // taken to be greater than the latter for cross-over comparisons.
           // Consistency is much more stringent for `Order` than for `Eq`;
           // expect bugs that are difficult to diagnose if you botch this up!
-          (
-            lhs.parallelMatchesGroupIds.nonEmpty,
-            rhs.parallelMatchesGroupIds.nonEmpty
-          ) match
-            case (true, true) =>
-              def orderedContentFrom(block: Block[Element]) =
-                block.parallelMatchesGroupIds
-                  .map(groupsOfParallelMatches.apply)
-                  .flatMap(
-                    _.toSeq.map(aMatch =>
-                      (
-                        (aMatch.baseContribution orElse aMatch.leftContribution orElse aMatch.rightContribution)
-                          .map(_.content: Seq[Element]),
-                        aMatch.ordinal
-                      )
-                    )
-                  )
-                  .toSeq
-
-              Order.compare(
-                orderedContentFrom(lhs),
-                orderedContentFrom(rhs)
-              )
-            case (true, false)  => -1
-            case (false, true)  => 1
-            case (false, false) =>
-              Order[Seq[Section[Element]]]
-                .compare(lhs.sectionsCoveredByGroup, rhs.sectionsCoveredByGroup)
+          if lhs == rhs then 0
+          else
+            (blockKeys(lhs), blockKeys(rhs)) match
+              case (Right(lhsContent), Right(rhsContent)) =>
+                if lhs.parallelMatchesGroupIds == rhs.parallelMatchesGroupIds
+                then 0
+                else Order.compare(lhsContent, rhsContent)
+              case (Right(_), Left(_))                    => -1
+              case (Left(_), Right(_))                    => 1
+              case (Left(lhsSections), Left(rhsSections)) =>
+                Order[Seq[Section[Element]]].compare(lhsSections, rhsSections)
       end given
 
       given Sized[Block[Element]] = _.size


### PR DESCRIPTION
This change optimizes the block order calculation in `SectionedCodeExtension.scala` by pre-calculating and caching block comparison keys (`blockKeys`) before running the block-level LCS dynamic programming algorithm.

Benchmark timing improvements on manual benchmark merge:
- `Main.scala`: Reduced LCS calculation time from ~38s down to ~13.5s (172 swathes)
- `MainTest.scala`: Reduced LCS calculation time from ~5.4s down to ~1.3s (101 swathes)

---
*PR created automatically by Jules for task [748949622406849971](https://jules.google.com/task/748949622406849971) started by @sageserpent-open*