### PR TITLE
Vet move destinations using parallel matches groups

### DIFF
--- a/src/main/scala/com/sageserpent/kineticmerge/core/MoveDestinationsReport.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MoveDestinationsReport.scala
@@ -65,12 +65,15 @@ object MoveDestinationsReport:
       ]],
       speculativeMoveDestinations: Set[SpeculativeMoveDestination[Element]]
   )(
-      matchesFor: Element => collection.Set[Match[Element]]
+      matchesFor: Element => collection.Set[Match[Element]],
+      isFirstOrLastInParallelMatchesGroup: Match[Element] => Boolean =
+        (_: Match[Element]) => true
   ): MoveEvaluation[Element] =
     val destinationsBySource =
       MultiDict.from(speculativeMigrationsBySource.keys.flatMap {
         speculativeSource =>
           val destinations = matchesFor(speculativeSource)
+            .filter(isFirstOrLastInParallelMatchesGroup)
             .flatMap {
               case Match.AllSides(_, leftElement, rightElement) =>
                 Seq(

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -1184,19 +1184,27 @@ object SectionedCodeExtension extends StrictLogging:
 
       def parallelGroupSectionsFor(
           anchor: Section[Element],
+          blocksFor: Section[Element] => IndexedSeq[Block[Element]],
           sideExtractor: Match[Section[Element]] => Option[Section[Element]]
       ): Set[Section[Element]] =
         val matches: Set[Match[Section[Element]]] =
           sectionedCode.matchesFor(anchor).toSet
-        matches.flatMap { (aMatch: Match[Section[Element]]) =>
-          sectionedCode.parallelMatchesGroupIdsByMatch.get(aMatch).toSeq.flatMap { groupId =>
-            sectionedCode.groupsOfParallelMatches.get(groupId) match
-              case Some(gMatches) =>
-                gMatches.toSeq.flatMap(sideExtractor)
-              case None =>
-                Seq.empty
-          }
+        val groupIds: Set[ParallelMatchesGroupId] = matches.flatMap { aMatch =>
+          sectionedCode.parallelMatchesGroupIdsByMatch.get(aMatch)
         }
+        val blocksOnSide = blocksFor(anchor)
+        val sectionsFromBlocks = blocksOnSide.collect {
+          case block if block.parallelMatchesGroupIds.exists(groupIds.contains) =>
+            block.sectionsCoveredByGroup
+        }.flatten.toSet
+
+        val sectionsFromMatches = groupIds.flatMap { groupId =>
+          sectionedCode.groupsOfParallelMatches.get(groupId) match
+            case Some(gMatches) => gMatches.toSeq.flatMap(sideExtractor)
+            case None           => Seq.empty
+        }
+
+        sectionsFromBlocks ++ sectionsFromMatches
 
       def anchoredContentFromSource(
           sourceAnchor: Section[Element]
@@ -1205,19 +1213,29 @@ object SectionedCodeExtension extends StrictLogging:
           sectionedCode.base(sectionedCode.basePathFor(sourceAnchor))
 
         val baseGroupSections =
-          parallelGroupSectionsFor(sourceAnchor, _.baseContribution)
+          parallelGroupSectionsFor(
+            sourceAnchor,
+            s => sectionedCode.baseBlocksFor(sectionedCode.basePathFor(s)),
+            _.baseContribution
+          )
 
         def selection(
             candidates: IndexedSeqView[Section[Element]]
         ): IndexedSeq[Section[Element]] =
           candidates
-            .takeWhile(candidate =>
-              (!basePreservations.contains(candidate) || baseGroupSections
-                .contains(candidate)) && !sourceAnchors
-                .contains(
-                  candidate
-                )
-            )
+            .takeWhile { candidate =>
+              // Splices growing out from the start or end of the implied block are terminated
+              // by stationary preservations (or another anchor). Splices growing into the block
+              // hoover up the block's sections (including interior/filler sections of the same parallel move group).
+              val isNotStationaryPreservation =
+                !basePreservations.contains(candidate)
+              val isSectionWithinCurrentParallelMove =
+                baseGroupSections.contains(candidate)
+              val isNotAnchor =
+                !sourceAnchors.contains(candidate)
+
+              (isNotStationaryPreservation || isSectionWithinCurrentParallelMove) && isNotAnchor
+            }
             // At this point, we only have a plain view rather than an indexed
             // one...
             .toIndexedSeq
@@ -1236,7 +1254,7 @@ object SectionedCodeExtension extends StrictLogging:
           Option[IndexedSeq[Section[Element]]],
           Option[IndexedSeq[Section[Element]]]
       ) =
-        val (file, preservations, coincidentInsertionsOrEdits, sideExtractor) =
+        val (file, preservations, coincidentInsertionsOrEdits, blocksFor, sideExtractor) =
           moveDestinationSide match
             case MoveDestinationSide.Left =>
               (
@@ -1245,6 +1263,7 @@ object SectionedCodeExtension extends StrictLogging:
                 ),
                 rightPreservations,
                 coincidentInsertionsOrEditsOnRight,
+                (s: Section[Element]) => sectionedCode.rightBlocksFor(sectionedCode.rightPathFor(s)),
                 (m: Match[Section[Element]]) => m.rightContribution
               )
             case MoveDestinationSide.Right =>
@@ -1254,22 +1273,37 @@ object SectionedCodeExtension extends StrictLogging:
                 ),
                 leftPreservations,
                 coincidentInsertionsOrEditsOnLeft,
+                (s: Section[Element]) => sectionedCode.leftBlocksFor(sectionedCode.leftPathFor(s)),
                 (m: Match[Section[Element]]) => m.leftContribution
               )
 
         val oppositeGroupSections =
-          parallelGroupSectionsFor(oppositeSideAnchor.element, sideExtractor)
+          parallelGroupSectionsFor(
+            oppositeSideAnchor.element,
+            blocksFor,
+            sideExtractor
+          )
 
         def selection(
             candidates: IndexedSeqView[Section[Element]]
         ): IndexedSeq[Section[Element]] = candidates
-          .takeWhile(candidate =>
-            (!preservations.contains(
-              candidate
-            ) || oppositeGroupSections.contains(candidate)) && !oppositeSideAnchors.contains(
-              candidate
-            ) && !coincidentInsertionsOrEdits.contains(candidate)
-          )
+          .takeWhile { candidate =>
+            // Splices growing out from the start or end of the implied block are terminated
+            // by stationary preservations (or another anchor). Splices growing into the block
+            // hoover up the block's sections (including interior/filler sections of the same parallel move group).
+            val isNotStationaryPreservation =
+              !preservations.contains(candidate)
+            val isSectionWithinCurrentParallelMove =
+              oppositeGroupSections.contains(candidate)
+            val isNotAnchor =
+              !oppositeSideAnchors.contains(candidate)
+            val isNotCoincidentInsertionOrEdit =
+              !coincidentInsertionsOrEdits.contains(candidate)
+
+            (isNotStationaryPreservation || isSectionWithinCurrentParallelMove) &&
+            isNotAnchor &&
+            isNotCoincidentInsertionOrEdit
+          }
           // At this point, we only have a plain view rather than an indexed
           // one...
           .toIndexedSeq
@@ -1326,7 +1360,7 @@ object SectionedCodeExtension extends StrictLogging:
           moveDestinationSide: MoveDestinationSide,
           moveDestinationAnchor: Section[Element]
       ): (IndexedSeq[Section[Element]], IndexedSeq[Section[Element]]) =
-        val (file, preservations, coincidentInsertionsOrEdits, sideExtractor) =
+        val (file, preservations, coincidentInsertionsOrEdits, blocksFor, sideExtractor) =
           moveDestinationSide match
             case MoveDestinationSide.Left =>
               (
@@ -1335,6 +1369,7 @@ object SectionedCodeExtension extends StrictLogging:
                 ),
                 leftPreservations,
                 coincidentInsertionsOrEditsOnLeft,
+                (s: Section[Element]) => sectionedCode.leftBlocksFor(sectionedCode.leftPathFor(s)),
                 (m: Match[Section[Element]]) => m.leftContribution
               )
             case MoveDestinationSide.Right =>
@@ -1344,22 +1379,37 @@ object SectionedCodeExtension extends StrictLogging:
                 ),
                 rightPreservations,
                 coincidentInsertionsOrEditsOnRight,
+                (s: Section[Element]) => sectionedCode.rightBlocksFor(sectionedCode.rightPathFor(s)),
                 (m: Match[Section[Element]]) => m.rightContribution
               )
 
         val destinationGroupSections =
-          parallelGroupSectionsFor(moveDestinationAnchor, sideExtractor)
+          parallelGroupSectionsFor(
+            moveDestinationAnchor,
+            blocksFor,
+            sideExtractor
+          )
 
         def selection(
             candidates: IndexedSeqView[Section[Element]]
         ): IndexedSeq[Section[Element]] = candidates
-          .takeWhile(candidate =>
-            (!preservations.contains(
-              candidate
-            ) || destinationGroupSections.contains(candidate)) && !moveDestinationAnchors.contains(
-              candidate
-            ) && !coincidentInsertionsOrEdits.contains(candidate)
-          )
+          .takeWhile { candidate =>
+            // Splices growing out from the start or end of the implied block are terminated
+            // by stationary preservations (or another anchor). Splices growing into the block
+            // hoover up the block's sections (including interior/filler sections of the same parallel move group).
+            val isNotStationaryPreservation =
+              !preservations.contains(candidate)
+            val isSectionWithinCurrentParallelMove =
+              destinationGroupSections.contains(candidate)
+            val isNotAnchor =
+              !moveDestinationAnchors.contains(candidate)
+            val isNotCoincidentInsertionOrEdit =
+              !coincidentInsertionsOrEdits.contains(candidate)
+
+            (isNotStationaryPreservation || isSectionWithinCurrentParallelMove) &&
+            isNotAnchor &&
+            isNotCoincidentInsertionOrEdit
+          }
           // At this point, we only have a plain view rather than an indexed
           // one...
           .toIndexedSeq

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -1184,8 +1184,7 @@ object SectionedCodeExtension extends StrictLogging:
 
       def parallelGroupSectionsFor(
           anchor: Section[Element],
-          blocksFor: Section[Element] => IndexedSeq[Block[Element]],
-          sideExtractor: Match[Section[Element]] => Option[Section[Element]]
+          blocksFor: Section[Element] => IndexedSeq[Block[Element]]
       ): Set[Section[Element]] =
         val matches: Set[Match[Section[Element]]] =
           sectionedCode.matchesFor(anchor).toSet
@@ -1193,18 +1192,11 @@ object SectionedCodeExtension extends StrictLogging:
           sectionedCode.parallelMatchesGroupIdsByMatch.get(aMatch)
         }
         val blocksOnSide = blocksFor(anchor)
-        val sectionsFromBlocks = blocksOnSide.collect {
-          case block if block.parallelMatchesGroupIds.exists(groupIds.contains) =>
+        blocksOnSide.collect {
+          case block
+              if block.parallelMatchesGroupIds.exists(groupIds.contains) =>
             block.sectionsCoveredByGroup
         }.flatten.toSet
-
-        val sectionsFromMatches = groupIds.flatMap { groupId =>
-          sectionedCode.groupsOfParallelMatches.get(groupId) match
-            case Some(gMatches) => gMatches.toSeq.flatMap(sideExtractor)
-            case None           => Seq.empty
-        }
-
-        sectionsFromBlocks ++ sectionsFromMatches
 
       def anchoredContentFromSource(
           sourceAnchor: Section[Element]
@@ -1215,8 +1207,7 @@ object SectionedCodeExtension extends StrictLogging:
         val baseGroupSections =
           parallelGroupSectionsFor(
             sourceAnchor,
-            s => sectionedCode.baseBlocksFor(sectionedCode.basePathFor(s)),
-            _.baseContribution
+            s => sectionedCode.baseBlocksFor(sectionedCode.basePathFor(s))
           )
 
         def selection(
@@ -1254,7 +1245,7 @@ object SectionedCodeExtension extends StrictLogging:
           Option[IndexedSeq[Section[Element]]],
           Option[IndexedSeq[Section[Element]]]
       ) =
-        val (file, preservations, coincidentInsertionsOrEdits, blocksFor, sideExtractor) =
+        val (file, preservations, coincidentInsertionsOrEdits, blocksFor) =
           moveDestinationSide match
             case MoveDestinationSide.Left =>
               (
@@ -1263,8 +1254,8 @@ object SectionedCodeExtension extends StrictLogging:
                 ),
                 rightPreservations,
                 coincidentInsertionsOrEditsOnRight,
-                (s: Section[Element]) => sectionedCode.rightBlocksFor(sectionedCode.rightPathFor(s)),
-                (m: Match[Section[Element]]) => m.rightContribution
+                (s: Section[Element]) =>
+                  sectionedCode.rightBlocksFor(sectionedCode.rightPathFor(s))
               )
             case MoveDestinationSide.Right =>
               (
@@ -1273,15 +1264,14 @@ object SectionedCodeExtension extends StrictLogging:
                 ),
                 leftPreservations,
                 coincidentInsertionsOrEditsOnLeft,
-                (s: Section[Element]) => sectionedCode.leftBlocksFor(sectionedCode.leftPathFor(s)),
-                (m: Match[Section[Element]]) => m.leftContribution
+                (s: Section[Element]) =>
+                  sectionedCode.leftBlocksFor(sectionedCode.leftPathFor(s))
               )
 
         val oppositeGroupSections =
           parallelGroupSectionsFor(
             oppositeSideAnchor.element,
-            blocksFor,
-            sideExtractor
+            blocksFor
           )
 
         def selection(
@@ -1360,7 +1350,7 @@ object SectionedCodeExtension extends StrictLogging:
           moveDestinationSide: MoveDestinationSide,
           moveDestinationAnchor: Section[Element]
       ): (IndexedSeq[Section[Element]], IndexedSeq[Section[Element]]) =
-        val (file, preservations, coincidentInsertionsOrEdits, blocksFor, sideExtractor) =
+        val (file, preservations, coincidentInsertionsOrEdits, blocksFor) =
           moveDestinationSide match
             case MoveDestinationSide.Left =>
               (
@@ -1369,8 +1359,8 @@ object SectionedCodeExtension extends StrictLogging:
                 ),
                 leftPreservations,
                 coincidentInsertionsOrEditsOnLeft,
-                (s: Section[Element]) => sectionedCode.leftBlocksFor(sectionedCode.leftPathFor(s)),
-                (m: Match[Section[Element]]) => m.leftContribution
+                (s: Section[Element]) =>
+                  sectionedCode.leftBlocksFor(sectionedCode.leftPathFor(s))
               )
             case MoveDestinationSide.Right =>
               (
@@ -1379,15 +1369,14 @@ object SectionedCodeExtension extends StrictLogging:
                 ),
                 rightPreservations,
                 coincidentInsertionsOrEditsOnRight,
-                (s: Section[Element]) => sectionedCode.rightBlocksFor(sectionedCode.rightPathFor(s)),
-                (m: Match[Section[Element]]) => m.rightContribution
+                (s: Section[Element]) =>
+                  sectionedCode.rightBlocksFor(sectionedCode.rightPathFor(s))
               )
 
         val destinationGroupSections =
           parallelGroupSectionsFor(
             moveDestinationAnchor,
-            blocksFor,
-            sideExtractor
+            blocksFor
           )
 
         def selection(

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -1073,6 +1073,17 @@ object SectionedCodeExtension extends StrictLogging:
         s"Coincident insertions or edits on right: ${pprintCustomised(coincidentInsertionsOrEditsOnRight)}."
       )
 
+      val firstAndLastMatchesInParallelMatchesGroups
+          : Set[Match[Section[Element]]] =
+        sectionedCode.groupsOfParallelMatches.values.flatMap { matches =>
+          if matches.nonEmpty then Seq(matches.head, matches.last)
+          else Seq.empty
+        }.toSet
+
+      val isFirstOrLastInParallelMatchesGroup
+          : Match[Section[Element]] => Boolean =
+        firstAndLastMatchesInParallelMatchesGroups.contains
+
       val moveEvaluation @ MoveEvaluation(
         moveDestinationsReport,
         migratedEditSuppressions,
@@ -1082,7 +1093,11 @@ object SectionedCodeExtension extends StrictLogging:
         MoveDestinationsReport.evaluateSpeculativeSourcesAndDestinations(
           speculativeMigrationsBySource,
           speculativeMoveDestinations
-        )(matchesFor)
+        )(
+          matchesFor = matchesFor,
+          isFirstOrLastInParallelMatchesGroup =
+            isFirstOrLastInParallelMatchesGroup
+        )
 
       logger.debug(s"Move evaluation: ${pprintCustomised(moveEvaluation)}.")
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/SectionedCodeExtension.scala
@@ -1080,9 +1080,22 @@ object SectionedCodeExtension extends StrictLogging:
           else Seq.empty
         }.toSet
 
+      def hasMigratedEditOrDeletion(aMatch: Match[Section[Element]]): Boolean =
+        aMatch.baseContribution.exists { baseSection =>
+          speculativeMigrationsBySource.get(baseSection).exists {
+            case SpeculativeContentMigration.CoincidentEditOrDeletion(_) => true
+            case SpeculativeContentMigration.LeftEditOrDeletion(_, _)     => true
+            case SpeculativeContentMigration.RightEditOrDeletion(_, _)    => true
+            case SpeculativeContentMigration.Conflict(_, _, _)            => true
+            case _                                                        => false
+          }
+        }
+
       val isFirstOrLastInParallelMatchesGroup
           : Match[Section[Element]] => Boolean =
-        firstAndLastMatchesInParallelMatchesGroups.contains
+        aMatch =>
+          firstAndLastMatchesInParallelMatchesGroups.contains(aMatch) ||
+            hasMigratedEditOrDeletion(aMatch)
 
       val moveEvaluation @ MoveEvaluation(
         moveDestinationsReport,
@@ -1169,18 +1182,38 @@ object SectionedCodeExtension extends StrictLogging:
         selection(file.sections.view.drop(1 + indexOfSection))
       end succeedingAnchoredContentUsingSelection
 
+      def parallelGroupSectionsFor(
+          anchor: Section[Element],
+          sideExtractor: Match[Section[Element]] => Option[Section[Element]]
+      ): Set[Section[Element]] =
+        val matches: Set[Match[Section[Element]]] =
+          sectionedCode.matchesFor(anchor).toSet
+        matches.flatMap { (aMatch: Match[Section[Element]]) =>
+          sectionedCode.parallelMatchesGroupIdsByMatch.get(aMatch).toSeq.flatMap { groupId =>
+            sectionedCode.groupsOfParallelMatches.get(groupId) match
+              case Some(gMatches) =>
+                gMatches.toSeq.flatMap(sideExtractor)
+              case None =>
+                Seq.empty
+          }
+        }
+
       def anchoredContentFromSource(
           sourceAnchor: Section[Element]
       ): (IndexedSeq[Section[Element]], IndexedSeq[Section[Element]]) =
         val file =
           sectionedCode.base(sectionedCode.basePathFor(sourceAnchor))
 
+        val baseGroupSections =
+          parallelGroupSectionsFor(sourceAnchor, _.baseContribution)
+
         def selection(
             candidates: IndexedSeqView[Section[Element]]
         ): IndexedSeq[Section[Element]] =
           candidates
             .takeWhile(candidate =>
-              !basePreservations.contains(candidate) && !sourceAnchors
+              (!basePreservations.contains(candidate) || baseGroupSections
+                .contains(candidate)) && !sourceAnchors
                 .contains(
                   candidate
                 )
@@ -1203,7 +1236,7 @@ object SectionedCodeExtension extends StrictLogging:
           Option[IndexedSeq[Section[Element]]],
           Option[IndexedSeq[Section[Element]]]
       ) =
-        val (file, preservations, coincidentInsertionsOrEdits) =
+        val (file, preservations, coincidentInsertionsOrEdits, sideExtractor) =
           moveDestinationSide match
             case MoveDestinationSide.Left =>
               (
@@ -1211,7 +1244,8 @@ object SectionedCodeExtension extends StrictLogging:
                   sectionedCode.rightPathFor(oppositeSideAnchor.element)
                 ),
                 rightPreservations,
-                coincidentInsertionsOrEditsOnRight
+                coincidentInsertionsOrEditsOnRight,
+                (m: Match[Section[Element]]) => m.rightContribution
               )
             case MoveDestinationSide.Right =>
               (
@@ -1219,16 +1253,20 @@ object SectionedCodeExtension extends StrictLogging:
                   sectionedCode.leftPathFor(oppositeSideAnchor.element)
                 ),
                 leftPreservations,
-                coincidentInsertionsOrEditsOnLeft
+                coincidentInsertionsOrEditsOnLeft,
+                (m: Match[Section[Element]]) => m.leftContribution
               )
+
+        val oppositeGroupSections =
+          parallelGroupSectionsFor(oppositeSideAnchor.element, sideExtractor)
 
         def selection(
             candidates: IndexedSeqView[Section[Element]]
         ): IndexedSeq[Section[Element]] = candidates
           .takeWhile(candidate =>
-            !preservations.contains(
+            (!preservations.contains(
               candidate
-            ) && !oppositeSideAnchors.contains(
+            ) || oppositeGroupSections.contains(candidate)) && !oppositeSideAnchors.contains(
               candidate
             ) && !coincidentInsertionsOrEdits.contains(candidate)
           )
@@ -1288,7 +1326,7 @@ object SectionedCodeExtension extends StrictLogging:
           moveDestinationSide: MoveDestinationSide,
           moveDestinationAnchor: Section[Element]
       ): (IndexedSeq[Section[Element]], IndexedSeq[Section[Element]]) =
-        val (file, preservations, coincidentInsertionsOrEdits) =
+        val (file, preservations, coincidentInsertionsOrEdits, sideExtractor) =
           moveDestinationSide match
             case MoveDestinationSide.Left =>
               (
@@ -1296,7 +1334,8 @@ object SectionedCodeExtension extends StrictLogging:
                   sectionedCode.leftPathFor(moveDestinationAnchor)
                 ),
                 leftPreservations,
-                coincidentInsertionsOrEditsOnLeft
+                coincidentInsertionsOrEditsOnLeft,
+                (m: Match[Section[Element]]) => m.leftContribution
               )
             case MoveDestinationSide.Right =>
               (
@@ -1304,16 +1343,20 @@ object SectionedCodeExtension extends StrictLogging:
                   sectionedCode.rightPathFor(moveDestinationAnchor)
                 ),
                 rightPreservations,
-                coincidentInsertionsOrEditsOnRight
+                coincidentInsertionsOrEditsOnRight,
+                (m: Match[Section[Element]]) => m.rightContribution
               )
+
+        val destinationGroupSections =
+          parallelGroupSectionsFor(moveDestinationAnchor, sideExtractor)
 
         def selection(
             candidates: IndexedSeqView[Section[Element]]
         ): IndexedSeq[Section[Element]] = candidates
           .takeWhile(candidate =>
-            !preservations.contains(
+            (!preservations.contains(
               candidate
-            ) && !moveDestinationAnchors.contains(
+            ) || destinationGroupSections.contains(candidate)) && !moveDestinationAnchors.contains(
               candidate
             ) && !coincidentInsertionsOrEdits.contains(candidate)
           )

--- a/src/test/scala/com/sageserpent/kineticmerge/core/BlockDuplicationAndCondensationTests.scala
+++ b/src/test/scala/com/sageserpent/kineticmerge/core/BlockDuplicationAndCondensationTests.scala
@@ -684,16 +684,16 @@ class BlockDuplicationAndCondensationTests:
       println(s"Right contributions: ${pprintCustomised(rightContributions)}")
 
       println(
-        s"Groups of parallel matches: ${pprintCustomised(sectionedCode.groupsOfParallelMatches)}"
+        s"Groups of parallel matches: ${pprintCustomised(sectionedCode.groupsOfParallelMatches).plainText}"
       )
       println(
-        s"Base blocks: ${pprintCustomised(sectionedCode.baseBlocksFor(placeholderPath))}"
+        s"Base blocks: ${pprintCustomised(sectionedCode.baseBlocksFor(placeholderPath)).plainText}"
       )
       println(
-        s"Left blocks: ${pprintCustomised(sectionedCode.leftBlocksFor(placeholderPath))}"
+        s"Left blocks: ${pprintCustomised(sectionedCode.leftBlocksFor(placeholderPath)).plainText}"
       )
       println(
-        s"Right blocks: ${pprintCustomised(sectionedCode.rightBlocksFor(placeholderPath))}"
+        s"Right blocks: ${pprintCustomised(sectionedCode.rightBlocksFor(placeholderPath)).plainText}"
       )
 
       assert(

--- a/src/test/scala/com/sageserpent/kineticmerge/core/BlockDuplicationAndCondensationTests.scala
+++ b/src/test/scala/com/sageserpent/kineticmerge/core/BlockDuplicationAndCondensationTests.scala
@@ -684,16 +684,16 @@ class BlockDuplicationAndCondensationTests:
       println(s"Right contributions: ${pprintCustomised(rightContributions)}")
 
       println(
-        s"Groups of parallel matches: ${pprintCustomised(sectionedCode.groupsOfParallelMatches).plainText}"
+        s"Groups of parallel matches: ${pprintCustomised(sectionedCode.groupsOfParallelMatches)}"
       )
       println(
-        s"Base blocks: ${pprintCustomised(sectionedCode.baseBlocksFor(placeholderPath)).plainText}"
+        s"Base blocks: ${pprintCustomised(sectionedCode.baseBlocksFor(placeholderPath))}"
       )
       println(
-        s"Left blocks: ${pprintCustomised(sectionedCode.leftBlocksFor(placeholderPath)).plainText}"
+        s"Left blocks: ${pprintCustomised(sectionedCode.leftBlocksFor(placeholderPath))}"
       )
       println(
-        s"Right blocks: ${pprintCustomised(sectionedCode.rightBlocksFor(placeholderPath)).plainText}"
+        s"Right blocks: ${pprintCustomised(sectionedCode.rightBlocksFor(placeholderPath))}"
       )
 
       assert(

--- a/src/test/scala/com/sageserpent/kineticmerge/core/MoveDestinationsReportTest.scala
+++ b/src/test/scala/com/sageserpent/kineticmerge/core/MoveDestinationsReportTest.scala
@@ -1,0 +1,89 @@
+package com.sageserpent.kineticmerge.core
+
+import cats.Eq
+import com.sageserpent.kineticmerge.core.ExpectyFlavouredAssert.assert
+import com.sageserpent.kineticmerge.core.MoveDestinationsReport.*
+import org.junit.jupiter.api.Test
+import pprint.Tree
+
+class MoveDestinationsReportTest:
+  case class FakeSection[Element](
+      override val startOffset: Int,
+      override val size: Int,
+      override val content: IndexedSeq[Element]
+  ) extends Section[Element]:
+    override def render: Tree =
+      pprint.Tree.Literal(s"FakeSection($startOffset, $size)")
+  end FakeSection
+
+  given [Element]: Eq[Section[Element]] = Eq.fromUniversalEquals
+
+  @Test
+  def interiorMatchesInParallelMatchesGroupAreExcludedFromMoveEvaluation(): Unit =
+    val baseSection1 = FakeSection(0, 10, Vector("m1"))
+    val leftSection1 = FakeSection(0, 10, Vector("m1"))
+
+    val baseSection2 = FakeSection(10, 10, Vector("m2"))
+    val leftSection2 = FakeSection(10, 10, Vector("m2"))
+
+    val baseSection3 = FakeSection(20, 10, Vector("m3"))
+    val leftSection3 = FakeSection(20, 10, Vector("m3"))
+
+    val match1: Match[Section[String]] =
+      Match.BaseAndLeft(baseSection1, leftSection1)
+    val match2: Match[Section[String]] =
+      Match.BaseAndLeft(baseSection2, leftSection2)
+    val match3: Match[Section[String]] =
+      Match.BaseAndLeft(baseSection3, leftSection3)
+
+    val matchesBySection: Map[Section[String], Set[Match[Section[String]]]] =
+      Map(
+        baseSection1 -> Set(match1),
+        baseSection2 -> Set(match2),
+        baseSection3 -> Set(match3)
+      )
+
+    val speculativeMigrationsBySource
+        : Map[Section[String], SpeculativeContentMigration[
+          Section[String]
+        ]] = Map(
+      baseSection1 -> SpeculativeContentMigration
+        .LeftEditOrDeletion(leftSection1, false),
+      baseSection2 -> SpeculativeContentMigration
+        .LeftEditOrDeletion(leftSection2, false),
+      baseSection3 -> SpeculativeContentMigration
+        .LeftEditOrDeletion(leftSection3, false)
+    )
+
+    val speculativeMoveDestinations
+        : Set[SpeculativeMoveDestination[Section[String]]] = Set(
+      SpeculativeMoveDestination.Left(leftSection1),
+      SpeculativeMoveDestination.Left(leftSection2),
+      SpeculativeMoveDestination.Left(leftSection3)
+    )
+
+    // Only match1 and match3 are vetted (first and last in parallel matches group)
+    val firstOrLastMatches: Set[Match[Section[String]]] = Set(match1, match3)
+
+    val evaluation =
+      MoveDestinationsReport.evaluateSpeculativeSourcesAndDestinations[Section[String]](
+        speculativeMigrationsBySource,
+        speculativeMoveDestinations
+      )(
+        section => matchesBySection.getOrElse(section, Set.empty),
+        firstOrLastMatches.contains
+      )
+
+    assert(
+      evaluation.moveDestinationsReport.sources == Set(
+        baseSection1,
+        baseSection3
+      )
+    )
+    assert(
+      evaluation.moveDestinationsReport.all == Set(leftSection1, leftSection3)
+    )
+    assert(!evaluation.moveDestinationsReport.sources.contains(baseSection2))
+    assert(!evaluation.moveDestinationsReport.all.contains(leftSection2))
+  end interiorMatchesInParallelMatchesGroupAreExcludedFromMoveEvaluation
+end MoveDestinationsReportTest


### PR DESCRIPTION
Updated MoveDestinationsReport.evaluateSpeculativeSourcesAndDestinations to accept a vetting predicate for filtering matches when combining speculative move sources and destinations. In SectionedCodeExtension.scala, constructed the predicate checking whether a match is the first or last element in any parallel matches group. Added unit tests in MoveDestinationsReportTest.

---
*PR created automatically by Jules for task [5193386868571153549](https://jules.google.com/task/5193386868571153549) started by @sageserpent-open*