### PR TITLE
Add --fuse-more-parallel-matches-groups feature toggle

### DIFF
--- a/src/main/scala/com/sageserpent/kineticmerge/Main.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/Main.scala
@@ -111,6 +111,13 @@ object Main extends StrictLogging:
           .text(
             "Do not commit a successful merge - leave merged changes staged in the index for review. Off by default."
           ),
+        opt[Unit](name = "fuse-more-parallel-matches-groups")
+          .action((fuseMoreParallelMatchesGroups, commandLineArguments) =>
+            commandLineArguments.copy(fuseMoreParallelMatchesGroups = true)
+          )
+          .text(
+            "Fuse parallel matches groups when removing redundant pairwise matches. Off by default."
+          ),
         opt[Unit](name = "no-ff")
           .action((noFastForward, commandLineArguments) =>
             commandLineArguments.copy(noFastForward = true)
@@ -271,7 +278,8 @@ object Main extends StrictLogging:
       thresholdSizeFractionForMatching,
       minimumAmbiguousMatchSize,
       ambiguousMatchesThreshold,
-      progressRecording = progressRecording
+      progressRecording = progressRecording,
+      fuseMoreParallelMatchesGroups = fuseMoreParallelMatchesGroups
     )
 
     val workflow = for
@@ -454,7 +462,8 @@ object Main extends StrictLogging:
       minimumMatchSize: Int,
       thresholdSizeFractionForMatching: Double,
       minimumAmbiguousMatchSize: Int,
-      ambiguousMatchesThreshold: Int
+      ambiguousMatchesThreshold: Int,
+      fuseMoreParallelMatchesGroups: Boolean
   )
 
   enum Change:
@@ -2870,7 +2879,8 @@ object Main extends StrictLogging:
         2,
       thresholdSizeFractionForMatching = 0,
       minimumAmbiguousMatchSize = 10,
-      ambiguousMatchesThreshold = 20
+      ambiguousMatchesThreshold = 20,
+      fuseMoreParallelMatchesGroups = false
     )
   end ApplicationRequest
 

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1867,6 +1867,8 @@ object MatchAnalysis extends StrictLogging:
           override val progressRecording: ProgressRecording     =
             configuration.progressRecording
           override val label: String = "Meta-match analysis"
+          override val fuseMoreParallelMatchesGroups: Boolean  =
+            configuration.fuseMoreParallelMatchesGroups
         end metaMatchConfiguration
 
         given Eq[Section[Element]] = Eq.by(_.content: Seq[Element])
@@ -2301,26 +2303,28 @@ object MatchAnalysis extends StrictLogging:
 
           (
             accumulatedRedundantPairwiseMatches,
-            accumulatedGroupIdCandidateCutovers.sets
-              .collect {
-                case (groupId, candidateReplacementGroupIds)
-                    // All the pairwise matches have to have just one consistent
-                    // group id cutover and that has to be consistent between
-                    // them.
-                    if 1 == candidateReplacementGroupIds.size =>
-                  val replacementGroupId = candidateReplacementGroupIds.head
-                  val groupsOfParallelMatches = this.groupsOfParallelMatches
-                  logger.debug(
-                    s"""Fusing parallel pairwise matches group: ${pprintCustomised(
-                        groupId -> groupsOfParallelMatches(groupId)
-                      )} into parallel matches group: ${pprintCustomised(
-                        replacementGroupId -> groupsOfParallelMatches(
-                          replacementGroupId
-                        )
-                      )}."""
-                  )
-                  groupId -> replacementGroupId
-              }
+            if fuseMoreParallelMatchesGroups then
+              accumulatedGroupIdCandidateCutovers.sets
+                .collect {
+                  case (groupId, candidateReplacementGroupIds)
+                      // All the pairwise matches have to have just one consistent
+                      // group id cutover and that has to be consistent between
+                      // them.
+                      if 1 == candidateReplacementGroupIds.size =>
+                    val replacementGroupId = candidateReplacementGroupIds.head
+                    val groupsOfParallelMatches = this.groupsOfParallelMatches
+                    logger.debug(
+                      s"""Fusing parallel pairwise matches group: ${pprintCustomised(
+                          groupId -> groupsOfParallelMatches(groupId)
+                        )} into parallel matches group: ${pprintCustomised(
+                          replacementGroupId -> groupsOfParallelMatches(
+                            replacementGroupId
+                          )
+                        )}."""
+                    )
+                    groupId -> replacementGroupId
+                }
+            else Map.empty
           )
         end val
 
@@ -3818,6 +3822,7 @@ object MatchAnalysis extends StrictLogging:
     val ambiguousMatchesThreshold: Int
     val progressRecording: ProgressRecording
     val label: String = ""
+    val fuseMoreParallelMatchesGroups: Boolean = false
   end AbstractConfiguration
 
   class AdmissibleFailure(message: String) extends RuntimeException(message)
@@ -3840,7 +3845,8 @@ object MatchAnalysis extends StrictLogging:
       minimumAmbiguousMatchSize: Int,
       ambiguousMatchesThreshold: Int,
       progressRecording: ProgressRecording = NoProgressRecording,
-      override val label: String = ""
+      override val label: String = "",
+      override val fuseMoreParallelMatchesGroups: Boolean = false
   ) extends AbstractConfiguration:
     // TODO: why would `minimumMatchSize` be zero?
     require(0 <= minimumMatchSize)

--- a/src/test/scala/com/sageserpent/kineticmerge/MainTest.scala
+++ b/src/test/scala/com/sageserpent/kineticmerge/MainTest.scala
@@ -14,7 +14,7 @@ import com.sageserpent.kineticmerge.core.Token.{
   equality as tokenEquality
 }
 import com.softwaremill.tagging.*
-import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.{Test, TestFactory}
 import os.{Path, RelPath}
 
 import scala.util.Random
@@ -3529,5 +3529,18 @@ class MainTest:
           .unsafeRunSync()
       }
   end cleanMergeOfABinaryFileDeletedInBothBranches
+
+  @Test
+  def fuseMoreParallelMatchesGroupsOptionParsing(): Unit =
+    // Passing --help returns exit code 0 when option parsing succeeds.
+    val defaultHelpExitCode = Main.apply("--help")
+    assert(0 == defaultHelpExitCode)
+
+    val optionHelpExitCode = Main.apply(
+      "--fuse-more-parallel-matches-groups",
+      "--help"
+    )
+    assert(0 == optionHelpExitCode)
+  end fuseMoreParallelMatchesGroupsOptionParsing
 
 end MainTest


### PR DESCRIPTION
Added a command-line feature toggle --fuse-more-parallel-matches-groups (off by default) that controls whether further parallel matches group fusion takes place in MatchesAndTheirSections.withoutRedundantPairwiseMatches. Redundant pairwise matches are removed regardless of the setting.

---
*PR created automatically by Jules for task [4419406878942423418](https://jules.google.com/task/4419406878942423418) started by @sageserpent-open*