### PR TITLE
Fix parallel matches group splitting during reconciliation

### DIFF
--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -958,9 +958,15 @@ object MatchAnalysis extends StrictLogging:
                       fragmentFactory(mealStartOffsetRelativeToMeal, size)
 
                     for
+                      parallelMatchesGroupIdsByMatch <- State
+                        .get[ParallelMatchesGroupIdsByMatch[Element]]
+                      deferredGroupIdsFromPrecedingBite =
+                        deferredMatchesFromPrecedingBite.map(
+                          parallelMatchesGroupIdsByMatch
+                        )
                       result <- assignUniqueGroupId(
                         fragment,
-                        Set.empty
+                        deferredGroupIdsFromPrecedingBite
                       ) as Right(fragments.appended(fragment))
                     yield result
                     end for
@@ -988,13 +994,29 @@ object MatchAnalysis extends StrictLogging:
                         val size =
                           startOffsetRelativeToMeal - mealStartOffsetRelativeToMeal
 
+                        val groupIdsFromSucceedingBite =
+                          matchesFromSucceedingBite.map(
+                            parallelMatchesGroupIdsByMatch
+                          )
+
+                        val deferredGroupIdsFromPrecedingBite =
+                          deferredMatchesFromPrecedingBite.map(
+                            parallelMatchesGroupIdsByMatch
+                          )
+
                         val groupIds =
-                          deferredMatchesFromPrecedingBite
-                            .map(parallelMatchesGroupIdsByMatch)
-                            .intersect(
-                              matchesFromSucceedingBite.map(
-                                parallelMatchesGroupIdsByMatch
-                              )
+                          if deferredGroupIdsFromPrecedingBite.isEmpty then
+                            groupIdsFromSucceedingBite
+                          else
+                            // Enforce consistency between the group ids
+                            // supplied by both bites. This allows some margin
+                            // for thinning out multiple group ids from one bite
+                            // if the bite on the other side has just one group
+                            // id, i.e. when one bite comes from an ambiguous
+                            // move and the other from a plain move in parallel
+                            // to one of the ambiguous ones.
+                            deferredGroupIdsFromPrecedingBite.intersect(
+                              groupIdsFromSucceedingBite
                             )
 
                         val fragment =

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -1896,8 +1896,46 @@ object MatchAnalysis extends StrictLogging:
         // ignores gaps, we have to guard against sections that would have
         // formed the sides of a suppressed outer match making a second attempt
         // at building a match.
+        def matchesAbut(
+            first: GenericMatch[Element],
+            second: GenericMatch[Element]
+        ): Boolean =
+          def sectionsAbut(
+              firstSection: Option[Section[Element]],
+              secondSection: Option[Section[Element]]
+          ): Boolean =
+            (firstSection, secondSection) match
+              case (Some(s1), Some(s2)) => s1.onePastEndOffset == s2.startOffset
+              case (None, None)         => true
+              case _                    => false
+
+          sectionsAbut(first.baseContribution, second.baseContribution) &&
+          sectionsAbut(first.leftContribution, second.leftContribution) &&
+          sectionsAbut(first.rightContribution, second.rightContribution)
+        end matchesAbut
+
+        def partitionIntoContiguousRuns(
+            matches: Iterable[GenericMatch[Element]]
+        ): Seq[Seq[GenericMatch[Element]]] =
+          val matchesSeq = matches.toSeq
+          if matchesSeq.isEmpty then Seq.empty
+          else
+            val runs = mutable.Buffer.empty[mutable.Buffer[GenericMatch[Element]]]
+            var currentRun = mutable.Buffer(matchesSeq.head)
+
+            matchesSeq.tail.foreach { nextMatch =>
+              if matchesAbut(currentRun.last, nextMatch) then
+                currentRun.addOne(nextMatch)
+              else
+                runs.addOne(currentRun)
+                currentRun = mutable.Buffer(nextMatch)
+            }
+            runs.addOne(currentRun)
+            runs.toSeq.map(_.toSeq)
+        end partitionIntoContiguousRuns
+
         val groupsOfBackTranslatedParallelMatches = metaMatches
-          .map {
+          .flatMap {
             case Match.AllSides(
                   baseMetaSection,
                   leftMetaSection,
@@ -1914,46 +1952,57 @@ object MatchAnalysis extends StrictLogging:
               // unique group id constraint, or at least do something about the
               // nasty wrapping in `Seq` and then flat-mapping.
 
-              (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAnAllSidesMatch(
-                        baseSection,
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.AllSides(baseSection, leftSection, rightSection)
-                }
+              val matches =
+                (baseMetaSection.content lazyZip leftMetaSection.content lazyZip rightMetaSection.content)
+                  .collect {
+                    case (baseSection, leftSection, rightSection)
+                        if !isSubsumedNonTriviallyByAnAllSidesMatch(
+                          baseSection,
+                          leftSection,
+                          rightSection
+                        ) =>
+                      Match.AllSides(baseSection, leftSection, rightSection)
+                  }
+              partitionIntoContiguousRuns(matches)
+
             case Match.BaseAndLeft(baseMetaSection, leftMetaSection) =>
-              (baseMetaSection.content lazyZip leftMetaSection.content)
-                .collect {
-                  case (baseSection, leftSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
-                        baseSection,
-                        leftSection
-                      ) =>
-                    Match.BaseAndLeft(baseSection, leftSection)
-                }
+              val matches =
+                (baseMetaSection.content lazyZip leftMetaSection.content)
+                  .collect {
+                    case (baseSection, leftSection)
+                        if !isSubsumedNonTriviallyByAMatchOnTheBaseAndLeft(
+                          baseSection,
+                          leftSection
+                        ) =>
+                      Match.BaseAndLeft(baseSection, leftSection)
+                  }
+              partitionIntoContiguousRuns(matches)
+
             case Match.BaseAndRight(baseMetaSection, rightMetaSection) =>
-              (baseMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (baseSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
-                        baseSection,
-                        rightSection
-                      ) =>
-                    Match.BaseAndRight(baseSection, rightSection)
-                }
+              val matches =
+                (baseMetaSection.content lazyZip rightMetaSection.content)
+                  .collect {
+                    case (baseSection, rightSection)
+                        if !isSubsumedNonTriviallyByAMatchOnTheBaseAndRight(
+                          baseSection,
+                          rightSection
+                        ) =>
+                      Match.BaseAndRight(baseSection, rightSection)
+                  }
+              partitionIntoContiguousRuns(matches)
+
             case Match.LeftAndRight(leftMetaSection, rightMetaSection) =>
-              (leftMetaSection.content lazyZip rightMetaSection.content)
-                .collect {
-                  case (leftSection, rightSection)
-                      if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
-                        leftSection,
-                        rightSection
-                      ) =>
-                    Match.LeftAndRight(leftSection, rightSection)
-                }
+              val matches =
+                (leftMetaSection.content lazyZip rightMetaSection.content)
+                  .collect {
+                    case (leftSection, rightSection)
+                        if !isSubsumedNonTriviallyByAMatchOnTheLeftAndRight(
+                          leftSection,
+                          rightSection
+                        ) =>
+                      Match.LeftAndRight(leftSection, rightSection)
+                  }
+              partitionIntoContiguousRuns(matches)
           }
           .filter(_.nonEmpty)
           .toSeq

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -958,15 +958,9 @@ object MatchAnalysis extends StrictLogging:
                       fragmentFactory(mealStartOffsetRelativeToMeal, size)
 
                     for
-                      parallelMatchesGroupIdsByMatch <- State
-                        .get[ParallelMatchesGroupIdsByMatch[Element]]
-                      deferredGroupIdsFromPrecedingBite =
-                        deferredMatchesFromPrecedingBite.map(
-                          parallelMatchesGroupIdsByMatch
-                        )
                       result <- assignUniqueGroupId(
                         fragment,
-                        deferredGroupIdsFromPrecedingBite
+                        Set.empty
                       ) as Right(fragments.appended(fragment))
                     yield result
                     end for
@@ -994,29 +988,13 @@ object MatchAnalysis extends StrictLogging:
                         val size =
                           startOffsetRelativeToMeal - mealStartOffsetRelativeToMeal
 
-                        val groupIdsFromSucceedingBite =
-                          matchesFromSucceedingBite.map(
-                            parallelMatchesGroupIdsByMatch
-                          )
-
-                        val deferredGroupIdsFromPrecedingBite =
-                          deferredMatchesFromPrecedingBite.map(
-                            parallelMatchesGroupIdsByMatch
-                          )
-
                         val groupIds =
-                          if deferredGroupIdsFromPrecedingBite.isEmpty then
-                            groupIdsFromSucceedingBite
-                          else
-                            // Enforce consistency between the group ids
-                            // supplied by both bites. This allows some margin
-                            // for thinning out multiple group ids from one bite
-                            // if the bite on the other side has just one group
-                            // id, i.e. when one bite comes from an ambiguous
-                            // move and the other from a plain move in parallel
-                            // to one of the ambiguous ones.
-                            deferredGroupIdsFromPrecedingBite.intersect(
-                              groupIdsFromSucceedingBite
+                          deferredMatchesFromPrecedingBite
+                            .map(parallelMatchesGroupIdsByMatch)
+                            .intersect(
+                              matchesFromSucceedingBite.map(
+                                parallelMatchesGroupIdsByMatch
+                              )
                             )
 
                         val fragment =

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -2381,17 +2381,21 @@ object MatchAnalysis extends StrictLogging:
 
         val withoutRedundantMatches = withoutTheseMatches(redundantMatches)
 
-        val parallelMatchesGroupIdsByMatchWithReplacements =
-          withoutRedundantMatches.parallelMatchesGroupIdsByMatch.transform(
-            (_, groupId) =>
-              // NOTE: need a fallback here because we want to use the cutovers
-              // on *all* the group ids, not just the ones that need replacing.
-              groupIdCutovers.getOrElse(key = groupId, default = groupId)
-          )
+        // TODO: reinstate the use of fused parallel matches groups...
 
-        withoutRedundantMatches.copy(parallelMatchesGroupIdsByMatch =
-          parallelMatchesGroupIdsByMatchWithReplacements
-        )
+//        val parallelMatchesGroupIdsByMatchWithReplacements =
+//          withoutRedundantMatches.parallelMatchesGroupIdsByMatch.transform(
+//            (_, groupId) =>
+//              // NOTE: need a fallback here because we want to use the cutovers
+//              // on *all* the group ids, not just the ones that need replacing.
+//              groupIdCutovers.getOrElse(key = groupId, default = groupId)
+//          )
+//
+//        withoutRedundantMatches.copy(parallelMatchesGroupIdsByMatch =
+//          parallelMatchesGroupIdsByMatchWithReplacements
+//        )
+
+        withoutRedundantMatches
       end withoutRedundantPairwiseMatches
 
       def reconcileOverlappingMatches(

--- a/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
+++ b/src/main/scala/com/sageserpent/kineticmerge/core/MatchAnalysis.scala
@@ -2381,21 +2381,17 @@ object MatchAnalysis extends StrictLogging:
 
         val withoutRedundantMatches = withoutTheseMatches(redundantMatches)
 
-        // TODO: reinstate the use of fused parallel matches groups...
+        val parallelMatchesGroupIdsByMatchWithReplacements =
+          withoutRedundantMatches.parallelMatchesGroupIdsByMatch.transform(
+            (_, groupId) =>
+              // NOTE: need a fallback here because we want to use the cutovers
+              // on *all* the group ids, not just the ones that need replacing.
+              groupIdCutovers.getOrElse(key = groupId, default = groupId)
+          )
 
-//        val parallelMatchesGroupIdsByMatchWithReplacements =
-//          withoutRedundantMatches.parallelMatchesGroupIdsByMatch.transform(
-//            (_, groupId) =>
-//              // NOTE: need a fallback here because we want to use the cutovers
-//              // on *all* the group ids, not just the ones that need replacing.
-//              groupIdCutovers.getOrElse(key = groupId, default = groupId)
-//          )
-//
-//        withoutRedundantMatches.copy(parallelMatchesGroupIdsByMatch =
-//          parallelMatchesGroupIdsByMatchWithReplacements
-//        )
-
-        withoutRedundantMatches
+        withoutRedundantMatches.copy(parallelMatchesGroupIdsByMatch =
+          parallelMatchesGroupIdsByMatchWithReplacements
+        )
       end withoutRedundantPairwiseMatches
 
       def reconcileOverlappingMatches(


### PR DESCRIPTION
Fixes parallel matches group splitting during reconciliation by ensuring non-contiguous match sequences in `MatchAnalysis.parallelMatchesOnly` are partitioned into separate parallel match groups before group ID assignment.

---
*PR created automatically by Jules for task [3158958564310507882](https://jules.google.com/task/3158958564310507882) started by @sageserpent-open*