### PR TITLE
Ensure all pairwise group matches are redundant before group fusion

### DIFF
--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -2288,10 +2288,24 @@ object MatchAnalysis extends StrictLogging:
               val replacementGroupId = groupIdsForAllSidesMatches.head
 
               accumulatedRedundantPairwiseMatches.add(pairwiseMatch)
-              accumulatedGroupIdCandidateCutovers.addOne(
-                groupIdForPairwiseMatch,
-                replacementGroupId
-              )
+
+              val groupMatches = parallelMatchesGroupIdsByMatch.collect {
+                case (m, `groupIdForPairwiseMatch`) => m
+              }
+
+              val allGroupMatchesAreRedundantWithReplacementGroup =
+                groupMatches.forall {
+                  case RedundantMatch(_, _, groupIds) =>
+                    groupIds.size == 1 && groupIds.head == replacementGroupId
+                  case _ => false
+                }
+
+              if allGroupMatchesAreRedundantWithReplacementGroup then
+                accumulatedGroupIdCandidateCutovers.addOne(
+                  groupIdForPairwiseMatch,
+                  replacementGroupId
+                )
+              end if
 
             case RedundantMatch(pairwiseMatch, _, _) =>
               accumulatedRedundantPairwiseMatches.add(pairwiseMatch)


### PR DESCRIPTION
Fixes parallel match group fusion in `MatchAnalysis.scala` by ensuring that group ID cutovers are only applied when all matches in a pairwise match group are redundant with the same target all-sides match group. This resolves test failures in `duplicateBlocksWithAnEditAreMerged` and eliminates merge conflicts on `Main.scala` in the manual benchmark.

---
*PR created automatically by Jules for task [16566806333632712675](https://jules.google.com/task/16566806333632712675) started by @sageserpent-open*